### PR TITLE
Test with newer Nix, fix "base16" base format naming

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -38,11 +38,11 @@
     "nix": {
       "flake": false,
       "locked": {
-        "lastModified": 1764532838,
-        "narHash": "sha256-hw4J7wfqXWBCvsMVXPS4nvkcSeTXAtR5h9Ylv7a7dBA=",
+        "lastModified": 1764972171,
+        "narHash": "sha256-rZf5zbxu0eCz3Lb4IrelWNuegoQHUjCguuJzcyPFvt0=",
         "owner": "nixos",
         "repo": "nix",
-        "rev": "8be9507a88f466dd44e6e56cd00167fa10e995b8",
+        "rev": "0db70b8184c1037a606d9cbd6c277c78f7adf647",
         "type": "github"
       },
       "original": {

--- a/harmonia-store-core/tests/json_upstream.rs
+++ b/harmonia-store-core/tests/json_upstream.rs
@@ -223,21 +223,21 @@ test_upstream_json!(
     }
 );
 
-// Base64 is the canonical/normal form, so test both read and write
+// Base16/hex is the canonical form, so test both read and write
 test_upstream_json!(
-    test_hash_sha256_base64,
-    libutil_test_data_path("hash/sha256-base64.json"),
+    test_hash_sha256_base16,
+    libutil_test_data_path("hash/sha256-base16.json"),
     Hash::new(
         Algorithm::SHA256,
         &hex!("f0e4c2f76c58916ec258f246851bea091d14d4247a2fc3e18694461b1816e13b"),
     )
 );
 
-// Base16/hex is not the canonical form - read-only test
+// Base64 is not the canonical form - read-only test
 #[test]
-fn test_hash_sha256_base16_from_json() {
+fn test_hash_sha256_base64_from_json() {
     test_upstream_json_from_json(
-        &libutil_test_data_path("hash/sha256-base16.json"),
+        &libutil_test_data_path("hash/sha256-base64.json"),
         &Hash::new(
             Algorithm::SHA256,
             &hex!("f0e4c2f76c58916ec258f246851bea091d14d4247a2fc3e18694461b1816e13b"),

--- a/harmonia-utils-base-encoding/src/lib.rs
+++ b/harmonia-utils-base-encoding/src/lib.rs
@@ -9,7 +9,7 @@
 //!
 //! This crate provides base encoding/decoding for the Nix store:
 //! - Nix base32 (special 32-character alphabet, LSB first, reversed)
-//! - Standard hex (base16)
+//! - Standard base16
 //! - Standard base64
 
 pub mod base32;
@@ -24,7 +24,7 @@ pub const fn base64_len(len: usize) -> usize {
 
 #[derive(derive_more::Display, Debug, PartialEq, Clone, Copy)]
 pub enum Base {
-    #[display("hex")]
+    #[display("base16")]
     Hex,
     #[display("nixbase32")]
     NixBase32,
@@ -48,12 +48,12 @@ impl<'de> Deserialize<'de> for Base {
     {
         let s = String::deserialize(deserializer)?;
         match s.as_str() {
-            "base16" | "hex" => Ok(Base::Hex),
+            "base16" => Ok(Base::Hex),
             "base64" => Ok(Base::Base64),
             "nix32" | "nixbase32" => Ok(Base::NixBase32),
             _ => Err(serde::de::Error::unknown_variant(
                 &s,
-                &["base16", "hex", "base64", "nix32", "nixbase32"],
+                &["base16", "base64", "nix32", "nixbase32"],
             )),
         }
     }
@@ -115,7 +115,7 @@ mod tests {
     #[test]
     fn test_base_serde() {
         // Test serialization
-        assert_eq!(serde_json::to_string(&Base::Hex).unwrap(), "\"hex\"");
+        assert_eq!(serde_json::to_string(&Base::Hex).unwrap(), "\"base16\"");
         assert_eq!(
             serde_json::to_string(&Base::NixBase32).unwrap(),
             "\"nixbase32\""
@@ -123,7 +123,10 @@ mod tests {
         assert_eq!(serde_json::to_string(&Base::Base64).unwrap(), "\"base64\"");
 
         // Test deserialization with canonical names
-        assert_eq!(serde_json::from_str::<Base>("\"hex\"").unwrap(), Base::Hex);
+        assert_eq!(
+            serde_json::from_str::<Base>("\"base16\"").unwrap(),
+            Base::Hex
+        );
         assert_eq!(
             serde_json::from_str::<Base>("\"nixbase32\"").unwrap(),
             Base::NixBase32
@@ -134,10 +137,6 @@ mod tests {
         );
 
         // Test deserialization with aliases
-        assert_eq!(
-            serde_json::from_str::<Base>("\"base16\"").unwrap(),
-            Base::Hex
-        );
         assert_eq!(
             serde_json::from_str::<Base>("\"nix32\"").unwrap(),
             Base::NixBase32

--- a/harmonia-utils-hash/src/fmt.rs
+++ b/harmonia-utils-hash/src/fmt.rs
@@ -1461,7 +1461,7 @@ mod unittests {
         #[rstest]
         #[should_panic = "hash 'sha25:a9993e364706816aba3e25717850c26c9cd0d89d' has unsupported digest algorithm 'sha25'"]
         #[case::unknown_algorithm("sha25:a9993e364706816aba3e25717850c26c9cd0d89d")]
-        #[should_panic = "hash 'sha1:Ka9993e364706816aba3e25717850c26c9cd0d89' has invalid symbol at 5 when decoding as hex"]
+        #[should_panic = "hash 'sha1:Ka9993e364706816aba3e25717850c26c9cd0d89' has invalid symbol at 5 when decoding as base16"]
         #[case::bad_symbol("sha1:Ka9993e364706816aba3e25717850c26c9cd0d89")]
         #[should_panic = "hash 'sha1:a9993e364706816aba3e25717850c26c9cd0d89' has wrong length for hash type 'sha1'"]
         #[case::wrong_length("sha1:a9993e364706816aba3e25717850c26c9cd0d89")]
@@ -1671,7 +1671,7 @@ mod unittests {
         }
 
         #[rstest]
-        #[should_panic = "hash 'sha1:k9993e364706816aba3e25717850c26c9cd0d89d' has invalid symbol at 5 when decoding as hex"]
+        #[should_panic = "hash 'sha1:k9993e364706816aba3e25717850c26c9cd0d89d' has invalid symbol at 5 when decoding as base16"]
         #[case::bad_hex_symbol("sha1:k9993e364706816aba3e25717850c26c9cd0d89d")]
         #[should_panic = "hash 'sha1:!pcd173cq987hw957sx6m0868wv3x6d9' has invalid symbol at 5 when decoding as nixbase32"]
         #[case::bad_nixbase32_symbol("sha1:!pcd173cq987hw957sx6m0868wv3x6d9")]

--- a/harmonia-utils-hash/src/lib.rs
+++ b/harmonia-utils-hash/src/lib.rs
@@ -93,8 +93,8 @@ impl Serialize for Hash {
     {
         let raw = RawHash {
             algorithm: self.algorithm,
-            format: Base::Base64,
-            hash: format!("{:#}", self.as_base64()),
+            format: Base::Hex,
+            hash: format!("{:#}", self.as_base16()),
         };
         raw.serialize(serializer)
     }
@@ -539,10 +539,10 @@ mod unittests {
 
     #[rstest]
     #[case::sha256_base64(&SHA256_ABC, "sha256", "base64", "ungWv48Bz+pBQUDeXa4iI7ADYaOWF3qctBD/YfIAFa0=")]
-    #[case::sha256_hex(&SHA256_ABC, "sha256", "hex", "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad")]
+    #[case::sha256_hex(&SHA256_ABC, "sha256", "base16", "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad")]
     #[case::sha256_nix32(&SHA256_ABC, "sha256", "nix32", "1b8m03r63zqhnjf7l5wnldhh7c134ap5vpj0850ymkq1iyzicy5s")]
     #[case::sha1_base64(&SHA1_ABC, "sha1", "base64", "qZk+NkcGgWq6PiVxeFDCbJzQ2J0=")]
-    #[case::sha1_hex(&SHA1_ABC, "sha1", "hex", "a9993e364706816aba3e25717850c26c9cd0d89d")]
+    #[case::sha1_hex(&SHA1_ABC, "sha1", "base16", "a9993e364706816aba3e25717850c26c9cd0d89d")]
     #[case::sha1_nix32(&SHA1_ABC, "sha1", "nix32", "kpcd173cq987hw957sx6m0868wv3x6d9")]
     fn test_serde_hash(
         #[case] hash: &Hash,
@@ -559,7 +559,7 @@ mod unittests {
 
         let serialized = serde_json::to_value(hash).unwrap();
         assert_eq!(serialized["algorithm"], algo_str);
-        assert_eq!(serialized["format"], "base64"); // Always serializes as base64
+        assert_eq!(serialized["format"], "base16"); // Always serializes as base16
 
         // Test deserialization with different formats
         let deserialized: Hash = serde_json::from_value(json).unwrap();


### PR DESCRIPTION
`base16` is now the default hash format. Make sure it is called that and not `hex`, which upstream Nix doesn't know about.