### PR TITLE
aterm: support `DrvWithVersion("xp-dyn-drv")` format

### DIFF
--- a/harmonia-store-aterm/src/parser.rs
+++ b/harmonia-store-aterm/src/parser.rs
@@ -16,6 +16,15 @@ use harmonia_utils_hash::fmt::NonSRI;
 
 use crate::ParseError;
 
+/// ATerm derivation format version.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ATermVersion {
+    /// Traditional unversioned form.
+    Traditional,
+    /// Supports dynamic derivation inputs.
+    DynamicDerivations,
+}
+
 pub(crate) struct Parser<'a> {
     bytes: &'a [u8],
     pos: usize,
@@ -44,12 +53,12 @@ impl<'a> Parser<'a> {
         &mut self,
         name: StorePathName,
     ) -> Result<Derivation, ParseError> {
-        self.expect_str("Derive(")?;
+        let version = self.parse_drv_header()?;
 
         let raw_outputs = self.parse_raw_outputs()?;
         self.expect_char(',')?;
 
-        let input_drvs = self.parse_input_drvs()?;
+        let input_drvs = self.parse_input_drvs(version)?;
         self.expect_char(',')?;
 
         let input_srcs = self.parse_input_srcs()?;
@@ -105,6 +114,31 @@ impl<'a> Parser<'a> {
         })
     }
 
