### PR TITLE
Update references to upstream repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /build
 /target
 .cache
+.direnv
 compile_commands.json

--- a/default.nix
+++ b/default.nix
@@ -30,7 +30,7 @@ rustPlatform.buildRustPackage ({
 
   meta = with lib; {
     description = "Nix binary cache implemented in rust using libnix-store";
-    homepage = "https://github.com/helsinki-systems/harmonia";
+    homepage = "https://github.com/nix-community/harmonia";
     license = with licenses; [ mit ];
     maintainers = [ maintainers.conni2461 ];
     platforms = platforms.all;

--- a/harmonia/Cargo.toml
+++ b/harmonia/Cargo.toml
@@ -4,8 +4,8 @@ version = "0.7.1"
 authors = ["Simon Hauser <simon.hauser@helsinki-systems.de>"]
 edition = "2021"
 license = "MIT"
-homepage = "https://github.com/helsinki-systems/harmonia"
-repository = "https://github.com/helsinki-systems/harmonia.git"
+homepage = "https://github.com/nix-community/harmonia"
+repository = "https://github.com/nix-community/harmonia.git"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/libnixstore/Cargo.toml
+++ b/libnixstore/Cargo.toml
@@ -4,8 +4,8 @@ version = "0.4.0"
 authors = ["Simon Hauser <simon.hauser@helsinki-systems.de>"]
 description = "Rust friendly bindings to nixos nix-store library"
 edition = "2021"
-homepage = "https://github.com/helsinki-systems/harmonia"
-repository = "https://github.com/helsinki-systems/harmonia.git"
+homepage = "https://github.com/nix-community/harmonia"
+repository = "https://github.com/nix-community/harmonia.git"
 license = "MIT"
 
 [dependencies]


### PR DESCRIPTION
Update references to the upstream repo, which also affects [the link on the homepage](https://github.com/nix-community/harmonia/blob/f2e72bddad233a2b9e08fae70f4e96474f63f105/harmonia/src/root.rs#L45).