### PR TITLE
store-core: fix CA fixed-output store path computation

### DIFF
--- a/harmonia-store-core/src/derivation/derivation_output.rs
+++ b/harmonia-store-core/src/derivation/derivation_output.rs
@@ -293,8 +293,8 @@ mod unittests {
     #[rstest]
     #[case::deffered(DerivationOutput::Deferred, "a", "a", Ok(None))]
     #[case::input(DerivationOutput::InputAddressed("00000000000000000000000000000000-_".parse().unwrap()), "a", "a", Ok(Some("00000000000000000000000000000000-_".parse().unwrap())))]
-    #[case::fixed_flat(DerivationOutput::CAFixed("fixed:sha256:248d6a61d20638b8e5c026930c3e6039a33ce45964ff2167f6ecedd419db06c1".parse().unwrap()), "konsole-18.12.3", "out", Ok(Some("g9ngnw4w5vr9y3xkb7k2awl3mp95abrb-konsole-18.12.3".parse().unwrap())))]
-    #[case::fixed_sha1(DerivationOutput::CAFixed("fixed:r:sha1:84983e441c3bd26ebaae4aa1f95129e5e54670f1".parse().unwrap()), "konsole-18.12.3", "out", Ok(Some("ag0y7g6rci9zsdz9nxcq5l1qllx3r99x-konsole-18.12.3".parse().unwrap())))]
+    #[case::fixed_flat(DerivationOutput::CAFixed("fixed:sha256:248d6a61d20638b8e5c026930c3e6039a33ce45964ff2167f6ecedd419db06c1".parse().unwrap()), "konsole-18.12.3", "out", Ok(Some("jw8chmp9sf8f7pw684cszp6pa2zmn0bx-konsole-18.12.3".parse().unwrap())))]
+    #[case::fixed_sha1(DerivationOutput::CAFixed("fixed:r:sha1:84983e441c3bd26ebaae4aa1f95129e5e54670f1".parse().unwrap()), "konsole-18.12.3", "out", Ok(Some("ww9d58nz1xsl5ck0vcpc99h23l1y2hln-konsole-18.12.3".parse().unwrap())))]
     #[case::fixed_source(DerivationOutput::CAFixed("fixed:r:sha256:248d6a61d20638b8e5c026930c3e6039a33ce45964ff2167f6ecedd419db06c1".parse().unwrap()), "konsole-18.12.3", "out", Ok(Some("1w01xxn8f7s9s4n65ry6rwd7x9awf04s-konsole-18.12.3".parse().unwrap())))]
     fn test_path(
         #[case] output: DerivationOutput,

--- a/harmonia-store-core/src/store_path/create.rs
+++ b/harmonia-store-core/src/store_path/create.rs
@@ -12,7 +12,7 @@
 //! fixed_path = 'output:out:', ':sha256', fixed_out_hash, ':', store_dir, ':', name
 //! fixed_output_path = source_path | fixed_path
 //! fixed_out_hash = digest(fixed_out_hash_input)
-//! fixed_out_hash_input = 'fixed:out:', ingestion_method, fixed_output_hash
+//! fixed_out_hash_input = 'fixed:out:', ingestion_method, fixed_output_hash, ':'
 //! ingestion_method = '' | 'r:'
 //! fixed_output_hash = algorithm, ':', base16
 //! ```
@@ -114,12 +114,14 @@ impl StoreDirDisplay for PathType {
                 write!(f, ":sha256:{digest:x}")
             }
             PathType::Output { hash } => {
-                let digest_input = format!("fixed:out:r:{hash:x}");
+                // Nix's makeFixedOutputPath hashes
+                // "fixed:out:<method><algo>:<hex>:" (note the trailing ':').
+                let digest_input = format!("fixed:out:r:{hash:x}:");
                 let digest = harmonia_utils_hash::Sha256::digest(digest_input);
                 write!(f, "output:out:sha256:{digest:x}")
             }
             PathType::FlatOutput { hash } => {
-                let digest_input = format!("fixed:out:{hash:x}");
+                let digest_input = format!("fixed:out:{hash:x}:");
                 let digest = harmonia_utils_hash::Sha256::digest(digest_input);
                 write!(f, "output:out:sha256:{digest:x}")
             }

--- a/harmonia-store-core/src/store_path/store_dir.rs
+++ b/harmonia-store-core/src/store_path/store_dir.rs
@@ -258,16 +258,25 @@ mod unittests {
     #[case::output(
         ContentAddress::Recursive("sha1:84983e441c3bd26ebaae4aa1f95129e5e54670f1".parse::<Any<Hash>>().unwrap().into()),
         "konsole-18.12.3",
-        Some("fixed:out:r:sha1:84983e441c3bd26ebaae4aa1f95129e5e54670f1"),
-        "output:out:sha256:3519044ac96a4bc192ada46062b3554eada7ba1f3574a0cb90c1697c6c68f4c1:/nix/store:konsole-18.12.3",
-        "ag0y7g6rci9zsdz9nxcq5l1qllx3r99x-konsole-18.12.3"
+        Some("fixed:out:r:sha1:84983e441c3bd26ebaae4aa1f95129e5e54670f1:"),
+        "output:out:sha256:5341f5afdd0fb724c8f7eae0e346de5bb151a00422d47ae683aed85cd78f7120:/nix/store:konsole-18.12.3",
+        "ww9d58nz1xsl5ck0vcpc99h23l1y2hln-konsole-18.12.3"
     )]
     #[case::flat_output(
         ContentAddress::Flat("sha256:248d6a61d20638b8e5c026930c3e6039a33ce45964ff2167f6ecedd419db06c1".parse::<Any<Hash>>().unwrap().into()),
         "konsole-18.12.3",
-        Some("fixed:out:sha256:248d6a61d20638b8e5c026930c3e6039a33ce45964ff2167f6ecedd419db06c1"),
-        "output:out:sha256:646f2df192aa311e8b6920068dac2ab52d0ea87cedf864c034d30c19ccd17b7f:/nix/store:konsole-18.12.3",
-        "g9ngnw4w5vr9y3xkb7k2awl3mp95abrb-konsole-18.12.3"
+        Some("fixed:out:sha256:248d6a61d20638b8e5c026930c3e6039a33ce45964ff2167f6ecedd419db06c1:"),
+        "output:out:sha256:e55d6c8c9a08e91f15d5344612c42305702f04f08c487a7aff0b56c4c4add3e7:/nix/store:konsole-18.12.3",
+        "jw8chmp9sf8f7pw684cszp6pa2zmn0bx-konsole-18.12.3"
+    )]
+    // Regression test: real-world fetchurl FOD (libssh2-1.11.1.tar.gz)
+    // verified against `nix-store -q --outputs` on the actual derivation.
+    #[case::flat_output_libssh2(
+        ContentAddress::Flat("sha256:d9ec76cbe34db98eec3539fe2c899d26b0c837cb3eb466a56b0f109cabf658f7".parse::<Any<Hash>>().unwrap().into()),
+        "libssh2-1.11.1.tar.gz",
+        Some("fixed:out:sha256:d9ec76cbe34db98eec3539fe2c899d26b0c837cb3eb466a56b0f109cabf658f7:"),
+        "output:out:sha256:00ab8c141988e4eedd4695bda86a40373b1f87efe846e29a81a28929a657ee2c:/nix/store:libssh2-1.11.1.tar.gz",
+        "j04yfblg6sk5abb4n067xv0x0dfraf73-libssh2-1.11.1.tar.gz"
     )]
     fn test_make_store_path_from_ca(
         #[case] ca: ContentAddress,


### PR DESCRIPTION
Nix's makeFixedOutputPath hashes "fixed:out:<method><algo>:<hex>:" including a trailing colon. We were omitting it, which made DerivationOutput::path() / make_store_path_from_ca() compute wrong store paths for every fixed-output derivation that does not take the "source" (recursive sha256) shortcut, i.e. all flat-hash fetchurl derivations and all non-sha256 recursive ones.

Observed in the new hydra-queue-runner on staging-hydra: it recorded e.g. s9ga14kiza189wgfyqfbpi6zw4jmfmgc-libssh2-1.11.1.tar.gz as the output of a drv whose real output (per nix-store -q --outputs) is j04yfblg6sk5abb4n067xv0x0dfraf73-libssh2-1.11.1.tar.gz.

The existing test vectors encoded the wrong values; replace them with ones cross-checked against `nix-instantiate` and add a real-world fetchurl regression case.