### PR TITLE
Add blake3 hashing support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -305,6 +305,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrayref"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
+
+[[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
 name = "askama_escape"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -377,6 +389,19 @@ name = "bitflags"
 version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
+
+[[package]]
+name = "blake3"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3888aaa89e4b2a40fca9848e400f6a658a5a3978de7be858e209cafa8be9a4a0"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "cc",
+ "cfg-if",
+ "constant_time_eq",
+]
 
 [[package]]
 name = "bstr"
@@ -536,6 +561,12 @@ name = "compression-core"
 version = "0.4.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75984efb6ed102a0d42db99afb6c1948f0380d1d91808d5529916e6c08b49d8d"
+
+[[package]]
+name = "constant_time_eq"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
 
 [[package]]
 name = "convert_case"
@@ -1194,6 +1225,7 @@ dependencies = [
 name = "harmonia-utils-hash"
 version = "2.1.0"
 dependencies = [
+ "blake3",
  "data-encoding",
  "derive_more",
  "harmonia-utils-base-encoding",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ nix = { version = "0.30", features = ["signal"] }
 bytes = "1.11"
 data-encoding = "2.6"
 md5 = "0.8"
+blake3 = "1.8.2"
 num_enum = "0.7"
 derive_more = { version = "2.1", features = ["display"] }
 pin-project-lite = "0.2"

--- a/harmonia-utils-hash/Cargo.toml
+++ b/harmonia-utils-hash/Cargo.toml
@@ -18,6 +18,7 @@ data-encoding = { workspace = true }
 derive_more = { workspace = true }
 harmonia-utils-base-encoding = { path = "../harmonia-utils-base-encoding" }
 md5 = { workspace = true }
+blake3 = { workspace = true }
 proptest = { workspace = true, optional = true }
 proptest-derive = { workspace = true, optional = true }
 ring = { workspace = true }


### PR DESCRIPTION
This PR adds blake3 hashing support, since Nix >=2.29 introduced it as an experimental feature.

See https://nix.dev/manual/nix/latest/command-ref/nix-hash.html#options and https://nix.dev/manual/nix/latest/development/experimental-features.html?highlight=blake3#blake3-hashes for more information.