### PR TITLE
Make nix, package configurable.

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,6 +1,7 @@
 { pkgs ? (import <nixpkgs> { })
 , rustPlatform ? pkgs.rustPlatform
 , nixVersions ? pkgs.nixVersions
+, nixForHarmonia ? nixVersions.unstable
 , nix-gitignore ? pkgs.nix-gitignore
 , lib ? pkgs.lib
 , clippy ? pkgs.clippy
@@ -19,7 +20,7 @@ rustPlatform.buildRustPackage ({
 
   nativeBuildInputs = [ pkg-config ] ++ lib.optionals enableClippy [ clippy ];
   buildInputs = [
-    nixVersions.unstable
+    nixForHarmonia
     nlohmann_json
     libsodium
     boost

--- a/module.nix
+++ b/module.nix
@@ -23,6 +23,12 @@ in
 
         description = lib.mdDoc "Settings to merge with the default configuration";
       };
+
+      package = lib.mkOption {
+        type = lib.types.path;
+        default = pkgs.callPackage ./. { };
+        description = "The harmonia package";
+      };
     };
   };
 
@@ -54,8 +60,9 @@ in
       # otherwise
       environment.HOME = "/run/harmonia";
 
+
       serviceConfig = {
-        ExecStart = "${pkgs.callPackage ./. { }}/bin/harmonia";
+        ExecStart = "${cfg.package}/bin/harmonia";
 
         User = "harmonia";
         Group = "harmonia";


### PR DESCRIPTION
Addresses https://github.com/nix-community/harmonia/issues/136, making it possible to deploy the harmonia-dev module on systems with an older nixpkgs without overlay shenanigans— tell the module what Harmonia package to use, and tell that Harmonia package which Nix to build against:

```
  services.harmonia-dev = {
    enable = true;
    package = harmonia.packages.${system}.harmonia.override {
      inherit (nix_2_17.packages.${system}) nix;
    };
  };
```