### PR TITLE
shell: drop unneded shell inputs

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -2,10 +2,6 @@
   pkgs ?
     (builtins.getFlake (builtins.toString ./.)).inputs.nixpkgs.legacyPackages.${builtins.currentSystem},
   boost ? pkgs.boost,
-  cargo-audit ? pkgs.cargo-audit,
-  cargo-edit ? pkgs.cargo-edit,
-  cargo-outdated ? pkgs.cargo-outdated,
-  cargo-watch ? pkgs.cargo-watch,
   clippy ? pkgs.clippy,
   lib ? pkgs.lib,
   libiconv ? pkgs.libiconv,
@@ -32,10 +28,6 @@ pkgs.mkShell {
     boost
     rustfmt
     clippy
-    cargo-watch
-    cargo-edit
-    cargo-outdated
-    cargo-audit
     openssl
     rust-analyzer
   ] ++ lib.optional (stdenv.isDarwin) [ libiconv ];


### PR DESCRIPTION
These inputs seem to be either very personal preference `cargo-watch`, done by other tools `cargo-outdated` -> dependabot, or most functionality included in `cargo` itself -> `cargo-edit` by now.

I noticed them, because `cargo-outdated` and `cargo-audit` have not fixed the time compilation bug yet, making it impossible to drop into a current devshell with `rustc --version: 1.80`.