### PR TITLE
env_logger: disable default features to drop jiff

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -864,7 +864,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a1c3cc8e57274ec99de65301228b537f1e4eedc1b8e0f9411c6caac8ae7308f"
 dependencies = [
  "log",
- "regex",
 ]
 
 [[package]]
@@ -876,7 +875,6 @@ dependencies = [
  "anstream",
  "anstyle",
  "env_filter",
- "jiff",
  "log",
 ]
 
@@ -1637,30 +1635,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
-name = "jiff"
-version = "0.2.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a3546dc96b6d42c5f24902af9e2538e82e39ad350b0c766eb3fbf2d8f3d8359"
-dependencies = [
- "jiff-static",
- "log",
- "portable-atomic",
- "portable-atomic-util",
- "serde_core",
-]
-
-[[package]]
-name = "jiff-static"
-version = "0.2.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a8c8b344124222efd714b73bb41f8b5120b27a7cc1c75593a6ff768d9d05aa4"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "jobserver"
 version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1972,21 +1946,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
 dependencies = [
  "plotters-backend",
-]
-
-[[package]]
-name = "portable-atomic"
-version = "1.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f89776e4d69bb58bc6993e99ffa1d11f228b839984854c7daeb5d37f87cbe950"
-
-[[package]]
-name = "portable-atomic-util"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
-dependencies = [
- "portable-atomic",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ repository = "https://github.com/nix-community/harmonia.git"
 version = "3.0.0"
 
 [workspace.dependencies]
-env_logger = "0.11"
+env_logger = { version = "0.11", default-features = false, features = [ "auto-color" ] }
 hex = "0.4"
 log = "0.4"
 nix = { version = "0.31", features = [ "signal", "mman" ] }

--- a/harmonia-cache/Cargo.toml
+++ b/harmonia-cache/Cargo.toml
@@ -22,10 +22,7 @@ actix-web = { version = "4", default-features = false, features = [
 ] }
 askama_escape = "0.15.6"
 async-compression = { version = "0.4.41", features = [ "tokio", "bzip2" ] }
-env_logger = { version = "0.11", default-features = false, features = [
-    "auto-color",
-    "humantime",
-] }
+env_logger = { workspace = true }
 http-range = "0.1"
 log = { workspace = true }
 mime = "0.3"


### PR DESCRIPTION
The humantime feature pulls in jiff (~14s cold compile) just to format timestamps in log lines. systemd journal already timestamps output, so this is redundant for the daemon/cache binaries.

Also drops the regex feature from env_logger; RUST_LOG filtering still works for plain module=level syntax via env_filter's non-regex path.