### PR TITLE
Added support for non-root Nix store

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -43,6 +43,7 @@
               t00-simple = import ./tests/t00-simple.nix testArgs;
               t01-signing = import ./tests/t01-signing.nix testArgs;
               t02-varnish = import ./tests/t02-varnish.nix testArgs;
+              t03-chroot = import ./tests/t03-chroot.nix testArgs;
             } // {
             clippy = config.packages.harmonia.override ({
               enableClippy = true;

--- a/harmonia/src/config.rs
+++ b/harmonia/src/config.rs
@@ -1,5 +1,6 @@
 use std::fs::read_to_string;
 
+use crate::store::Store;
 use anyhow::{Context, Result};
 use base64::{engine::general_purpose, Engine};
 use serde::Deserialize;
@@ -33,8 +34,11 @@ pub(crate) struct Config {
     pub(crate) priority: usize,
     #[serde(default)]
     pub(crate) sign_key_path: Option<String>,
-    #[serde(default)]
+
+    #[serde(skip)]
     pub(crate) secret_key: Option<String>,
+    #[serde(skip)]
+    pub(crate) store: Store,
 }
 
 fn get_secret_key(sign_key_path: Option<&str>) -> Result<Option<String>> {
@@ -65,5 +69,6 @@ pub(crate) fn load() -> Result<Config> {
     )
     .with_context(|| format!("Couldn't parse config file '{settings_file}'"))?;
     settings.secret_key = get_secret_key(settings.sign_key_path.as_deref())?;
+    settings.store = Store::new();
     Ok(settings)
 }

--- a/harmonia/src/main.rs
+++ b/harmonia/src/main.rs
@@ -11,6 +11,7 @@ mod narinfo;
 mod narlist;
 mod root;
 mod serve;
+mod store;
 mod version;
 
 fn nixhash(hash: &str) -> Option<String> {

--- a/harmonia/src/store.rs
+++ b/harmonia/src/store.rs
@@ -1,0 +1,42 @@
+use std::path::PathBuf;
+
+#[derive(Default, Debug)]
+pub struct Store {
+    virtual_store: String,
+    real_store: Option<String>,
+}
+
+impl Store {
+    pub fn new() -> Self {
+        let real_store = libnixstore::get_real_store_dir();
+        let virtual_store = libnixstore::get_store_dir();
+
+        if virtual_store == real_store {
+            return Self {
+                virtual_store,
+                real_store: None,
+            };
+        }
+        Self {
+            virtual_store,
+            real_store: Some(real_store),
+        }
+    }
+    pub fn get_real_path(&self, virtual_path: &str) -> PathBuf {
+        if let Some(real_store) = &self.real_store {
+            if virtual_path.starts_with(&self.virtual_store) {
+                return PathBuf::from(format!(
+                    "{}{}",
+                    real_store,
+                    &virtual_path[self.virtual_store.len()..]
+                ));
+            }
+        }
+        PathBuf::from(virtual_path)
+    }
+    pub fn real_store(&self) -> &str {
+        self.real_store
+            .as_ref()
+            .map_or(&self.virtual_store, |s| s.as_str())
+    }
+}

--- a/libnixstore/include/nix.h
+++ b/libnixstore/include/nix.h
@@ -14,6 +14,7 @@ rust::String sign_string(rust::Str secret_key, rust::Str msg);
 bool check_signature(rust::Str public_key, rust::Str sig, rust::Str msg);
 InternalDrv derivation_from_path(rust::Str drv_path);
 rust::String get_store_dir();
+rust::String get_real_store_dir();
 rust::String get_build_log(rust::Str derivation_path);
 rust::String get_nar_list(rust::Str store_path);
 

--- a/libnixstore/src/lib.rs
+++ b/libnixstore/src/lib.rs
@@ -48,6 +48,7 @@ mod ffi {
         fn check_signature(public_key: &str, sig: &str, msg: &str) -> Result<bool>;
         fn derivation_from_path(drv_path: &str) -> Result<InternalDrv>;
         fn get_store_dir() -> String;
+        fn get_real_store_dir() -> String;
         fn get_build_log(derivation_path: &str) -> Result<String>;
         fn get_nar_list(store_path: &str) -> Result<String>;
     }
@@ -216,6 +217,13 @@ pub fn derivation_from_path(drv_path: &str) -> Result<Drv, cxx::Exception> {
 /// Returns the path to the directory where nix store sources and derived files.
 pub fn get_store_dir() -> String {
     ffi::get_store_dir()
+}
+
+#[inline]
+#[must_use]
+/// Returns the physical path to the nix store.
+pub fn get_real_store_dir() -> String {
+    ffi::get_real_store_dir()
 }
 
 #[inline]

--- a/libnixstore/src/nix.cpp
+++ b/libnixstore/src/nix.cpp
@@ -6,6 +6,7 @@
 #include <nix/globals.hh>
 #include <nix/shared.hh>
 #include <nix/store-api.hh>
+#include <nix/local-fs-store.hh>
 #include <nix/log-store.hh>
 #include <nix/content-address.hh>
 #include <nix/util.hh>
@@ -190,6 +191,16 @@ InternalDrv derivation_from_path(rust::Str drv_path) {
 
 rust::String get_store_dir() {
   return nix::settings.nixStore;
+}
+
+rust::String get_real_store_dir() {
+  auto store = get_store();
+  auto *fsstore = dynamic_cast<nix::LocalFSStore *>(&(*store));
+
+  if (fsstore != nullptr)
+    return fsstore->getRealStoreDir();
+  else
+    return get_store_dir();
 }
 
 rust::String get_build_log(rust::Str derivation_path) {

--- a/tests/t03-chroot.nix
+++ b/tests/t03-chroot.nix
@@ -1,0 +1,66 @@
+(import ./lib.nix)
+  ({ ... }:
+  {
+    name = "t03-chroot";
+
+    nodes = {
+      harmonia = { pkgs, ... }:
+        {
+          imports = [ ../module.nix ];
+
+          services.harmonia-dev.enable = true;
+          # We need to manipulate the target store first
+          systemd.services."harmonia-dev".wantedBy = pkgs.lib.mkForce [ ];
+
+          networking.firewall.allowedTCPPorts = [ 5000 ];
+          nix.settings.store = "/guest?read-only=1";
+          nix.extraOptions = ''
+            experimental-features = nix-command read-only-local-store
+          '';
+        };
+
+      client01 = { lib, ... }:
+        {
+          nix.settings.require-sigs = false;
+          nix.settings.substituters = lib.mkForce [ "http://harmonia:5000" ];
+          nix.extraOptions = ''
+            experimental-features = nix-command
+          '';
+        };
+    };
+
+    testScript =
+      ''
+        import json
+        start_all()
+
+        harmonia.wait_until_succeeds("echo 'test contents' > /my-file")
+        harmonia.wait_until_succeeds("mkdir /my-dir && cp /my-file /my-dir/")
+        f = harmonia.wait_until_succeeds("nix store --store /guest add-file /my-file")
+        d = harmonia.wait_until_succeeds("nix store --store /guest add-path /my-dir")
+        harmonia.systemctl("start harmonia-dev.service")
+        harmonia.wait_for_unit("harmonia-dev.service")
+
+        client01.wait_until_succeeds("curl -f http://harmonia:5000/version")
+        client01.succeed("curl -f http://harmonia:5000/nix-cache-info")
+
+        client01.wait_until_succeeds(f"nix copy --from http://harmonia:5000/ {f}")
+        client01.succeed(f"grep 'test contents' {f}")
+
+        dhash = d.removeprefix("/nix/store/")
+        dhash = dhash[:dhash.find('-')]
+        out = client01.wait_until_succeeds(f"curl -v http://harmonia:5000/{dhash}.ls")
+        data = json.loads(out)
+        print(out)
+        assert data["version"] == 1, "version is not correct"
+        assert data["root"]["entries"]["my-file"]["type"] == "regular", "expect my-file file in listing"
+
+        out = client01.wait_until_succeeds(f"curl -v http://harmonia:5000/serve/{dhash}/")
+        print(out)
+        assert "my-file" in out, "my-file not in listing"
+
+        out = client01.wait_until_succeeds(f"curl -v http://harmonia:5000/serve/{dhash}/my-file").strip()
+        print(out)
+        assert "test contents" == out, f"expected 'test contents', got '{out}'"
+      '';
+  })


### PR DESCRIPTION
This fixes #254 by adding a function, `get_real_store_dir`, to `libnixstore` to support non-root nix stores, where the physical and logical paths differ.
