### PR TITLE
improve error messages: replace unwrap with expect/pattern matching

### DIFF
--- a/harmonia-cache/src/narlist.rs
+++ b/harmonia-cache/src/narlist.rs
@@ -125,7 +125,9 @@ async fn get_nar_list(path: PathBuf) -> Result<NarList> {
                     });
                 }
             } else {
-                let entry = stack.pop().unwrap();
+                let entry = stack
+                    .pop()
+                    .expect("stack should not be empty inside loop iteration");
                 if let Some(frame) = stack.last_mut() {
                     let name = match entry.path.file_name() {
                         Some(name) => name.to_string_lossy().into_owned(),
@@ -147,7 +149,7 @@ async fn get_nar_list(path: PathBuf) -> Result<NarList> {
             }
         }
 
-        root.unwrap()
+        root.expect("root should be set after processing directory stack")
     } else {
         return Err(ServeError::ServeFailed {
             source: std::io::Error::other(format!(

--- a/harmonia-daemon/src/server/mod.rs
+++ b/harmonia-daemon/src/server/mod.rs
@@ -676,10 +676,9 @@ where
             let fut = self.reader.try_read_value::<Request>().boxed();
             trace!("Request Size {}", size_of_val(fut.deref()));
             let res = fut.await?;
-            if res.is_none() {
+            let Some(request) = res else {
                 break;
-            }
-            let request = res.unwrap();
+            };
             let op = request.operation();
             let span = request.span();
             async {

--- a/harmonia-store-remote/src/client.rs
+++ b/harmonia-store-remote/src/client.rs
@@ -479,7 +479,9 @@ where
             let _ = sender.send((reader, result));
         };
         async {
-            let (reader, result) = receiver.await.unwrap();
+            let (reader, result) = receiver
+                .await
+                .expect("stderr processing stream dropped before sending result");
             let reader = reader.get_mut().lend(NarBytesReader::new);
             match result {
                 Ok(_) => Ok(AsyncBufReadCompat::new(reader)),


### PR DESCRIPTION

Replace remaining .unwrap() calls in production code with descriptive
.expect() messages or idiomatic pattern matching to provide better
context when invariant violations occur.
