### PR TITLE
replace futures umbrella with futures-core/-sink/-util

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -789,52 +789,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "futures"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
-dependencies = [
- "futures-channel",
- "futures-core",
- "futures-executor",
- "futures-io",
- "futures-sink",
- "futures-task",
- "futures-util",
-]
-
-[[package]]
-name = "futures-channel"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
-dependencies = [
- "futures-core",
- "futures-sink",
-]
-
-[[package]]
 name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
-
-[[package]]
-name = "futures-executor"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
-dependencies = [
- "futures-core",
- "futures-task",
- "futures-util",
-]
-
-[[package]]
-name = "futures-io"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
 name = "futures-macro"
@@ -871,13 +829,10 @@ version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
- "futures-channel",
  "futures-core",
- "futures-io",
  "futures-macro",
  "futures-sink",
  "futures-task",
- "memchr",
  "pin-project-lite",
  "slab",
 ]
@@ -982,7 +937,8 @@ dependencies = [
  "actix-web",
  "askama_escape",
  "async-compression",
- "futures",
+ "futures-core",
+ "futures-util",
  "harmonia-nar",
  "harmonia-store-core",
  "harmonia-store-remote",
@@ -1016,7 +972,8 @@ version = "3.0.0"
 name = "harmonia-daemon"
 version = "3.0.0"
 dependencies = [
- "futures",
+ "futures-core",
+ "futures-util",
  "harmonia-protocol",
  "harmonia-store-core",
  "harmonia-store-db",
@@ -1039,7 +996,9 @@ dependencies = [
  "bstr",
  "bytes",
  "derive_more",
- "futures",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
  "harmonia-utils-io",
  "harmonia-utils-test",
  "nix",
@@ -1063,7 +1022,8 @@ dependencies = [
  "bstr",
  "bytes",
  "derive_more",
- "futures",
+ "futures-core",
+ "futures-util",
  "harmonia-nar",
  "harmonia-protocol-derive",
  "harmonia-store-core",
@@ -1153,7 +1113,8 @@ name = "harmonia-store-remote"
 version = "3.0.0"
 dependencies = [
  "async-stream",
- "futures",
+ "futures-core",
+ "futures-util",
  "harmonia-nar",
  "harmonia-protocol",
  "harmonia-store-core",
@@ -1201,7 +1162,7 @@ name = "harmonia-utils-io"
 version = "0.0.0-alpha.0"
 dependencies = [
  "bytes",
- "futures",
+ "futures-util",
  "hex-literal",
  "pin-project-lite",
  "proptest",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1101,7 +1101,6 @@ dependencies = [
 name = "harmonia-store-db"
 version = "3.0.0"
 dependencies = [
- "rstest",
  "rusqlite",
  "tempfile",
  "thiserror",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,9 @@ bytes = "1.11"
 data-encoding = "2.6"
 derive_more = { version = "2.1", features = [ "display" ] }
 ed25519-dalek = "2"
-futures = "0.3"
+futures-core = "0.3"
+futures-sink = "0.3"
+futures-util = { version = "0.3", features = [ "sink" ] }
 getrandom = "0.3"
 md5 = "0.8"
 memchr = "2"

--- a/harmonia-cache/Cargo.toml
+++ b/harmonia-cache/Cargo.toml
@@ -34,7 +34,6 @@ rustls-pemfile = "2"
 rustls-pki-types = "1"
 serde = { workspace = true }
 serde_json = { workspace = true }
-tempfile = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
 tokio-util = { workspace = true, features = [ "io" ] }
@@ -54,6 +53,7 @@ prometheus            = { workspace = true }
 [dev-dependencies]
 harmonia-utils-test = { version = "0.0.0-alpha.0" }
 nix                 = { workspace = true }
+tempfile            = { workspace = true }
 tokio               = { workspace = true, features = [ "process" ] }
 
 [lints]

--- a/harmonia-cache/Cargo.toml
+++ b/harmonia-cache/Cargo.toml
@@ -43,7 +43,8 @@ tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 url = "2.5.7"
 # Nix.rs-based crates
-futures               = { workspace = true }
+futures-core          = { workspace = true }
+futures-util          = { workspace = true }
 harmonia-nar          = { version = "3.0.0" }
 harmonia-store-core   = { version = "0.0.0-alpha.0" }
 harmonia-store-remote = { version = "3.0.0" }

--- a/harmonia-cache/src/nar.rs
+++ b/harmonia-cache/src/nar.rs
@@ -202,14 +202,14 @@ fn create_range_stream<S>(
     stream: S,
     offset: u64,
     length: u64,
-) -> impl futures::Stream<Item = std::result::Result<Bytes, std::io::Error>>
+) -> impl futures_core::Stream<Item = std::result::Result<Bytes, std::io::Error>>
 where
-    S: futures::Stream<Item = std::result::Result<Bytes, std::io::Error>> + Unpin,
+    S: futures_core::Stream<Item = std::result::Result<Bytes, std::io::Error>> + Unpin,
 {
-    futures::stream::unfold(
+    futures_util::stream::unfold(
         (stream, offset, length, 0u64),
         |(mut stream, offset, length, mut sent)| async move {
-            use futures::StreamExt;
+            use futures_util::StreamExt;
 
             loop {
                 match stream.next().await {
@@ -255,7 +255,7 @@ where
 mod test {
     use super::*;
     use crate::error::{IoErrorContext, Result};
-    use futures::StreamExt;
+    use futures_util::StreamExt;
     use std::fs;
     use std::os::unix::fs::PermissionsExt;
     use std::path::PathBuf;
@@ -263,7 +263,7 @@ mod test {
 
     async fn dump_to_vec(path: PathBuf) -> Vec<u8> {
         let stream = NarByteStream::new(path);
-        futures::pin_mut!(stream);
+        futures_util::pin_mut!(stream);
 
         let mut result = Vec::new();
         while let Some(chunk) = stream.next().await {

--- a/harmonia-daemon/Cargo.toml
+++ b/harmonia-daemon/Cargo.toml
@@ -9,7 +9,8 @@ repository.workspace = true
 readme               = "README.md"
 
 [dependencies]
-futures             = { workspace = true }
+futures-core        = { workspace = true }
+futures-util        = { workspace = true }
 harmonia-protocol   = { version = "3.0.0" }
 harmonia-store-core = { version = "0.0.0-alpha.0" }
 harmonia-store-db   = { version = "3.0.0" }

--- a/harmonia-daemon/src/server/mod.rs
+++ b/harmonia-daemon/src/server/mod.rs
@@ -15,8 +15,8 @@ use std::fmt::Debug;
 use std::ops::Deref;
 use std::pin::{Pin, pin};
 
-use futures::future::TryFutureExt;
-use futures::{FutureExt, Stream, StreamExt as _};
+use futures_core::Stream;
+use futures_util::{FutureExt, StreamExt as _, TryFutureExt};
 use tokio::io::{AsyncBufRead, AsyncRead, AsyncWrite, AsyncWriteExt, copy_buf};
 use tokio::net::UnixListener;
 use tracing::{Instrument, debug, error, info, instrument, trace};

--- a/harmonia-nar/Cargo.toml
+++ b/harmonia-nar/Cargo.toml
@@ -17,7 +17,9 @@ readme               = "README.md"
 bstr              = { workspace = true }
 bytes             = { workspace = true }
 derive_more       = { workspace = true }
-futures           = { workspace = true }
+futures-core      = { workspace = true }
+futures-sink      = { workspace = true }
+futures-util      = { workspace = true }
 harmonia-utils-io = { version = "0.0.0-alpha.0" }
 nix.workspace     = true
 pin-project-lite  = { workspace = true }

--- a/harmonia-nar/src/archive/byte_stream.rs
+++ b/harmonia-nar/src/archive/byte_stream.rs
@@ -4,7 +4,8 @@ use std::pin::Pin;
 use std::task::{Context, Poll, ready};
 
 use bytes::{Bytes, BytesMut};
-use futures::{SinkExt, Stream, StreamExt};
+use futures_core::Stream;
+use futures_util::{SinkExt, StreamExt};
 use tokio::io::AsyncWrite;
 use tokio::sync::mpsc;
 use tokio_util::sync::PollSender;
@@ -116,7 +117,7 @@ impl NarByteStream {
             let mut nar_writer = NarWriter::new(writer);
             let events = DumpOptions::new().dump(path);
 
-            futures::pin_mut!(events);
+            futures_util::pin_mut!(events);
             while let Some(event_result) = events.next().await {
                 match event_result {
                     Ok(event) => {

--- a/harmonia-nar/src/archive/dumper.rs
+++ b/harmonia-nar/src/archive/dumper.rs
@@ -13,7 +13,7 @@ use std::{collections::VecDeque, io};
 
 use bstr::{ByteSlice as _, ByteVec as _};
 use bytes::Bytes;
-use futures::Stream;
+use futures_core::Stream;
 use pin_project_lite::pin_project;
 use tokio::io::{AsyncBufRead, AsyncRead, BufReader};
 use tokio::sync::{OwnedSemaphorePermit, Semaphore};
@@ -464,7 +464,7 @@ impl Stream for NarDumper {
 mod unittests {
     use std::fs::create_dir_all;
 
-    use futures::TryStreamExt as _;
+    use futures_util::TryStreamExt as _;
     use tempfile::Builder;
 
     use super::*;

--- a/harmonia-nar/src/archive/parser.rs
+++ b/harmonia-nar/src/archive/parser.rs
@@ -3,7 +3,7 @@ use std::pin::Pin;
 use std::task::{Context, Poll, ready};
 
 use bytes::Buf;
-use futures::Stream;
+use futures_core::Stream;
 use pin_project_lite::pin_project;
 use tokio::io::AsyncRead;
 use tracing::trace;
@@ -152,7 +152,7 @@ pub async fn read_nar<R>(source: R) -> io::Result<crate::archive::test_data::Tes
 where
     R: AsyncRead + Unpin,
 {
-    use futures::stream::TryStreamExt as _;
+    use futures_util::stream::TryStreamExt as _;
     parse_nar(source)
         .and_then(NarEvent::read_file)
         .try_collect()
@@ -164,7 +164,7 @@ mod unittests {
     use std::io::Cursor;
 
     use bytes::Bytes;
-    use futures::TryStreamExt;
+    use futures_util::TryStreamExt;
     use rstest::rstest;
     use tokio::fs::File;
     use tokio::io::AsyncReadExt as _;

--- a/harmonia-nar/src/archive/restorer.rs
+++ b/harmonia-nar/src/archive/restorer.rs
@@ -12,7 +12,8 @@ use std::task::{Poll, ready};
 use bstr::ByteSlice as _;
 use bytes::Bytes;
 use derive_more::Display;
-use futures::{Sink, Stream};
+use futures_core::Stream;
+use futures_sink::Sink;
 use pin_project_lite::pin_project;
 use thiserror::Error;
 use tokio::io::AsyncBufRead;
@@ -349,7 +350,7 @@ impl RestoreOptions {
         P: Into<PathBuf>,
         R: AsyncBufRead + Send + 'static,
     {
-        use futures::stream::StreamExt as _;
+        use futures_util::stream::StreamExt as _;
         let restorer = NarRestorer::new_restorer(path, self.use_case_hack);
         stream.map(|item| item.into()).forward(restorer).await
     }
@@ -375,7 +376,7 @@ where
 mod unittests {
     use super::*;
     use crate::archive::{NarEvent, dump, test_data};
-    use futures::stream::{StreamExt as _, TryStreamExt as _, iter};
+    use futures_util::stream::{StreamExt as _, TryStreamExt as _, iter};
     use rstest::rstest;
     use tempfile::Builder;
 
@@ -409,8 +410,8 @@ mod unittests {
 
 #[cfg(test)]
 mod proptests {
-    use futures::stream::iter;
-    use futures::{StreamExt as _, TryStreamExt as _};
+    use futures_util::stream::iter;
+    use futures_util::{StreamExt as _, TryStreamExt as _};
     use proptest::proptest;
     use tempfile::tempdir;
 

--- a/harmonia-nar/src/archive/writer.rs
+++ b/harmonia-nar/src/archive/writer.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use bytes::{Buf, BufMut, BytesMut};
-use futures::Sink;
+use futures_sink::Sink;
 use pin_project_lite::pin_project;
 use tokio::io::{AsyncBufRead, AsyncWrite};
 
@@ -218,7 +218,7 @@ pub fn write_nar<'e, E>(events: E) -> bytes::Bytes
 where
     E: IntoIterator<Item = &'e super::test_data::TestNarEvent>,
 {
-    use futures::{FutureExt as _, SinkExt as _, StreamExt as _, stream::iter};
+    use futures_util::{FutureExt as _, SinkExt as _, StreamExt as _, stream::iter};
     use std::io::Cursor;
 
     let mut buf = Vec::new();
@@ -239,8 +239,8 @@ where
 
 #[cfg(test)]
 mod unittests {
-    use futures::StreamExt as _;
-    use futures::stream::iter;
+    use futures_util::StreamExt as _;
+    use futures_util::stream::iter;
     use rstest::rstest;
     use tempfile::tempdir;
     use tokio::fs::File;

--- a/harmonia-protocol/Cargo.toml
+++ b/harmonia-protocol/Cargo.toml
@@ -18,7 +18,8 @@ async-stream     = { workspace = true }
 bstr             = { workspace = true }
 bytes            = { workspace = true }
 derive_more      = { workspace = true }
-futures          = { workspace = true }
+futures-core     = { workspace = true }
+futures-util     = { workspace = true }
 libc             = "0.2"
 num_enum         = { workspace = true }
 pin-project-lite = { workspace = true }

--- a/harmonia-protocol/src/daemon_wire/add_multiple_to_store.rs
+++ b/harmonia-protocol/src/daemon_wire/add_multiple_to_store.rs
@@ -1,7 +1,8 @@
 use std::pin::pin;
 
 use async_stream::try_stream;
-use futures::{Stream, StreamExt};
+use futures_core::Stream;
+use futures_util::StreamExt;
 use pin_project_lite::pin_project;
 use tokio::io::{AsyncBufRead, AsyncRead, AsyncWrite, copy_buf};
 use tracing::{Instrument, debug, debug_span, instrument, trace};
@@ -127,8 +128,8 @@ mod unittests {
     use std::io::Cursor;
 
     use bytes::Bytes;
-    use futures::stream::iter;
-    use futures::{TryFutureExt as _, TryStreamExt as _};
+    use futures_util::stream::iter;
+    use futures_util::{TryFutureExt as _, TryStreamExt as _};
     use rstest::rstest;
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
     use tokio::try_join;
@@ -249,7 +250,7 @@ mod unittests {
         ],
     )]
     async fn test_read_written(#[case] infos: Vec<(ValidPathInfo, test_data::TestNarEvents)>) {
-        use futures::FutureExt as _;
+        use futures_util::FutureExt as _;
         use tokio::io::simplex;
 
         use harmonia_nar::archive::read_nar;

--- a/harmonia-protocol/src/daemon_wire/logger.rs
+++ b/harmonia-protocol/src/daemon_wire/logger.rs
@@ -9,8 +9,8 @@ use std::task::{Context, Poll, ready};
 
 use async_stream::stream;
 use bytes::Bytes;
-use futures::Stream;
-use futures::stream::{Empty, empty};
+use futures_core::Stream;
+use futures_util::stream::{Empty, empty};
 use num_enum::{IntoPrimitive, TryFromPrimitive};
 use pin_project_lite::pin_project;
 use tokio::io::{AsyncBufRead, AsyncBufReadExt, AsyncRead, AsyncWrite, AsyncWriteExt as _};
@@ -593,7 +593,7 @@ pub trait FutureResultExt: Future {
     /// ```rust
     /// # use std::future::{ready, Future};
     /// # use std::pin::pin;
-    /// # use futures::stream::StreamExt as _;
+    /// # use futures_util::stream::StreamExt as _;
     /// use harmonia_protocol::daemon::FutureResultExt as _;
     /// # tokio_test::block_on(async {
     /// let result = ready(12).empty_logs();
@@ -617,7 +617,7 @@ pub trait FutureResultExt: Future {
     /// ```rust
     /// # use std::future::{ready, Future};
     /// # use std::pin::pin;
-    /// # use futures::stream::StreamExt as _;
+    /// # use futures_util::stream::StreamExt as _;
     /// # use harmonia_protocol::daemon::DaemonResult;
     /// use harmonia_protocol::daemon::FutureResultExt as _;
     /// # tokio_test::block_on(async {

--- a/harmonia-protocol/src/types.rs
+++ b/harmonia-protocol/src/types.rs
@@ -5,7 +5,7 @@ use std::pin::Pin;
 
 use bstr::ByteSlice;
 use bytes::Bytes;
-use futures::Stream;
+use futures_core::Stream;
 use num_enum::{IntoPrimitive, TryFromPrimitive};
 use thiserror::Error;
 use tokio::io::AsyncBufRead;

--- a/harmonia-store-db/Cargo.toml
+++ b/harmonia-store-db/Cargo.toml
@@ -18,7 +18,6 @@ thiserror = { workspace = true }
 tracing   = { workspace = true }
 
 [dev-dependencies]
-rstest   = { workspace = true }
 tempfile = { workspace = true }
 
 [lints]

--- a/harmonia-store-remote/Cargo.toml
+++ b/harmonia-store-remote/Cargo.toml
@@ -25,7 +25,8 @@ harmonia-utils-io   = { version = "0.0.0-alpha.0" }
 
 # Async runtime
 async-stream = { workspace = true }
-futures      = { workspace = true }
+futures-core = { workspace = true }
+futures-util = { workspace = true }
 tokio        = { workspace = true }
 
 # Utilities

--- a/harmonia-store-remote/src/client.rs
+++ b/harmonia-store-remote/src/client.rs
@@ -12,9 +12,10 @@ use std::pin::Pin;
 use std::sync::atomic::AtomicU64;
 
 use async_stream::stream;
-use futures::Stream;
-use futures::future::Either;
-use futures::io::Cursor;
+use std::io::Cursor;
+
+use futures_core::Stream;
+use futures_util::future::Either;
 use tokio::io::{AsyncBufRead, AsyncRead, AsyncWrite, AsyncWriteExt as _, copy_buf};
 use tokio::net::UnixStream;
 use tokio::net::unix::{OwnedReadHalf, OwnedWriteHalf};

--- a/harmonia-utils-io/Cargo.toml
+++ b/harmonia-utils-io/Cargo.toml
@@ -15,7 +15,7 @@ readme               = "README.md"
 
 [dependencies]
 bytes            = { workspace = true }
-futures          = { workspace = true }
+futures-util     = { workspace = true }
 pin-project-lite = { workspace = true }
 tokio            = { workspace = true, features = [ "io-util", "sync" ] }
 tracing          = { workspace = true }

--- a/harmonia-utils-io/src/lending.rs
+++ b/harmonia-utils-io/src/lending.rs
@@ -5,7 +5,7 @@ use std::pin::Pin;
 use std::task::{Context, Poll, ready};
 
 use bytes::Bytes;
-use futures::FutureExt;
+use futures_util::FutureExt;
 use pin_project_lite::pin_project;
 use tokio::io::{AsyncBufRead, AsyncRead, ReadBuf};
 use tokio::sync::oneshot;

--- a/harmonia-utils-test/src/lib.rs
+++ b/harmonia-utils-test/src/lib.rs
@@ -40,9 +40,6 @@ impl CanonicalTempDir {
     }
 }
 
-/// Byte string type alias.
-pub type ByteString = bytes::Bytes;
-
 pub mod helpers;
 pub mod json_upstream;
 
@@ -64,8 +61,8 @@ prop_compose! {
 }
 
 prop_compose! {
-    pub fn arb_byte_string()(data in any::<Vec<u8>>()) -> ByteString {
-        ByteString::from(data)
+    pub fn arb_byte_string()(data in any::<Vec<u8>>()) -> bytes::Bytes {
+        bytes::Bytes::from(data)
     }
 }
 


### PR DESCRIPTION
The `futures` facade pulls in futures-executor, futures-channel and futures-io, none of which we use — we run on tokio and only need the Stream/Sink traits and the StreamExt/SinkExt/FutureExt combinators. Depend on the underlying crates directly.