### PR TITLE
logging: fix RUST_LOG defaults and docs after tracing switch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1073,7 +1073,6 @@ dependencies = [
  "hex-literal",
  "libc",
  "num_enum",
- "paste",
  "pin-project-lite",
  "proptest",
  "proptest-derive",
@@ -1217,7 +1216,6 @@ name = "harmonia-utils-test"
 version = "0.0.0-alpha.0"
 dependencies = [
  "bytes",
- "paste",
  "proptest",
  "serde",
  "serde_json",
@@ -1685,12 +1683,6 @@ dependencies = [
  "smallvec",
  "windows-link",
 ]
-
-[[package]]
-name = "paste"
-version = "1.0.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "percent-encoding"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,6 @@ derive_more = { version = "2.1", features = [ "display" ] }
 ed25519-dalek = "2"
 futures = "0.3"
 getrandom = "0.3"
-hex = "0.4"
 md5 = "0.8"
 memchr = "2"
 nix = { version = "0.31", features = [ "signal", "mman" ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,7 +75,6 @@ syn         = "2.0"
 
 # Test / dev only
 hex-literal     = "1.1"
-paste           = "1.0"
 proptest        = "1.11"
 proptest-derive = "0.8"
 rstest          = "0.26"

--- a/README.md
+++ b/README.md
@@ -190,11 +190,13 @@ Note: When TLS is enabled, harmonia will only accept HTTPS connections on the co
 
 ### Logging Configuration
 
-Logging can be configured with
-[env_logger](https://docs.rs/env_logger/latest/env_logger/). The default value
-is `info,actix_web=debug`. To only log errors use the following
-`RUST_LOG=error` and to only disable access logging, use
-`RUST_LOG=info,actix_web::middleware=error`
+Logging is handled by [tracing](https://docs.rs/tracing) and configured via the
+`RUST_LOG` environment variable using
+[EnvFilter](https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html)
+syntax (compatible with the familiar `env_logger` directives). The default
+filter is `info`. To only log errors use `RUST_LOG=error`, and to keep info
+messages while disabling actix access logging use
+`RUST_LOG=info,actix_web::middleware=error`.
 
 ## Build
 

--- a/harmonia-daemon/src/main.rs
+++ b/harmonia-daemon/src/main.rs
@@ -11,7 +11,9 @@ use tracing_subscriber::EnvFilter;
 async fn main() -> Result<(), DaemonError> {
     // Initialize tracing; bridges `log` records (tokio, rusqlite) via tracing-log.
     tracing_subscriber::fmt()
-        .with_env_filter(EnvFilter::from_default_env())
+        .with_env_filter(
+            EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")),
+        )
         .init();
 
     // Load configuration

--- a/harmonia-protocol/Cargo.toml
+++ b/harmonia-protocol/Cargo.toml
@@ -44,7 +44,6 @@ harmonia-nar        = { version = "3.0.0", features = [ "test" ] }
 harmonia-store-core = { version = "0.0.0-alpha.0", features = [ "test" ] }
 harmonia-utils-test = { version = "0.0.0-alpha.0" }
 hex-literal         = { workspace = true }
-paste               = { workspace = true }
 proptest            = { workspace = true }
 proptest-derive     = { workspace = true }
 rstest              = { workspace = true }

--- a/harmonia-utils-test/Cargo.toml
+++ b/harmonia-utils-test/Cargo.toml
@@ -15,7 +15,6 @@ readme               = "README.md"
 
 [dependencies]
 bytes      = { workspace = true }
-paste      = { workspace = true }
 proptest   = { workspace = true }
 serde      = { workspace = true }
 serde_json = { workspace = true }

--- a/harmonia-utils-test/src/json_upstream.rs
+++ b/harmonia-utils-test/src/json_upstream.rs
@@ -76,14 +76,17 @@ where
 #[macro_export]
 macro_rules! test_upstream_json {
     ($test_name:ident, $path:expr, $value:expr) => {
-        $crate::paste::paste! {
+        mod $test_name {
+            #[allow(unused_imports)]
+            use super::*;
+
             #[test]
-            fn [<$test_name _from_json>]() {
+            fn from_json() {
                 $crate::json_upstream::test_upstream_json_from_json(&$path, &$value);
             }
 
             #[test]
-            fn [<$test_name _to_json>]() {
+            fn to_json() {
                 $crate::json_upstream::test_upstream_json_to_json(&$path, &$value);
             }
         }

--- a/harmonia-utils-test/src/lib.rs
+++ b/harmonia-utils-test/src/lib.rs
@@ -43,10 +43,6 @@ impl CanonicalTempDir {
 /// Byte string type alias.
 pub type ByteString = bytes::Bytes;
 
-// Re-export paste for macro hygiene
-#[doc(hidden)]
-pub use paste;
-
 pub mod helpers;
 pub mod json_upstream;
 

--- a/module.nix
+++ b/module.nix
@@ -140,7 +140,7 @@ in
             credential: "%d/${credential.id}"
           ) credentials;
           # print stack traces
-          RUST_LOG = "actix_web=debug";
+          RUST_LOG = "info,actix_web=debug";
           RUST_BACKTRACE = "1";
         };
 


### PR DESCRIPTION
EnvFilter::from_default_env() yields an empty filter when RUST_LOG is unset, which silences everything including errors. env_logger used to default to ERROR, and harmonia-cache previously defaulted to "info". Give harmonia-daemon the same "info" fallback so a bare invocation still logs.

module.nix set RUST_LOG="actix_web=debug" for the cache service, which (with both env_logger and EnvFilter) suppresses every target outside actix_web — including harmonia's own startup/info messages. Prefix with "info," so the service logs its own state again.

Update README to reflect the tracing/EnvFilter backend and the actual default filter.