+    fn parse_drv_header(&mut self) -> Result<ATermVersion, ParseError> {
+        if self.bytes[self.pos..].starts_with(b"Derive(") {
+            self.pos += b"Derive(".len();
+            Ok(ATermVersion::Traditional)
+        } else if self.bytes[self.pos..].starts_with(b"DrvWithVersion(") {
+            self.pos += b"DrvWithVersion(".len();
+            let version_bytes = self.parse_string()?;
+            let version_str = std::str::from_utf8(&version_bytes)
+                .map_err(|_| ParseError::InvalidUtf8 { pos: self.pos })?;
+            if version_str != "xp-dyn-drv" {
+                return Err(ParseError::UnexpectedEof {
+                    expected: "xp-dyn-drv",
+                    pos: self.pos,
+                });
+            }
+            self.expect_char(',')?;
+            Ok(ATermVersion::DynamicDerivations)
+        } else {
+            Err(ParseError::UnexpectedEof {
+                expected: "Derive(",
+                pos: self.pos,
+            })
+        }
+    }
+
     fn parse_raw_outputs(&mut self) -> Result<Vec<RawOutput>, ParseError> {
         self.expect_char('[')?;
         let mut outputs = Vec::new();
@@ -138,7 +172,10 @@ impl<'a> Parser<'a> {
         Ok(outputs)
     }
 
-    fn parse_input_drvs(&mut self) -> Result<BTreeMap<StorePath, OutputInputs>, ParseError> {
+    fn parse_input_drvs(
+        &mut self,
+        version: ATermVersion,
+    ) -> Result<BTreeMap<StorePath, OutputInputs>, ParseError> {
         self.expect_char('[')?;
         let mut drvs = BTreeMap::new();
 
@@ -147,27 +184,10 @@ impl<'a> Parser<'a> {
             let path = self.parse_store_path()?;
             self.expect_char(',')?;
 
-            self.expect_char('[')?;
-            let mut output_names = BTreeSet::new();
-            while self.peek() != Some(b']') {
-                let name_bytes = self.parse_string()?;
-                let name_str = std::str::from_utf8(&name_bytes)
-                    .map_err(|_| ParseError::InvalidUtf8 { pos: self.pos })?;
-                output_names.insert(name_str.parse::<OutputName>()?);
-                if self.peek() == Some(b',') {
-                    self.advance();
-                }
-            }
-            self.expect_char(']')?;
+            let output_inputs = self.parse_output_inputs(version)?;
             self.expect_char(')')?;
 
-            drvs.insert(
-                path,
-                OutputInputs {
-                    outputs: output_names,
-                    dynamic_outputs: BTreeMap::new(),
-                },
-            );
+            drvs.insert(path, output_inputs);
 
             if self.peek() == Some(b',') {
                 self.advance();
@@ -176,6 +196,74 @@ impl<'a> Parser<'a> {
 
         self.expect_char(']')?;
         Ok(drvs)
+    }
+
+    fn parse_output_inputs(&mut self, version: ATermVersion) -> Result<OutputInputs, ParseError> {
+        match version {
+            ATermVersion::Traditional => {
+                let outputs = self.parse_output_names()?;
+                Ok(OutputInputs {
+                    outputs,
+                    dynamic_outputs: BTreeMap::new(),
+                })
+            }
+            ATermVersion::DynamicDerivations => match self.peek() {
+                Some(b'[') => {
+                    let outputs = self.parse_output_names()?;
+                    Ok(OutputInputs {
+                        outputs,
+                        dynamic_outputs: BTreeMap::new(),
+                    })
+                }
+                Some(b'(') => {
+                    self.expect_char('(')?;
+                    let outputs = self.parse_output_names()?;
+                    self.expect_char(',')?;
+                    self.expect_char('[')?;
+                    let mut dynamic_outputs = BTreeMap::new();
+                    while self.peek() != Some(b']') {
+                        self.expect_char('(')?;
+                        let name_bytes = self.parse_string()?;
+                        let name_str = std::str::from_utf8(&name_bytes)
+                            .map_err(|_| ParseError::InvalidUtf8 { pos: self.pos })?;
+                        let output_name: OutputName = name_str.parse()?;
+                        self.expect_char(',')?;
+                        let child = self.parse_output_inputs(version)?;
+                        self.expect_char(')')?;
+                        dynamic_outputs.insert(output_name, child);
+                        if self.peek() == Some(b',') {
+                            self.advance();
+                        }
+                    }
+                    self.expect_char(']')?;
+                    self.expect_char(')')?;
+                    Ok(OutputInputs {
+                        outputs,
+                        dynamic_outputs,
+                    })
+                }
+                _ => Err(ParseError::UnexpectedEof {
+                    expected: "[ or (",
+                    pos: self.pos,
+                }),
+            },
+        }
+    }
+
+    fn parse_output_names(&mut self) -> Result<BTreeSet<OutputName>, ParseError> {
+        self.expect_char('[')?;
+        let mut output_names = BTreeSet::new();
+        while self.peek() != Some(b']') {
+            let name_bytes = self.parse_string()?;
+            let name_str = std::str::from_utf8(&name_bytes)
+                .map_err(|_| ParseError::InvalidUtf8 { pos: self.pos })?;
+            output_names.insert(name_str.parse::<OutputName>()?);
+            if self.peek() == Some(b',') {
+                self.advance();
+            }
+        }
+        self.expect_char(']')?;
+        Ok(output_names)
     }
 
     fn parse_input_srcs(&mut self) -> Result<StorePathSet, ParseError> {
@@ -294,18 +382,6 @@ impl<'a> Parser<'a> {
 
         self.expect_char(']')?;
         Ok(items)
-    }
-
-    fn expect_str(&mut self, expected: &'static str) -> Result<(), ParseError> {
-        if self.bytes[self.pos..].starts_with(expected.as_bytes()) {
-            self.pos += expected.len();
-            Ok(())
-        } else {
-            Err(ParseError::UnexpectedEof {
-                expected,
-                pos: self.pos,
-            })
-        }
     }
 
     fn expect_char(&mut self, expected: char) -> Result<(), ParseError> {

--- a/harmonia-store-aterm/src/printer.rs
+++ b/harmonia-store-aterm/src/printer.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 
 use harmonia_store_core::ByteString;
 use harmonia_store_core::derivation::{
@@ -23,15 +23,24 @@ pub fn write_derivation<I>(store_dir: &StoreDir, drv: &DerivationT<I>, out: &mut
 where
     for<'a> DerivationInputs: From<&'a I>,
 {
-    out.push_str("Derive(");
+    let inputs = DerivationInputs::from(&drv.inputs);
+    let has_dynamic = inputs
+        .drvs
+        .values()
+        .any(|oi| !oi.dynamic_outputs.is_empty());
+
+    if has_dynamic {
+        out.push_str("DrvWithVersion(\"xp-dyn-drv\",");
+    } else {
+        out.push_str("Derive(");
+    }
 
     // Outputs
     write_outputs(store_dir, &drv.name, &drv.outputs, out);
     out.push(',');
 
     // Input derivations and input sources
-    let inputs = DerivationInputs::from(&drv.inputs);
-    write_input_drvs(store_dir, &inputs.drvs, out);
+    write_input_drvs(store_dir, &inputs.drvs, has_dynamic, out);
     out.push(',');
     write_input_srcs(store_dir, &inputs.srcs, out);
     out.push(',');
@@ -128,6 +137,7 @@ fn write_outputs(
 fn write_input_drvs(
     store_dir: &StoreDir,
     drvs: &BTreeMap<StorePath, OutputInputs>,
+    versioned: bool,
     out: &mut String,
 ) {
     out.push('[');
@@ -141,17 +151,41 @@ fn write_input_drvs(
         write_escaped(out, abs.to_string_lossy().as_bytes());
         out.push(',');
 
-        // Output names
-        out.push('[');
-        for (j, name) in output_inputs.outputs.iter().enumerate() {
-            if j > 0 {
-                out.push(',');
-            }
-            write_escaped(out, name.as_ref().as_bytes());
-        }
-        out.push(']');
+        write_output_inputs(output_inputs, versioned, out);
 
         out.push(')');
+    }
+    out.push(']');
+}
+
+fn write_output_inputs(oi: &OutputInputs, versioned: bool, out: &mut String) {
+    if versioned && !oi.dynamic_outputs.is_empty() {
+        out.push('(');
+        write_output_names(&oi.outputs, out);
+        out.push_str(",[");
+        for (i, (name, child)) in oi.dynamic_outputs.iter().enumerate() {
+            if i > 0 {
+                out.push(',');
+            }
+            out.push('(');
+            write_escaped(out, name.as_ref().as_bytes());
+            out.push(',');
+            write_output_inputs(child, versioned, out);
+            out.push(')');
+        }
+        out.push_str("])");
+    } else {
+        write_output_names(&oi.outputs, out);
+    }
+}
+
+fn write_output_names(outputs: &BTreeSet<OutputName>, out: &mut String) {
+    out.push('[');
+    for (j, name) in outputs.iter().enumerate() {
+        if j > 0 {
+            out.push(',');
+        }
+        write_escaped(out, name.as_ref().as_bytes());
     }
     out.push(']');
 }

--- a/harmonia-store-aterm/tests/upstream_drv.rs
+++ b/harmonia-store-aterm/tests/upstream_drv.rs
@@ -29,6 +29,7 @@ use rstest::rstest;
 #[case::ia_advanced_attributes_structured_attrs_defaults(
     "derivation/ia/advanced-attributes-structured-attrs-defaults"
 )]
+#[case::dyn_dep("derivation/dyn-dep-derivation")]
 fn drv_matches_json_and_roundtrips(#[case] base_path: &str) {
     let store_dir = StoreDir::default();
 
@@ -52,4 +53,18 @@ fn drv_matches_json_and_roundtrips(#[case] base_path: &str) {
     // Print back to ATerm and verify roundtrip
     let printed = print_derivation_aterm(&store_dir, &from_aterm);
     assert_eq!(printed, drv_str);
+}
+
+#[rstest]
+#[case::bad_version("derivation/bad-version.drv")]
+#[case::bad_old_version_dyn_deps("derivation/bad-old-version-dyn-deps.drv")]
+fn drv_parse_error(#[case] relative_path: &str) {
+    let store_dir = StoreDir::default();
+    let drv_path = libstore_test_data_path(relative_path);
+    let drv_str = std::fs::read_to_string(&drv_path)
+        .unwrap_or_else(|e| panic!("failed to read {}: {e}", drv_path.display()));
+    assert!(
+        parse_derivation_aterm(&store_dir, &drv_str, "test".parse().unwrap()).is_err(),
+        "{relative_path} should fail to parse"
+    );
 }


### PR DESCRIPTION
Nix uses `DrvWithVersion` instead of `Derive` for derivations with dynamic derivation inputs. Being able to parse this type is required for Hydra to parse .drv files produced by `builtins.outputOf`.