### PR TITLE
Add /build-trace-v2 endpoint for content-addressed derivations

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -18,16 +18,15 @@
     "nix": {
       "flake": false,
       "locked": {
-        "lastModified": 1776205241,
-        "narHash": "sha256-7DgRBh7cDTCM6Kkb19b9QE8+7bMuw5jLJpJFRM3JGC4=",
+        "lastModified": 1776446071,
+        "narHash": "sha256-US8lD1/KbTQZyc/hZv5HzamrEOMN8fzwCzEtGEEY4Pk=",
         "owner": "nixos",
         "repo": "nix",
-        "rev": "f11bb9b9e45209086e30c1127749da9032460921",
+        "rev": "ca49695a69081c612cbc99a51e78c69fb4ece190",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "2.34-maintenance",
         "repo": "nix",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -6,7 +6,7 @@
   inputs.treefmt-nix.inputs.nixpkgs.follows = "nixpkgs";
   inputs.crane.url = "github:ipetkov/crane";
   inputs.nix = {
-    url = "github:nixos/nix/2.34-maintenance";
+    url = "github:nixos/nix";
     # We just need some test data, we're not building upstream nix.
     flake = false;
   };

--- a/harmonia-cache/src/main.rs
+++ b/harmonia-cache/src/main.rs
@@ -153,7 +153,18 @@ async fn inner_main() -> Result<()> {
     let metrics_data = web::Data::new(metrics.clone());
 
     tracing::info!("listening on {}", c.bind);
-    let mut server = HttpServer::new(move || {
+    let nar_route = format!("/nar/{{narhash:[{NIXBASE32_ALPHABET}]{{52}}}}.nar");
+    // narinfos served by nix-serve have the narhash embedded in the nar URL.
+    // While we don't do that, if nix-serve is replaced with harmonia, the old nar URLs
+    // will stay in client caches for a while - so support them anyway.
+    let nix_serve_nar_route = format!(
+        "/nar/{{outhash:[{a}]{{32}}}}-{{narhash:[{a}]{{52}}}}.nar",
+        a = NIXBASE32_ALPHABET
+    );
+    let mut server = 
+        
+        
+        HttpServer::new(move || {
         App::new()
                 .wrap(middleware::Condition::new(config_data.enable_compression, middleware::Compress::default()))
                 .wrap(prometheus::PrometheusMiddleware::new(metrics.clone()))
@@ -178,6 +189,7 @@ async fn inner_main() -> Result<()> {
                     web::get().to(nar::get),
                 )
                 .route("/serve/{hash}{path:.*}", web::get().to(serve::get))
+                .route("/serve/{hash}{path:.*}", web::head().to(serve::get))
                 .route("/log/{drv}", web::get().to(buildlog::get))
                 .route("/version", web::get().to(version::get))
                 .route("/health", web::get().to(health::get))
@@ -187,7 +199,7 @@ async fn inner_main() -> Result<()> {
         // default is 5 seconds, which is too small when doing mass requests on slow machines
         .client_request_timeout(Duration::from_secs(30))
     .workers(c.workers)
-    .max_connection_rate(c.max_connection_rate);
+        .max_connection_rate(c.max_connection_rate);
 
     let try_url = Url::parse(&c.bind);
     let (bind, uds) = if let Ok(url) = try_url.as_ref() {

--- a/harmonia-cache/src/main.rs
+++ b/harmonia-cache/src/main.rs
@@ -36,6 +36,7 @@ mod nar;
 mod narinfo;
 mod narlist;
 mod prometheus;
+mod realisations;
 mod root;
 mod serve;
 mod store;
@@ -161,45 +162,38 @@ async fn inner_main() -> Result<()> {
         "/nar/{{outhash:[{a}]{{32}}}}-{{narhash:[{a}]{{52}}}}.nar",
         a = NIXBASE32_ALPHABET
     );
-    let mut server = 
-        
-        
-        HttpServer::new(move || {
+    let mut server = HttpServer::new(move || {
         App::new()
-                .wrap(middleware::Condition::new(config_data.enable_compression, middleware::Compress::default()))
-                .wrap(prometheus::PrometheusMiddleware::new(metrics.clone()))
-                .app_data(config_data.clone())
-                .app_data(metrics_data.clone())
-                .route("/", web::get().to(root::get))
-                .route("/{hash}.ls", web::get().to(narlist::get))
-                .route("/{hash}.ls", web::head().to(narlist::get))
-                .route("/{hash}.narinfo", web::get().to(narinfo::get))
-                .route("/{hash}.narinfo", web::head().to(narinfo::get))
-                .route(
-                    &format!("/nar/{{narhash:[{NIXBASE32_ALPHABET}]{{52}}}}.nar"),
-                    web::get().to(nar::get),
-                )
-                .route(
-                    // narinfos served by nix-serve have the narhash embedded in the nar URL.
-                    // While we don't do that, if nix-serve is replaced with harmonia, the old nar URLs
-                    // will stay in client caches for a while - so support them anyway.
-                    &format!(
-                        "/nar/{{outhash:[{NIXBASE32_ALPHABET}]{{32}}}}-{{narhash:[{NIXBASE32_ALPHABET}]{{52}}}}.nar"
-                    ),
-                    web::get().to(nar::get),
-                )
-                .route("/serve/{hash}{path:.*}", web::get().to(serve::get))
-                .route("/serve/{hash}{path:.*}", web::head().to(serve::get))
-                .route("/log/{drv}", web::get().to(buildlog::get))
-                .route("/version", web::get().to(version::get))
-                .route("/health", web::get().to(health::get))
-                .route("/nix-cache-info", web::get().to(cacheinfo::get))
-                .route("/metrics", web::get().to(prometheus::metrics_handler))
-        })
-        // default is 5 seconds, which is too small when doing mass requests on slow machines
-        .client_request_timeout(Duration::from_secs(30))
+            .wrap(middleware::Condition::new(
+                config_data.enable_compression,
+                middleware::Compress::default(),
+            ))
+            .wrap(prometheus::PrometheusMiddleware::new(metrics.clone()))
+            .app_data(config_data.clone())
+            .app_data(metrics_data.clone())
+            .route("/", web::get().to(root::get))
+            .route("/{hash}.ls", web::get().to(narlist::get))
+            .route("/{hash}.ls", web::head().to(narlist::get))
+            .route("/{hash}.narinfo", web::get().to(narinfo::get))
+            .route("/{hash}.narinfo", web::head().to(narinfo::get))
+            .route(&nar_route, web::get().to(nar::get))
+            .route(&nix_serve_nar_route, web::get().to(nar::get))
+            .route("/serve/{hash}{path:.*}", web::get().to(serve::get))
+            .route("/serve/{hash}{path:.*}", web::head().to(serve::get))
+            .route("/log/{drv}", web::get().to(buildlog::get))
+            .route("/version", web::get().to(version::get))
+            .route("/health", web::get().to(health::get))
+            .route("/nix-cache-info", web::get().to(cacheinfo::get))
+            .route(
+                "/build-trace-v2/{drv_path}/{output}",
+                web::get().to(realisations::get),
+            )
+            .route("/metrics", web::get().to(prometheus::metrics_handler))
+    })
+    // default is 5 seconds, which is too small when doing mass requests on slow machines
+    .client_request_timeout(Duration::from_secs(30))
     .workers(c.workers)
-        .max_connection_rate(c.max_connection_rate);
+    .max_connection_rate(c.max_connection_rate);
 
     let try_url = Url::parse(&c.bind);
     let (bind, uds) = if let Ok(url) = try_url.as_ref() {

--- a/harmonia-cache/src/realisations.rs
+++ b/harmonia-cache/src/realisations.rs
@@ -1,0 +1,75 @@
+//! Handler for content-addressed derivation realisations (build-trace).
+//!
+//! Serves `UnkeyedRealisation` JSON at
+//! `/build-trace-v2/{drv_path}/{output}.doi`, where `{drv_path}` is the store
+//! path base name of the derivation and `{output}` is the output name.
+
+use actix_web::{HttpResponse, web};
+use harmonia_store_core::derived_path::OutputName;
+use harmonia_store_core::realisation::DrvOutput;
+use harmonia_store_core::store_path::StorePath;
+use harmonia_store_remote::DaemonStore;
+
+use crate::config::Config;
+use crate::{ServerResult, cache_control_max_age_1y, cache_control_no_store};
+
+pub async fn get(path: web::Path<(String, String)>, settings: web::Data<Config>) -> ServerResult {
+    let (drv_path_raw, output_raw) = path.into_inner();
+    let output_raw = output_raw
+        .strip_suffix(".doi")
+        .unwrap_or(&output_raw)
+        .to_owned();
+
+    let drv_path: StorePath = match drv_path_raw.parse() {
+        Ok(p) => p,
+        Err(e) => {
+            tracing::debug!("Invalid drv path '{drv_path_raw}': {e}");
+            return Ok(HttpResponse::BadRequest()
+                .insert_header(cache_control_no_store())
+                .body(format!("Invalid derivation path: {e}")));
+        }
+    };
+    let output_name: OutputName = match output_raw.parse() {
+        Ok(o) => o,
+        Err(e) => {
+            tracing::debug!("Invalid output name '{output_raw}': {e}");
+            return Ok(HttpResponse::BadRequest()
+                .insert_header(cache_control_no_store())
+                .body(format!("Invalid output name: {e}")));
+        }
+    };
+
+    let drv_output = DrvOutput {
+        drv_path,
+        output_name,
+    };
+
+    let mut guard = settings.store.acquire().await?;
+    let realisation = match guard.client().query_realisation(&drv_output).await {
+        Ok(r) => r,
+        Err(e) => {
+            // Daemon may lack the `realisation-with-path-not-hash` feature
+            // (e.g. talking to an older nix-daemon). Treat as not-found so
+            // clients fall back gracefully.
+            tracing::debug!(
+                "Failed to query realisation for {drv_output}: {e} (treating as not found)"
+            );
+            return Ok(HttpResponse::NotFound()
+                .insert_header(cache_control_no_store())
+                .body("realisation not found"));
+        }
+    };
+
+    match realisation {
+        Some(realisation) => Ok(HttpResponse::Ok()
+            .insert_header(cache_control_max_age_1y())
+            .content_type("application/json")
+            .json(realisation)),
+        None => {
+            tracing::debug!("Realisation not found for {drv_output}");
+            Ok(HttpResponse::NotFound()
+                .insert_header(cache_control_no_store())
+                .body("realisation not found"))
+        }
+    }
+}

--- a/harmonia-cache/tests/chroot.rs
+++ b/harmonia-cache/tests/chroot.rs
@@ -227,6 +227,32 @@ real_nix_store = "{}"
         "Expected 'test contents', got '{content}'"
     );
 
+    // Test serve endpoint - HEAD request returns metadata without body
+    // (regression test for https://github.com/nix-community/harmonia/issues/569)
+    let output = Command::new("curl")
+        .args([
+            "--fail",
+            "--head",
+            "--max-time",
+            "5",
+            &format!("http://127.0.0.1:{port}/serve/{dir_hash}/my-file"),
+        ])
+        .output()?;
+
+    assert!(
+        output.status.success(),
+        "HEAD request on /serve file failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let head_response = String::from_utf8(output.stdout)?;
+    let content_len = "test contents".len();
+    assert!(
+        head_response
+            .lines()
+            .any(|l| l.to_ascii_lowercase() == format!("content-length: {content_len}")),
+        "Expected content-length: {content_len} header in HEAD response, got:\n{head_response}"
+    );
+
     // Test that we can fetch narinfo for the file with the virtual path
     println!("Testing narinfo fetch with virtual path...");
 

--- a/harmonia-cache/tests/realisations.rs
+++ b/harmonia-cache/tests/realisations.rs
@@ -1,0 +1,49 @@
+mod daemon;
+
+use daemon::{CanonicalTempDir, Daemon, DaemonConfig, NixDaemon, Result, TestCacheBuilder};
+use std::process::Command;
+
+fn curl_status(url: &str) -> Result<String> {
+    let output = Command::new("curl")
+        .args([
+            "--silent",
+            "--output",
+            "/dev/null",
+            "--write-out",
+            "%{http_code}",
+        ])
+        .arg(url)
+        .output()?;
+    Ok(String::from_utf8(output.stdout)?.trim().to_string())
+}
+
+#[tokio::test]
+async fn test_build_trace_endpoint() -> Result<()> {
+    let temp_dir = CanonicalTempDir::new()?;
+    let store_dir = temp_dir.path().join("store");
+    let state_dir = temp_dir.path().join("var");
+
+    let daemon_config = DaemonConfig {
+        socket_path: temp_dir.path().join("nix-daemon.sock"),
+        store_dir: store_dir.clone(),
+        state_dir: state_dir.clone(),
+    };
+
+    let daemon = NixDaemon::start(daemon_config).await?;
+    let cache = TestCacheBuilder::new().daemon(daemon).build().await?;
+
+    let status = curl_status(&cache.url("/build-trace-v2/not-a-store-path/out.doi"))?;
+    assert_eq!(status, "400", "Expected 400 for invalid drv path");
+
+    let status = curl_status(
+        &cache.url("/build-trace-v2/g1w7hy3qg1w7hy3qg1w7hy3qg1w7hy3q-bar.drv/out%7Bput.doi"),
+    )?;
+    assert_eq!(status, "400", "Expected 400 for invalid output name");
+
+    let status = curl_status(
+        &cache.url("/build-trace-v2/g1w7hy3qg1w7hy3qg1w7hy3qg1w7hy3q-bar.drv/out.doi"),
+    )?;
+    assert_eq!(status, "404", "Expected 404 for non-existent realisation");
+
+    Ok(())
+}

--- a/harmonia-daemon/src/handler.rs
+++ b/harmonia-daemon/src/handler.rs
@@ -20,6 +20,7 @@ use harmonia_protocol::daemon::{
     ResultLog, TrustLevel,
 };
 use harmonia_protocol::valid_path_info::UnkeyedValidPathInfo;
+use harmonia_store_core::realisation::{DrvOutput, UnkeyedRealisation};
 use harmonia_store_core::store_path::{StoreDir, StorePath, StorePathHash};
 use harmonia_store_db::StoreDb;
 use harmonia_utils_hash::{Hash, fmt::Any};
@@ -189,6 +190,55 @@ impl DaemonStore for LocalStoreHandler {
                     .file_name()
                     .and_then(|n| n.to_str())?;
                 StorePath::from_base_path(base_name).ok()
+            }))
+        }
+        .empty_logs()
+    }
+
+    fn query_realisation<'a>(
+        &'a mut self,
+        output_id: &'a DrvOutput,
+    ) -> impl ResultLog<Output = DaemonResult<Option<UnkeyedRealisation>>> + Send + 'a {
+        async move {
+            let drv_path = output_id.drv_path.to_string();
+            let output_name = output_id.output_name.to_string();
+            let db = self.db.clone();
+            let result = tokio::task::spawn_blocking(move || {
+                let db = db.blocking_lock();
+                if !db.has_ca_schema().unwrap_or(false) {
+                    return Ok(None);
+                }
+                db.query_realisation(&drv_path, &output_name)
+            })
+            .await
+            .map_err(|e| ProtocolError::custom(format!("Task join error: {e}")))?
+            .map_err(|e| ProtocolError::custom(format!("Database error: {e}")))?;
+
+            let Some(row) = result else {
+                return Ok(None);
+            };
+
+            let base_name = std::path::Path::new(&row.output_path)
+                .file_name()
+                .and_then(|n| n.to_str())
+                .unwrap_or(&row.output_path);
+            let out_path = StorePath::from_base_path(base_name).map_err(|e| {
+                ProtocolError::custom(format!(
+                    "Invalid output path '{}' in BuildTraceV3: {e}",
+                    row.output_path
+                ))
+            })?;
+            let signatures = row
+                .signatures
+                .as_deref()
+                .unwrap_or("")
+                .split_whitespace()
+                .filter_map(|s| s.parse().ok())
+                .collect();
+
+            Ok(Some(UnkeyedRealisation {
+                out_path,
+                signatures,
             }))
         }
         .empty_logs()

--- a/harmonia-daemon/src/server/mod.rs
+++ b/harmonia-daemon/src/server/mod.rs
@@ -37,16 +37,17 @@ use harmonia_protocol::log::LogMessage;
 use harmonia_protocol::ser::{NixWrite, NixWriter};
 use harmonia_protocol::types::{AddToStoreItem, DaemonPath};
 use harmonia_protocol::valid_path_info::ValidPathInfo;
+use harmonia_protocol::version::{FeatureSet, supported_features};
 use harmonia_store_core::derivation::BasicDerivation;
 use harmonia_store_core::derived_path::{DerivedPath, OutputName};
-use harmonia_store_core::realisation::{DrvOutput, Realisation};
+use harmonia_store_core::realisation::{DrvOutput, Realisation, UnkeyedRealisation};
 use harmonia_store_core::signature::Signature;
 use harmonia_store_core::store_path::{
     ContentAddressMethodAlgorithm, StorePath, StorePathHash, StorePathSet,
 };
 use harmonia_utils_io::{AsyncBufReadCompat, BytesReader};
 
-const PROTOCOL_VERSION: ProtocolVersion = ProtocolVersion::from_parts(1, 37);
+const PROTOCOL_VERSION: ProtocolVersion = ProtocolVersion::from_parts(1, 38);
 const NIX_VERSION: &str = "2.24.0 (Harmonia)";
 
 pub struct RecoverableError {
@@ -518,7 +519,7 @@ where
     fn query_realisation<'a>(
         &'a mut self,
         output_id: &'a DrvOutput,
-    ) -> impl ResultLog<Output = DaemonResult<BTreeSet<Realisation>>> + Send + 'a {
+    ) -> impl ResultLog<Output = DaemonResult<Option<UnkeyedRealisation>>> + Send + 'a {
         let ret = Box::pin(self.0.query_realisation(output_id));
         trace!("QueryRealisation Size {}", size_of_val(ret.deref()));
         ret
@@ -624,9 +625,26 @@ where
         }
         self.reader.set_version(version);
         self.writer.set_version(version);
+
+        // Exchange features (protocol >= 1.38).
+        let mut features = FeatureSet::new();
+        if version.minor() >= 38 {
+            let client_features: FeatureSet =
+                self.reader.read_value().await.with_field("features")?;
+            let local = supported_features();
+            self.writer
+                .write_value(&local)
+                .await
+                .with_field("features")?;
+            self.writer.flush().await?;
+            features = local.intersection(&client_features).cloned().collect();
+        }
+        self.reader.set_features(features.clone());
+        self.writer.set_features(features.clone());
         debug!(
             ?version,
             ?client_version,
+            ?features,
             "Server Version is {}, Client version is {}",
             version,
             client_version
@@ -993,7 +1011,9 @@ where
                 self.writer.write_value(&value).await?;
             }
             AddMultipleToStore(req) => {
-                let builder = NixReader::builder().set_version(self.reader.version());
+                let builder = NixReader::builder()
+                    .set_version(self.reader.version())
+                    .set_features(self.reader.features().clone());
                 let buf_reader = AsyncBufReadCompat::new(&mut self.reader);
                 let mut framed = FramedReader::new(buf_reader);
                 let source = builder.build_buffered(&mut framed);

--- a/harmonia-daemon/src/tests/sqlite_nix_store.rs
+++ b/harmonia-daemon/src/tests/sqlite_nix_store.rs
@@ -185,3 +185,46 @@ async fn test_handler_with_nix_store() {
         "Should return None for non-existent hash part"
     );
 }
+
+/// `query_realisation` against a hand-populated `BuildTraceV3` table.
+#[tokio::test]
+async fn test_handler_query_realisation() {
+    let temp_dir = CanonicalTempDir::new().unwrap();
+    let store_dir = StoreDir::new("/nix/store").unwrap();
+    let db_path = temp_dir.path().join("db.sqlite");
+
+    let drv_base = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-ca.drv";
+    let out_full = "/nix/store/bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb-out";
+    let sig = "cache.nixos.org-1:0CpHca+06TwFp9VkMyz5OaphT3E8mnS+1SWymYlvFaghKSYPCMQ66TS1XPAr1+y9rfQZPLaHrBjjnIRktE/nAA==";
+
+    {
+        let db = StoreDb::open(&db_path, harmonia_store_db::OpenMode::Create).unwrap();
+        db.create_schema().unwrap();
+        db.register_realisation(drv_base, "out", out_full, Some(sig))
+            .unwrap();
+    }
+
+    let handler = LocalStoreHandler::new(store_dir, db_path).await.unwrap();
+    let mut store = handler.handshake().await.unwrap();
+
+    let id = harmonia_store_core::realisation::DrvOutput {
+        drv_path: StorePath::from_base_path(drv_base).unwrap(),
+        output_name: "out".parse().unwrap(),
+    };
+    let r = store.query_realisation(&id).await.unwrap().unwrap();
+    assert_eq!(
+        r.out_path,
+        StorePath::from_base_path("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb-out").unwrap()
+    );
+    assert_eq!(r.signatures.len(), 1);
+    assert_eq!(
+        r.signatures.iter().next().unwrap().name(),
+        "cache.nixos.org-1"
+    );
+
+    let miss = harmonia_store_core::realisation::DrvOutput {
+        drv_path: StorePath::from_base_path(drv_base).unwrap(),
+        output_name: "dev".parse().unwrap(),
+    };
+    assert!(store.query_realisation(&miss).await.unwrap().is_none());
+}

--- a/harmonia-protocol/src/build_result.rs
+++ b/harmonia-protocol/src/build_result.rs
@@ -14,7 +14,7 @@ use crate::de::{Error as _, NixDeserialize as NixDeserializeTrait, NixRead};
 use crate::ser::{NixSerialize as NixSerializeTrait, NixWrite};
 use crate::types::{DaemonInt, DaemonString, DaemonTime};
 use harmonia_store_core::derived_path::OutputName;
-use harmonia_store_core::realisation::Realisation;
+use harmonia_store_core::realisation::UnkeyedRealisation;
 
 /// Success status values for BuildResult.
 ///
@@ -82,7 +82,7 @@ pub struct BuildResultSuccess {
     pub status: SuccessStatus,
     /// For derivations, a mapping from output names to realisations.
     #[serde(default)]
-    pub built_outputs: BTreeMap<OutputName, Realisation>,
+    pub built_outputs: BTreeMap<OutputName, UnkeyedRealisation>,
 }
 
 /// Failed build result data.
@@ -159,7 +159,16 @@ impl NixDeserializeTrait for BuildResult {
         let stop_time: DaemonTime = reader.read_value().await?;
         let cpu_user: Option<Microseconds> = reader.read_value().await?;
         let cpu_system: Option<Microseconds> = reader.read_value().await?;
-        let built_outputs: BTreeMap<OutputName, Realisation> = reader.read_value().await?;
+        let built_outputs: BTreeMap<OutputName, UnkeyedRealisation> =
+            if reader.has_feature(crate::version::FEATURE_REALISATION_WITH_PATH) {
+                reader.read_value().await?
+            } else {
+                // Legacy peers send a StringMap of JSON realisations. We don't
+                // implement the back-compat parsing; just drain the map and
+                // discard, since harmonia never builds.
+                let _ignored: BTreeMap<String, String> = reader.read_value().await?;
+                BTreeMap::new()
+            };
 
         let inner = if let Ok(status) = SuccessStatus::try_from(status_raw) {
             BuildResultInner::Success(BuildResultSuccess {
@@ -199,14 +208,14 @@ impl NixSerializeTrait for BuildResult {
             u16,
             &DaemonString,
             bool,
-            &BTreeMap<OutputName, Realisation>,
+            &BTreeMap<OutputName, UnkeyedRealisation>,
         ) = match &self.inner {
             BuildResultInner::Success(s) => {
                 static EMPTY_STRING: DaemonString = DaemonString::new();
                 (s.status.into(), &EMPTY_STRING, false, &s.built_outputs)
             }
             BuildResultInner::Failure(f) => {
-                static EMPTY_MAP: BTreeMap<OutputName, Realisation> = BTreeMap::new();
+                static EMPTY_MAP: BTreeMap<OutputName, UnkeyedRealisation> = BTreeMap::new();
                 (
                     f.status.into(),
                     &f.error_msg,
@@ -224,9 +233,119 @@ impl NixSerializeTrait for BuildResult {
         writer.write_value(&self.stop_time).await?;
         writer.write_value(&self.cpu_user).await?;
         writer.write_value(&self.cpu_system).await?;
-        writer.write_value(built_outputs).await?;
+        if writer.has_feature(crate::version::FEATURE_REALISATION_WITH_PATH) {
+            writer.write_value(built_outputs).await?;
+        } else {
+            // Legacy peers expect a StringMap of JSON realisations keyed by
+            // `sha256:<hex>!<out>`. The hash modulo no longer exists; old
+            // clients only extract `outputName` and `outPath`, so a dummy hash
+            // suffices.
+            let dummy_hash =
+                "sha256:0000000000000000000000000000000000000000000000000000000000000000";
+            writer.write_value(&built_outputs.len()).await?;
+            for (output_name, realisation) in built_outputs {
+                let id = format!("{dummy_hash}!{output_name}");
+                let json = format!(r#"{{"id":"{id}","outPath":"{}"}}"#, realisation.out_path);
+                writer.write_slice(id.as_bytes()).await?;
+                writer.write_slice(json.as_bytes()).await?;
+            }
+        }
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod arbitrary {
+    use super::*;
+    use proptest::prelude::*;
+
+    impl Arbitrary for SuccessStatus {
+        type Parameters = ();
+        type Strategy = BoxedStrategy<Self>;
+        fn arbitrary_with(_: ()) -> Self::Strategy {
+            use SuccessStatus::*;
+            prop_oneof![
+                Just(Built),
+                Just(Substituted),
+                Just(AlreadyValid),
+                Just(ResolvesToAlreadyValid),
+            ]
+            .boxed()
+        }
+    }
+
+    impl Arbitrary for FailureStatus {
+        type Parameters = ();
+        type Strategy = BoxedStrategy<Self>;
+        fn arbitrary_with(_: ()) -> Self::Strategy {
+            use FailureStatus::*;
+            prop_oneof![
+                Just(PermanentFailure),
+                Just(InputRejected),
+                Just(OutputRejected),
+                Just(TransientFailure),
+                Just(CachedFailure),
+                Just(TimedOut),
+                Just(MiscFailure),
+                Just(DependencyFailed),
+                Just(LogLimitExceeded),
+                Just(NotDeterministic),
+                Just(NoSubstituters),
+            ]
+            .boxed()
+        }
+    }
+
+    impl Arbitrary for BuildResult {
+        type Parameters = ();
+        type Strategy = BoxedStrategy<Self>;
+        fn arbitrary_with(_: ()) -> Self::Strategy {
+            let success = (
+                any::<SuccessStatus>(),
+                proptest::collection::btree_map(
+                    any::<OutputName>(),
+                    any::<UnkeyedRealisation>(),
+                    0..4,
+                ),
+            )
+                .prop_map(|(status, built_outputs)| {
+                    BuildResultInner::Success(BuildResultSuccess {
+                        status,
+                        built_outputs,
+                    })
+                });
+            let failure = (any::<FailureStatus>(), any::<Vec<u8>>(), any::<bool>()).prop_map(
+                |(status, error_msg, is_non_deterministic)| {
+                    BuildResultInner::Failure(BuildResultFailure {
+                        status,
+                        error_msg: error_msg.into(),
+                        is_non_deterministic,
+                    })
+                },
+            );
+            (
+                prop_oneof![success, failure],
+                any::<DaemonInt>(),
+                any::<DaemonTime>(),
+                any::<DaemonTime>(),
+                any::<Option<Microseconds>>(),
+                any::<Option<Microseconds>>(),
+            )
+                .prop_map(
+                    |(inner, times_built, start_time, stop_time, cpu_user, cpu_system)| {
+                        BuildResult {
+                            inner,
+                            times_built,
+                            start_time,
+                            stop_time,
+                            cpu_user,
+                            cpu_system,
+                        }
+                    },
+                )
+                .boxed()
+        }
     }
 }
 
@@ -320,5 +439,70 @@ impl<'de> Deserialize<'de> for BuildResultInner {
                 .map(BuildResultInner::Failure)
                 .map_err(D::Error::custom)
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Cursor;
+
+    use tokio::io::AsyncWriteExt as _;
+
+    use super::*;
+    use crate::de::{NixRead, NixReader};
+    use crate::ser::{NixWrite, NixWriter};
+
+    fn sample_success() -> BuildResult {
+        BuildResult {
+            inner: BuildResultInner::Success(BuildResultSuccess {
+                status: SuccessStatus::Built,
+                built_outputs: [(
+                    "out".parse().unwrap(),
+                    UnkeyedRealisation {
+                        out_path: "g1w7hy3qg1w7hy3qg1w7hy3qg1w7hy3q-foo".parse().unwrap(),
+                        signatures: Default::default(),
+                    },
+                )]
+                .into(),
+            }),
+            times_built: 1,
+            start_time: 30,
+            stop_time: 50,
+            cpu_user: Some(500.into()),
+            cpu_system: Some(604.into()),
+        }
+    }
+
+    async fn write(features: crate::version::FeatureSet, v: &BuildResult) -> Vec<u8> {
+        let mut buf = Vec::new();
+        let mut w = NixWriter::builder().set_features(features).build(&mut buf);
+        w.write_value(v).await.unwrap();
+        w.flush().await.unwrap();
+        drop(w);
+        buf
+    }
+
+    async fn read(features: crate::version::FeatureSet, buf: Vec<u8>) -> BuildResult {
+        let mut r = NixReader::builder()
+            .set_features(features)
+            .build_buffered(Cursor::new(buf));
+        r.read_value().await.unwrap()
+    }
+
+    /// Without the feature, the writer must emit the legacy StringMap form
+    /// (so an old peer keeps decoding), and our reader must be able to drain
+    /// it without desyncing the stream — built_outputs are simply dropped.
+    #[tokio::test]
+    async fn wire_roundtrip_without_feature_degrades_gracefully() {
+        let v = sample_success();
+        let buf = write(Default::default(), &v).await;
+        assert!(buf.windows(4).any(|w| w == b"!out"));
+        let back = read(Default::default(), buf).await;
+        let BuildResultInner::Success(s) = &back.inner else {
+            panic!("expected success")
+        };
+        assert!(s.built_outputs.is_empty());
+        assert_eq!(back.times_built, v.times_built);
+        assert_eq!(back.start_time, v.start_time);
     }
 }

--- a/harmonia-protocol/src/daemon_wire/types2.rs
+++ b/harmonia-protocol/src/daemon_wire/types2.rs
@@ -418,8 +418,6 @@ pub struct QueryMissingResult {
     pub nar_size: u64,
 }
 
-pub type QueryRealisationResponse = Vec<Realisation>;
-
 #[derive(Debug, Clone, PartialEq, Eq, Hash, NixDeserialize, NixSerialize)]
 pub struct AddMultipleToStoreRequest {
     pub repair: bool,

--- a/harmonia-protocol/src/de/mock.rs
+++ b/harmonia-protocol/src/de/mock.rs
@@ -7,6 +7,7 @@ use bytes::Bytes;
 use thiserror::Error;
 
 use crate::ProtocolVersion;
+use crate::version::FeatureSet;
 use harmonia_store_core::store_path::StoreDir;
 
 use super::NixRead;
@@ -85,6 +86,7 @@ impl From<Operation> for OperationType {
 
 pub struct Builder {
     version: ProtocolVersion,
+    features: FeatureSet,
     store_dir: StoreDir,
     ops: VecDeque<Operation>,
 }
@@ -93,6 +95,7 @@ impl Builder {
     pub fn new() -> Builder {
         Builder {
             version: Default::default(),
+            features: crate::version::supported_features(),
             store_dir: Default::default(),
             ops: VecDeque::new(),
         }
@@ -137,6 +140,7 @@ impl Builder {
     pub fn build(&mut self) -> Mock {
         Mock {
             version: self.version,
+            features: self.features.clone(),
             store_dir: self.store_dir.clone(),
             ops: self.ops.clone(),
         }
@@ -151,6 +155,7 @@ impl Default for Builder {
 
 pub struct Mock {
     version: ProtocolVersion,
+    features: FeatureSet,
     store_dir: StoreDir,
     ops: VecDeque<Operation>,
 }
@@ -164,6 +169,10 @@ impl NixRead for Mock {
 
     fn store_dir(&self) -> &StoreDir {
         &self.store_dir
+    }
+
+    fn features(&self) -> &FeatureSet {
+        &self.features
     }
 
     async fn try_read_number(&mut self) -> Result<Option<u64>, Self::Error> {

--- a/harmonia-protocol/src/de/mod.rs
+++ b/harmonia-protocol/src/de/mod.rs
@@ -6,6 +6,7 @@ use std::{fmt, io};
 use ::bytes::Bytes;
 
 use super::ProtocolVersion;
+use crate::version::FeatureSet;
 use harmonia_store_core::store_path::StoreDir;
 
 mod bytes;
@@ -67,6 +68,12 @@ pub trait NixRead: Send {
     /// of the protocol and so this can be used for implementing that.
     fn version(&self) -> ProtocolVersion;
     fn store_dir(&self) -> &StoreDir;
+
+    /// Negotiated worker-protocol feature set (>= 1.38).
+    fn features(&self) -> &FeatureSet;
+    fn has_feature(&self, feature: &str) -> bool {
+        self.features().contains(feature)
+    }
 
     /// Read a single u64 from the protocol.
     /// This returns an Option to support gracefull shutdown.
@@ -157,6 +164,10 @@ impl<T: ?Sized + NixRead> NixRead for &mut T {
 
     fn store_dir(&self) -> &StoreDir {
         (**self).store_dir()
+    }
+
+    fn features(&self) -> &FeatureSet {
+        (**self).features()
     }
 
     fn try_read_number(

--- a/harmonia-protocol/src/de/reader.rs
+++ b/harmonia-protocol/src/de/reader.rs
@@ -10,6 +10,7 @@ use pin_project_lite::pin_project;
 use tokio::io::{AsyncRead, ReadBuf};
 
 use crate::ProtocolVersion;
+use crate::version::FeatureSet;
 use harmonia_store_core::store_path::StoreDir;
 use harmonia_utils_io::{
     AsyncBytesRead, BytesReader, DEFAULT_MAX_BUF_SIZE, DEFAULT_RESERVED_BUF_SIZE,
@@ -22,6 +23,7 @@ pub struct NixReaderBuilder {
     reserved_buf_size: usize,
     max_buf_size: usize,
     version: ProtocolVersion,
+    features: FeatureSet,
     store_dir: StoreDir,
 }
 
@@ -31,6 +33,7 @@ impl Default for NixReaderBuilder {
             reserved_buf_size: DEFAULT_RESERVED_BUF_SIZE,
             max_buf_size: DEFAULT_MAX_BUF_SIZE,
             version: Default::default(),
+            features: Default::default(),
             store_dir: Default::default(),
         }
     }
@@ -52,6 +55,11 @@ impl NixReaderBuilder {
         self
     }
 
+    pub fn set_features(mut self, features: FeatureSet) -> Self {
+        self.features = features;
+        self
+    }
+
     pub fn set_store_dir(mut self, store_dir: &StoreDir) -> Self {
         self.store_dir = store_dir.clone();
         self
@@ -66,6 +74,7 @@ impl NixReaderBuilder {
             reserved_buf_size: self.reserved_buf_size,
             max_buf_size: self.max_buf_size,
             version: self.version,
+            features: self.features,
             store_dir: self.store_dir,
         }
     }
@@ -90,6 +99,7 @@ pin_project! {
         reserved_buf_size: usize,
         max_buf_size: usize,
         version: ProtocolVersion,
+        features: FeatureSet,
         store_dir: StoreDir,
     }
 }
@@ -112,6 +122,18 @@ where
 impl<R> NixReader<R> {
     pub fn set_version(&mut self, version: ProtocolVersion) {
         self.version = version;
+    }
+
+    pub fn set_features(&mut self, features: FeatureSet) {
+        self.features = features;
+    }
+
+    pub fn features(&self) -> &FeatureSet {
+        &self.features
+    }
+
+    pub fn version(&self) -> ProtocolVersion {
+        self.version
     }
 
     pub fn get_ref(&self) -> &R {
@@ -145,6 +167,10 @@ where
 
     fn store_dir(&self) -> &StoreDir {
         &self.store_dir
+    }
+
+    fn features(&self) -> &FeatureSet {
+        &self.features
     }
 
     async fn try_read_number(&mut self) -> Result<Option<u64>, Self::Error> {

--- a/harmonia-protocol/src/lib.rs
+++ b/harmonia-protocol/src/lib.rs
@@ -39,13 +39,18 @@ pub mod version;
 
 pub use nar_hash::NarHash;
 
-pub use version::ProtocolVersion;
+pub use version::{
+    FEATURE_REALISATION_WITH_PATH, Feature, FeatureSet, ProtocolVersion, supported_features,
+};
 
 // Re-exports required by derive macros (harmonia_protocol_derive generates code using crate::store_path, etc.)
 pub use harmonia_store_core::store_path;
 
 // Hand-written serialization impls for harmonia-store-core types
 mod store_impls;
+
+#[cfg(test)]
+mod wire_roundtrip;
 
 // Re-export structure for code that references harmonia_protocol::daemon::...
 pub mod daemon {

--- a/harmonia-protocol/src/ser/mock.rs
+++ b/harmonia-protocol/src/ser/mock.rs
@@ -8,6 +8,7 @@ use ::proptest::prelude::TestCaseError;
 use thiserror::Error;
 
 use crate::ProtocolVersion;
+use crate::version::FeatureSet;
 use harmonia_store_core::store_path::StoreDir;
 
 use super::NixWrite;
@@ -106,6 +107,7 @@ impl From<Operation> for OperationType {
 
 pub struct Builder {
     version: ProtocolVersion,
+    features: FeatureSet,
     store_dir: StoreDir,
     ops: VecDeque<Operation>,
 }
@@ -114,6 +116,7 @@ impl Builder {
     pub fn new() -> Builder {
         Builder {
             version: Default::default(),
+            features: crate::version::supported_features(),
             store_dir: Default::default(),
             ops: VecDeque::new(),
         }
@@ -121,6 +124,11 @@ impl Builder {
 
     pub fn version<V: Into<ProtocolVersion>>(&mut self, version: V) -> &mut Self {
         self.version = version.into();
+        self
+    }
+
+    pub fn features(&mut self, features: FeatureSet) -> &mut Self {
+        self.features = features;
         self
     }
 
@@ -225,6 +233,7 @@ impl Builder {
     pub fn build(&mut self) -> Mock {
         Mock {
             version: self.version,
+            features: self.features.clone(),
             store_dir: self.store_dir.clone(),
             ops: self.ops.clone(),
         }
@@ -239,6 +248,7 @@ impl Default for Builder {
 
 pub struct Mock {
     version: ProtocolVersion,
+    features: FeatureSet,
     store_dir: StoreDir,
     ops: VecDeque<Operation>,
 }
@@ -312,6 +322,10 @@ impl NixWrite for Mock {
 
     fn store_dir(&self) -> &StoreDir {
         &self.store_dir
+    }
+
+    fn features(&self) -> &FeatureSet {
+        &self.features
     }
 
     async fn write_number(&mut self, value: u64) -> Result<(), Self::Error> {

--- a/harmonia-protocol/src/ser/mod.rs
+++ b/harmonia-protocol/src/ser/mod.rs
@@ -3,6 +3,7 @@ use std::future::Future;
 use std::{fmt, io};
 
 use super::ProtocolVersion;
+use crate::version::FeatureSet;
 use harmonia_store_core::store_path::StoreDir;
 
 mod bytes;
@@ -57,6 +58,12 @@ pub trait NixWrite: Send {
     fn version(&self) -> ProtocolVersion;
     fn store_dir(&self) -> &StoreDir;
 
+    /// Negotiated worker-protocol feature set (>= 1.38).
+    fn features(&self) -> &FeatureSet;
+    fn has_feature(&self, feature: &str) -> bool {
+        self.features().contains(feature)
+    }
+
     fn write_number(&mut self, value: u64) -> impl Future<Output = Result<(), Self::Error>> + Send;
     fn write_slice(&mut self, buf: &[u8]) -> impl Future<Output = Result<(), Self::Error>> + Send;
     fn write_display<D>(&mut self, msg: D) -> impl Future<Output = Result<(), Self::Error>> + Send
@@ -90,6 +97,10 @@ impl<T: NixWrite> NixWrite for &mut T {
 
     fn store_dir(&self) -> &StoreDir {
         (**self).store_dir()
+    }
+
+    fn features(&self) -> &FeatureSet {
+        (**self).features()
     }
 
     fn write_number(&mut self, value: u64) -> impl Future<Output = Result<(), Self::Error>> + Send {

--- a/harmonia-protocol/src/ser/writer.rs
+++ b/harmonia-protocol/src/ser/writer.rs
@@ -12,6 +12,7 @@ use pin_project_lite::pin_project;
 use tokio::io::{AsyncWrite, AsyncWriteExt};
 
 use crate::ProtocolVersion;
+use crate::version::FeatureSet;
 use harmonia_store_core::store_path::StoreDir;
 use harmonia_utils_io::wire::{ZEROS, calc_padding};
 use harmonia_utils_io::{DEFAULT_BUF_SIZE, RESERVED_BUF_SIZE};
@@ -24,6 +25,7 @@ pub struct NixWriterBuilder {
     display_buf_size: usize,
     initial_buf_size: usize,
     version: ProtocolVersion,
+    features: FeatureSet,
     store_dir: StoreDir,
 }
 
@@ -35,6 +37,7 @@ impl Default for NixWriterBuilder {
             display_buf_size: 8192,
             initial_buf_size: DEFAULT_BUF_SIZE,
             version: Default::default(),
+            features: Default::default(),
             store_dir: Default::default(),
         }
     }
@@ -74,6 +77,11 @@ impl NixWriterBuilder {
         self
     }
 
+    pub fn set_features(mut self, features: FeatureSet) -> Self {
+        self.features = features;
+        self
+    }
+
     pub fn set_store_dir(mut self, store_dir: &StoreDir) -> Self {
         self.store_dir = store_dir.clone();
         self
@@ -91,6 +99,7 @@ impl NixWriterBuilder {
             reserved_buf_size: self.reserved_buf_size,
             max_buf_size: self.initial_buf_size,
             version: self.version,
+            features: self.features,
             store_dir: self.store_dir,
         }
     }
@@ -106,6 +115,7 @@ pin_project! {
         reserved_buf_size: usize,
         max_buf_size: usize,
         version: ProtocolVersion,
+        features: FeatureSet,
         store_dir: StoreDir,
     }
 }
@@ -130,6 +140,18 @@ where
 
     pub fn set_version(&mut self, version: ProtocolVersion) {
         self.version = version;
+    }
+
+    pub fn set_features(&mut self, features: FeatureSet) {
+        self.features = features;
+    }
+
+    pub fn features(&self) -> &FeatureSet {
+        &self.features
+    }
+
+    pub fn version(&self) -> ProtocolVersion {
+        self.version
     }
 
     /// Remaining capacity in internal buffer
@@ -299,6 +321,10 @@ where
 
     fn store_dir(&self) -> &StoreDir {
         &self.store_dir
+    }
+
+    fn features(&self) -> &FeatureSet {
+        &self.features
     }
 
     async fn write_number(&mut self, value: u64) -> Result<(), Self::Error> {

--- a/harmonia-protocol/src/store_impls.rs
+++ b/harmonia-protocol/src/store_impls.rs
@@ -19,7 +19,7 @@ use crate::ser::{NixSerialize, NixWrite};
 use harmonia_protocol_derive::{nix_deserialize_remote, nix_serialize_remote};
 use harmonia_store_core::derivation::{BasicDerivation, DerivationOutput};
 use harmonia_store_core::derived_path::{DerivedPath, LegacyDerivedPath, OutputName};
-use harmonia_store_core::realisation::Realisation;
+use harmonia_store_core::realisation::{DrvOutput, Realisation, UnkeyedRealisation};
 use harmonia_store_core::store_path::{
     ContentAddress, ContentAddressMethodAlgorithm, StorePath, StorePathName,
 };
@@ -337,16 +337,100 @@ impl NixDeserialize for ActivityResult {
     }
 }
 
-// ========== Realisation ==========
+// ========== Realisation / DrvOutput ==========
+//
+// Wire format requires the `realisation-with-path-not-hash` feature.
+// Harmonia only advertises/accepts the new format; if the peer did not
+// negotiate the feature these serializers fail explicitly so the protocol
+// doesn't get desynced.
+
+fn require_realisation_feature_ser<W: NixWrite>(writer: &W) -> Result<(), W::Error> {
+    use crate::ser::Error;
+    if writer.has_feature(crate::version::FEATURE_REALISATION_WITH_PATH) {
+        Ok(())
+    } else {
+        Err(W::Error::unsupported_data(format_args!(
+            "peer is missing the '{}' protocol feature, needed to support content-addressing derivations",
+            crate::version::FEATURE_REALISATION_WITH_PATH
+        )))
+    }
+}
+
+fn require_realisation_feature_de<R: ?Sized + NixRead>(reader: &R) -> Result<(), R::Error> {
+    use crate::de::Error;
+    if reader.has_feature(crate::version::FEATURE_REALISATION_WITH_PATH) {
+        Ok(())
+    } else {
+        Err(R::Error::invalid_data(format_args!(
+            "peer is missing the '{}' protocol feature, needed to support content-addressing derivations",
+            crate::version::FEATURE_REALISATION_WITH_PATH
+        )))
+    }
+}
+
+impl NixSerialize for DrvOutput {
+    async fn serialize<W>(&self, writer: &mut W) -> Result<(), W::Error>
+    where
+        W: NixWrite,
+    {
+        require_realisation_feature_ser(writer)?;
+        writer.write_value(&self.drv_path).await?;
+        writer.write_value(&self.output_name).await
+    }
+}
+
+impl NixDeserialize for DrvOutput {
+    async fn try_deserialize<R>(reader: &mut R) -> Result<Option<Self>, R::Error>
+    where
+        R: ?Sized + NixRead + Send,
+    {
+        let Some(drv_path) = reader.try_read_value::<StorePath>().await? else {
+            return Ok(None);
+        };
+        require_realisation_feature_de(reader)?;
+        let output_name = reader.read_value().await?;
+        Ok(Some(DrvOutput {
+            drv_path,
+            output_name,
+        }))
+    }
+}
+
+impl NixSerialize for UnkeyedRealisation {
+    async fn serialize<W>(&self, writer: &mut W) -> Result<(), W::Error>
+    where
+        W: NixWrite,
+    {
+        require_realisation_feature_ser(writer)?;
+        writer.write_value(&self.out_path).await?;
+        writer.write_value(&self.signatures).await
+    }
+}
+
+impl NixDeserialize for UnkeyedRealisation {
+    async fn try_deserialize<R>(reader: &mut R) -> Result<Option<Self>, R::Error>
+    where
+        R: ?Sized + NixRead + Send,
+    {
+        let Some(out_path) = reader.try_read_value::<StorePath>().await? else {
+            return Ok(None);
+        };
+        require_realisation_feature_de(reader)?;
+        let signatures = reader.read_value().await?;
+        Ok(Some(UnkeyedRealisation {
+            out_path,
+            signatures,
+        }))
+    }
+}
 
 impl NixSerialize for Realisation {
     async fn serialize<W>(&self, writer: &mut W) -> Result<(), W::Error>
     where
         W: NixWrite,
     {
-        use crate::ser::Error;
-        let s = serde_json::to_string(&self).map_err(W::Error::custom)?;
-        writer.write_slice(s.as_bytes()).await
+        writer.write_value(&self.id).await?;
+        writer.write_value(&self.value).await
     }
 }
 
@@ -355,13 +439,46 @@ impl NixDeserialize for Realisation {
     where
         R: ?Sized + NixRead + Send,
     {
+        let Some(id) = reader.try_read_value::<DrvOutput>().await? else {
+            return Ok(None);
+        };
+        let value = reader.read_value().await?;
+        Ok(Some(Realisation { id, value }))
+    }
+}
+
+/// `Option<UnkeyedRealisation>` uses a 0/1 tag word like upstream's
+/// `WorkerProto::Serialise<std::optional<UnkeyedRealisation>>`.
+impl NixSerialize for Option<UnkeyedRealisation> {
+    async fn serialize<W>(&self, writer: &mut W) -> Result<(), W::Error>
+    where
+        W: NixWrite,
+    {
+        match self {
+            None => writer.write_number(0).await,
+            Some(v) => {
+                writer.write_number(1).await?;
+                writer.write_value(v).await
+            }
+        }
+    }
+}
+
+impl NixDeserialize for Option<UnkeyedRealisation> {
+    async fn try_deserialize<R>(reader: &mut R) -> Result<Option<Self>, R::Error>
+    where
+        R: ?Sized + NixRead + Send,
+    {
         use crate::de::Error;
-        if let Some(buf) = reader.try_read_bytes().await? {
-            Ok(Some(
-                serde_json::from_slice(&buf).map_err(R::Error::custom)?,
-            ))
-        } else {
-            Ok(None)
+        let Some(tag) = reader.try_read_number().await? else {
+            return Ok(None);
+        };
+        match tag {
+            0 => Ok(Some(None)),
+            1 => Ok(Some(Some(reader.read_value().await?))),
+            _ => Err(R::Error::invalid_data(
+                "invalid optional build trace from remote",
+            )),
         }
     }
 }
@@ -576,16 +693,6 @@ nix_serialize_remote!(
     harmonia_store_core::store_path::StorePathHash
 );
 
-// DrvOutput
-nix_deserialize_remote!(
-    #[nix(from_str)]
-    harmonia_store_core::realisation::DrvOutput
-);
-nix_serialize_remote!(
-    #[nix(display)]
-    harmonia_store_core::realisation::DrvOutput
-);
-
 // StoreDir - uses the store_dir from the NixRead/NixWrite context
 impl crate::de::NixDeserialize for harmonia_store_core::store_path::StoreDir {
     async fn try_deserialize<R>(reader: &mut R) -> Result<Option<Self>, R::Error>
@@ -605,77 +712,49 @@ impl crate::ser::NixSerialize for harmonia_store_core::store_path::StoreDir {
 
 #[cfg(test)]
 mod tests {
-
-    use crate::de::NixRead;
     use crate::ser::NixWrite;
-    use harmonia_store_core::realisation::Realisation;
-    use rstest::rstest;
-    use std::collections::BTreeMap;
+    use harmonia_store_core::realisation::{DrvOutput, Realisation, UnkeyedRealisation};
 
-    macro_rules! set {
-        () => { std::collections::BTreeSet::new() };
-        ($($x:expr),+ $(,)?) => {{
-            let mut ret = std::collections::BTreeSet::new();
-            $(
-                ret.insert($x.parse().unwrap());
-            )+
-            ret
-        }};
-    }
-
-    macro_rules! btree_map {
-        () => { BTreeMap::new() };
-        ($($k:expr => $v:expr),+ $(,)?) => {{
-            let mut ret = BTreeMap::new();
-            $(
-                ret.insert($k.parse().unwrap(), $v.parse().unwrap());
-            )+
-            ret
-        }};
-    }
-
-    #[tokio::test]
-    #[rstest]
-    #[case(
+    fn sample_realisation() -> Realisation {
         Realisation {
-            id: "sha256:ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad!out".parse().unwrap(),
-            out_path: "7h7qgvs4kgzsn8a6rb273saxyqh4jxlz-konsole-18.12.3".parse().unwrap(),
-            signatures: set!["cache.nixos.org-1:0CpHca+06TwFp9VkMyz5OaphT3E8mnS+1SWymYlvFaghKSYPCMQ66TS1XPAr1+y9rfQZPLaHrBjjnIRktE/nAA=="],
-            dependent_realisations: btree_map![
-                "sha256:ba7816bf8f01cfea414140de5dae2223b00361a496177a9cf410ff61f20015ad!dev" => "7h7qgvs4kgzsn8a6rb273saxyqh4jxlz-konsole-18.12.3-dev",
-                "sha256:ba7816bf8f01cfea414140de5dae2223b00361a696177a9cf410ff61f20015ad!bin" => "7h7qgvs4kgzsn8a6rb273saxyqh4jxlz-konsole-18.12.3-bin",
+            id: DrvOutput {
+                drv_path: "g1w7hy3qg1w7hy3qg1w7hy3qg1w7hy3q-bar.drv".parse().unwrap(),
+                output_name: "out".parse().unwrap(),
+            },
+            value: UnkeyedRealisation {
+                out_path: "7h7qgvs4kgzsn8a6rb273saxyqh4jxlz-konsole-18.12.3"
+                    .parse()
+                    .unwrap(),
+                signatures: ["cache.nixos.org-1:0CpHca+06TwFp9VkMyz5OaphT3E8mnS+1SWymYlvFaghKSYPCMQ66TS1XPAr1+y9rfQZPLaHrBjjnIRktE/nAA==".parse().unwrap()].into(),
+            },
+        }
+    }
 
-            ],
-        },
-        "{\"id\":\"sha256:ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad!out\",\"outPath\":\"7h7qgvs4kgzsn8a6rb273saxyqh4jxlz-konsole-18.12.3\",\"signatures\":[\"cache.nixos.org-1:0CpHca+06TwFp9VkMyz5OaphT3E8mnS+1SWymYlvFaghKSYPCMQ66TS1XPAr1+y9rfQZPLaHrBjjnIRktE/nAA==\"],\"dependentRealisations\":{\"sha256:ba7816bf8f01cfea414140de5dae2223b00361a496177a9cf410ff61f20015ad!dev\":\"7h7qgvs4kgzsn8a6rb273saxyqh4jxlz-konsole-18.12.3-dev\",\"sha256:ba7816bf8f01cfea414140de5dae2223b00361a696177a9cf410ff61f20015ad!bin\":\"7h7qgvs4kgzsn8a6rb273saxyqh4jxlz-konsole-18.12.3-bin\"}}",
-    )]
-    async fn nix_write_realisation(#[case] value: Realisation, #[case] expected: &str) {
+    /// Pins the exact wire bytes for interop with upstream Nix; the
+    /// `wire_roundtrip` proptests only check self-consistency.
+    #[tokio::test]
+    async fn nix_write_realisation() {
+        let value = sample_realisation();
         let mut mock = crate::ser::mock::Builder::new()
-            .write_slice(expected.as_bytes())
+            .write_display("/nix/store/g1w7hy3qg1w7hy3qg1w7hy3qg1w7hy3q-bar.drv")
+            .write_display("out")
+            .write_display("/nix/store/7h7qgvs4kgzsn8a6rb273saxyqh4jxlz-konsole-18.12.3")
+            .write_number(1)
+            .write_display("cache.nixos.org-1:0CpHca+06TwFp9VkMyz5OaphT3E8mnS+1SWymYlvFaghKSYPCMQ66TS1XPAr1+y9rfQZPLaHrBjjnIRktE/nAA==")
             .build();
         mock.write_value(&value).await.unwrap();
     }
 
     #[tokio::test]
-    #[rstest]
-    #[case(
-        Realisation {
-            id: "sha256:ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad!out".parse().unwrap(),
-            out_path: "7h7qgvs4kgzsn8a6rb273saxyqh4jxlz-konsole-18.12.3".parse().unwrap(),
-            signatures: set!["cache.nixos.org-1:0CpHca+06TwFp9VkMyz5OaphT3E8mnS+1SWymYlvFaghKSYPCMQ66TS1XPAr1+y9rfQZPLaHrBjjnIRktE/nAA=="],
-            dependent_realisations: btree_map![
-                "sha256:ba7816bf8f01cfea414140de5dae2223b00361a496177a9cf410ff61f20015ad!dev" => "7h7qgvs4kgzsn8a6rb273saxyqh4jxlz-konsole-18.12.3-dev",
-                "sha256:ba7816bf8f01cfea414140de5dae2223b00361a696177a9cf410ff61f20015ad!bin" => "7h7qgvs4kgzsn8a6rb273saxyqh4jxlz-konsole-18.12.3-bin",
-
-            ],
-        },
-        "{\"id\":\"sha256:ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad!out\",\"outPath\":\"7h7qgvs4kgzsn8a6rb273saxyqh4jxlz-konsole-18.12.3\",\"signatures\":[\"cache.nixos.org-1:0CpHca+06TwFp9VkMyz5OaphT3E8mnS+1SWymYlvFaghKSYPCMQ66TS1XPAr1+y9rfQZPLaHrBjjnIRktE/nAA==\"],\"dependentRealisations\":{\"sha256:ba7816bf8f01cfea414140de5dae2223b00361a496177a9cf410ff61f20015ad!dev\":\"7h7qgvs4kgzsn8a6rb273saxyqh4jxlz-konsole-18.12.3-dev\",\"sha256:ba7816bf8f01cfea414140de5dae2223b00361a696177a9cf410ff61f20015ad!bin\":\"7h7qgvs4kgzsn8a6rb273saxyqh4jxlz-konsole-18.12.3-bin\"}}",
-    )]
-    async fn nix_read_realisation(#[case] expected: Realisation, #[case] value: &str) {
-        let mut mock = crate::de::mock::Builder::new()
-            .read_slice(value.as_bytes())
+    async fn nix_write_drv_output_missing_feature() {
+        let value = sample_realisation().id;
+        let mut mock = crate::ser::mock::Builder::new()
+            .features(Default::default())
             .build();
-        let actual: Realisation = mock.read_value().await.unwrap();
-        assert_eq!(actual, expected);
+        let err = mock.write_value(&value).await.unwrap_err();
+        assert!(
+            err.to_string()
+                .contains(crate::version::FEATURE_REALISATION_WITH_PATH)
+        );
     }
 }

--- a/harmonia-protocol/src/types.rs
+++ b/harmonia-protocol/src/types.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::BTreeMap;
 use std::fmt;
 use std::future::{Future, ready};
 use std::pin::Pin;
@@ -22,7 +22,7 @@ use crate::valid_path_info::{UnkeyedValidPathInfo, ValidPathInfo};
 use harmonia_protocol_derive::{NixDeserialize, NixSerialize};
 use harmonia_store_core::derivation::BasicDerivation;
 use harmonia_store_core::derived_path::{DerivedPath, OutputName};
-use harmonia_store_core::realisation::{DrvOutput, Realisation};
+use harmonia_store_core::realisation::{DrvOutput, Realisation, UnkeyedRealisation};
 use harmonia_store_core::signature::Signature;
 use harmonia_store_core::store_path::{
     ContentAddressMethodAlgorithm, StorePath, StorePathHash, StorePathSet,
@@ -538,7 +538,7 @@ pub trait DaemonStore: Send {
     fn query_realisation<'a>(
         &'a mut self,
         output_id: &'a DrvOutput,
-    ) -> impl ResultLog<Output = DaemonResult<BTreeSet<Realisation>>> + Send + 'a {
+    ) -> impl ResultLog<Output = DaemonResult<Option<UnkeyedRealisation>>> + Send + 'a {
         ready(Err(DaemonError::unimplemented(Operation::QueryRealisation))).empty_logs()
     }
 
@@ -801,7 +801,7 @@ where
     fn query_realisation<'a>(
         &'a mut self,
         output_id: &'a DrvOutput,
-    ) -> impl ResultLog<Output = DaemonResult<BTreeSet<Realisation>>> + Send + 'a {
+    ) -> impl ResultLog<Output = DaemonResult<Option<UnkeyedRealisation>>> + Send + 'a {
         (**self).query_realisation(output_id)
     }
 

--- a/harmonia-protocol/src/valid_path_info.rs
+++ b/harmonia-protocol/src/valid_path_info.rs
@@ -57,6 +57,35 @@ fn is_empty_signatures(set: &Cow<'_, BTreeSet<Signature>>) -> bool {
     set.is_empty()
 }
 
+/// path-info JSON v2 keeps signatures as `name:base64` strings; the default
+/// `Signature` serde impl now emits the structured `{keyName, sig}` form, so
+/// we override it here.
+mod sig_strings {
+    use super::*;
+    use serde::ser::SerializeSeq;
+
+    #[expect(clippy::ptr_arg, reason = "needed for serde with")]
+    pub fn serialize<S>(set: &Cow<'_, BTreeSet<Signature>>, s: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut seq = s.serialize_seq(Some(set.len()))?;
+        for sig in set.iter() {
+            seq.serialize_element(&sig.to_string())?;
+        }
+        seq.end()
+    }
+
+    pub fn deserialize<'de, D>(d: D) -> Result<Cow<'static, BTreeSet<Signature>>, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        // `Signature`'s Deserialize already accepts both string and object form.
+        let set = BTreeSet::<Signature>::deserialize(d)?;
+        Ok(Cow::Owned(set))
+    }
+}
+
 /// Pure format: omits default impure fields during serialization
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -69,7 +98,7 @@ struct RawUnkeyedValidPathInfoPure<'a> {
     references: Cow<'a, BTreeSet<StorePath>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     registration_time: Option<DaemonTime>,
-    #[serde(skip_serializing_if = "is_empty_signatures")]
+    #[serde(skip_serializing_if = "is_empty_signatures", with = "sig_strings")]
     signatures: Cow<'a, BTreeSet<Signature>>,
     store_dir: Cow<'a, StoreDir>,
     #[serde(skip_serializing_if = "is_false")]
@@ -98,7 +127,7 @@ struct RawUnkeyedValidPathInfo<'a> {
     references: Cow<'a, BTreeSet<StorePath>>,
     #[serde(default)]
     registration_time: Option<DaemonTime>,
-    #[serde(default = "default_cow_set")]
+    #[serde(default = "default_cow_set", with = "sig_strings")]
     signatures: Cow<'a, BTreeSet<Signature>>,
     #[serde(default = "default_cow_store_dir")]
     store_dir: Cow<'a, StoreDir>,

--- a/harmonia-protocol/src/version.rs
+++ b/harmonia-protocol/src/version.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeSet;
 use std::{
     fmt,
     ops::{
@@ -13,9 +14,26 @@ use harmonia_protocol_derive::{NixDeserialize, NixSerialize};
 pub const NIX_VERSION: &str = "Harmonia 2.1.0";
 const PROTOCOL_VERSION_MAJOR: u8 = 1;
 pub const PROTOCOL_VERSION: ProtocolVersion =
-    ProtocolVersion::from_parts(PROTOCOL_VERSION_MAJOR, 37);
+    ProtocolVersion::from_parts(PROTOCOL_VERSION_MAJOR, 38);
 pub const PROTOCOL_VERSION_MIN: ProtocolVersion =
     ProtocolVersion::from_parts(PROTOCOL_VERSION_MAJOR, 37);
+
+/// A worker-protocol feature flag.
+///
+/// Since protocol 1.38 the version number is augmented with a set of feature
+/// strings exchanged during the handshake. The negotiated feature set is the
+/// intersection of the client's and server's advertised features.
+pub type Feature = String;
+pub type FeatureSet = BTreeSet<Feature>;
+
+/// `DrvOutput`/`UnkeyedRealisation` are transmitted as raw store-path fields
+/// instead of the legacy `sha256:<hex>!out` JSON-string format.
+pub const FEATURE_REALISATION_WITH_PATH: &str = "realisation-with-path-not-hash";
+
+/// Features harmonia advertises during handshake.
+pub fn supported_features() -> FeatureSet {
+    [FEATURE_REALISATION_WITH_PATH.to_owned()].into()
+}
 
 #[derive(
     Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, NixDeserialize, NixSerialize,

--- a/harmonia-protocol/src/wire_roundtrip.rs
+++ b/harmonia-protocol/src/wire_roundtrip.rs
@@ -1,0 +1,74 @@
+//! Property-based roundtrip tests for the worker-protocol wire serializers.
+//!
+//! Many types in this crate already derive `Arbitrary`; this module turns
+//! those into actual `NixWriter -> bytes -> NixReader` roundtrip checks so
+//! field-order or padding bugs in manual `NixSerialize`/`NixDeserialize` impls
+//! are caught.
+
+use std::io::Cursor;
+
+use proptest::prelude::*;
+use tokio::io::AsyncWriteExt as _;
+
+use crate::de::{NixDeserialize, NixRead, NixReader};
+use crate::ser::{NixSerialize, NixWrite, NixWriter};
+use crate::version::{FeatureSet, supported_features};
+
+async fn roundtrip<T>(features: FeatureSet, v: &T) -> T
+where
+    T: NixSerialize + NixDeserialize + Send,
+{
+    let mut buf = Vec::new();
+    let mut w = NixWriter::builder()
+        .set_features(features.clone())
+        .build(&mut buf);
+    w.write_value(v).await.expect("write");
+    w.flush().await.expect("flush");
+    drop(w);
+
+    let mut r = NixReader::builder()
+        .set_features(features)
+        .build_buffered(Cursor::new(buf));
+    let back: T = r.read_value().await.expect("read");
+    assert!(
+        r.read_value::<u64>().await.is_err(),
+        "trailing bytes after read"
+    );
+    back
+}
+
+/// Declare a `NixWriter`/`NixReader` proptest roundtrip for `$ty`.
+///
+/// Runs with `supported_features()` so feature-gated serializers (e.g.
+/// `Realisation`) are exercised. For lossy back-compat paths use a fixed-input
+/// test instead.
+macro_rules! wire_roundtrip {
+    ($name:ident, $ty:ty) => {
+        #[test]
+        fn $name() {
+            let rt = tokio::runtime::Builder::new_current_thread()
+                .build()
+                .unwrap();
+            proptest!(|(v in any::<$ty>())| {
+                let back = rt.block_on(roundtrip::<$ty>(supported_features(), &v));
+                prop_assert_eq!(back, v);
+            });
+        }
+    };
+}
+
+use crate::build_result::BuildResult;
+use crate::daemon_wire::types2::QueryMissingResult;
+use harmonia_store_core::derived_path::DerivedPath;
+use harmonia_store_core::realisation::{DrvOutput, Realisation, UnkeyedRealisation};
+
+wire_roundtrip!(roundtrip_drv_output, DrvOutput);
+wire_roundtrip!(roundtrip_unkeyed_realisation, UnkeyedRealisation);
+wire_roundtrip!(
+    roundtrip_option_unkeyed_realisation,
+    Option<UnkeyedRealisation>
+);
+wire_roundtrip!(roundtrip_realisation, Realisation);
+wire_roundtrip!(roundtrip_build_result, BuildResult);
+wire_roundtrip!(roundtrip_query_missing_result, QueryMissingResult);
+wire_roundtrip!(roundtrip_derived_path, DerivedPath);

--- a/harmonia-protocol/tests/json_upstream/build_result.rs
+++ b/harmonia-protocol/tests/json_upstream/build_result.rs
@@ -6,7 +6,7 @@ use harmonia_protocol::daemon_wire::types2::{
     Microseconds, SuccessStatus,
 };
 use harmonia_store_core::derived_path::OutputName;
-use harmonia_store_core::realisation::Realisation;
+use harmonia_store_core::realisation::UnkeyedRealisation;
 
 test_upstream_json!(
     test_build_result_success,
@@ -18,24 +18,16 @@ test_upstream_json!(
                 built_outputs: [
                     (
                         "bar".parse::<OutputName>().unwrap(),
-                        Realisation {
-                            id: "sha256:6f869f9ea2823bda165e06076fd0de4366dead2c0e8d2dbbad277d4f15c373f5!bar"
-                                .parse()
-                                .unwrap(),
+                        UnkeyedRealisation {
                             out_path: "g1w7hy3qg1w7hy3qg1w7hy3qg1w7hy3q-bar".parse().unwrap(),
                             signatures: Default::default(),
-                            dependent_realisations: Default::default(),
                         },
                     ),
                     (
                         "foo".parse::<OutputName>().unwrap(),
-                        Realisation {
-                            id: "sha256:6f869f9ea2823bda165e06076fd0de4366dead2c0e8d2dbbad277d4f15c373f5!foo"
-                                .parse()
-                                .unwrap(),
+                        UnkeyedRealisation {
                             out_path: "g1w7hy3qg1w7hy3qg1w7hy3qg1w7hy3q-foo".parse().unwrap(),
                             signatures: Default::default(),
-                            dependent_realisations: Default::default(),
                         },
                     ),
                 ]

--- a/harmonia-store-core/src/realisation.rs
+++ b/harmonia-store-core/src/realisation.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::BTreeSet;
 use std::str::FromStr;
 
 use derive_more::Display;
@@ -7,29 +7,29 @@ use thiserror::Error;
 
 use crate::derived_path::OutputName;
 use crate::signature::Signature;
-use crate::store_path::{StorePath, StorePathNameError};
-use harmonia_utils_hash::Hash;
-use harmonia_utils_hash::fmt::Any;
+use crate::store_path::{ParseStorePathError, StorePath, StorePathNameError};
 
 /// Identifies a specific output of a derivation.
 ///
-/// String form: `sha256:<hex>!<output_name>`, where the hash is the
-/// "hash modulo" of the derivation.
-#[derive(Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Clone, Display)]
-#[display("{drv_hash:x}!{output_name}")]
+/// String form (`to_string`/`FromStr`): `<drv-basename>^<output-name>`, where
+/// `<drv-basename>` is the store-path base name (without store dir).
+///
+/// JSON form: `{"drvPath": "<basename>", "outputName": "<name>"}`.
+#[derive(Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Clone, Display, Serialize, Deserialize)]
+#[display("{drv_path}^{output_name}")]
+#[serde(rename_all = "camelCase")]
 pub struct DrvOutput {
-    pub drv_hash: harmonia_utils_hash::Hash,
+    pub drv_path: StorePath,
     pub output_name: OutputName,
 }
-crate::impl_serde_via_string!(DrvOutput);
 
 #[derive(Debug, PartialEq, Clone, Error)]
 pub enum ParseDrvOutputError {
     #[error("derivation output {0}")]
-    Hash(
+    DrvPath(
         #[from]
         #[source]
-        harmonia_utils_hash::fmt::ParseHashError,
+        ParseStorePathError,
     ),
     #[error("derivation output has {0}")]
     OutputName(
@@ -37,7 +37,7 @@ pub enum ParseDrvOutputError {
         #[source]
         StorePathNameError,
     ),
-    #[error("missing '!' in derivation output '{0}'")]
+    #[error("missing '^' in derivation output id '{0}'")]
     InvalidDerivationOutputId(String),
 }
 
@@ -45,11 +45,11 @@ impl FromStr for DrvOutput {
     type Err = ParseDrvOutputError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        if let Some((drv_hash_s, output_name_s)) = s.split_once('!') {
-            let drv_hash = drv_hash_s.parse::<Any<Hash>>()?.into_hash();
+        if let Some((drv_path_s, output_name_s)) = s.rsplit_once('^') {
+            let drv_path = drv_path_s.parse()?;
             let output_name = output_name_s.parse()?;
             Ok(DrvOutput {
-                drv_hash,
+                drv_path,
                 output_name,
             })
         } else {
@@ -58,39 +58,57 @@ impl FromStr for DrvOutput {
     }
 }
 
+/// A realisation without its `DrvOutput` key.
+///
+/// This is what binary caches store at
+/// `build-trace-v2/<drv-basename>/<output-name>.doi`.
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
-pub struct Realisation {
-    pub id: DrvOutput,
+pub struct UnkeyedRealisation {
     pub out_path: StorePath,
-    pub signatures: BTreeSet<Signature>,
-    /// Always empty. Nix hardcodes `"dependentRealisations": {}` for backwards compat.
     #[serde(default)]
-    pub dependent_realisations: BTreeMap<DrvOutput, StorePath>,
+    pub signatures: BTreeSet<Signature>,
+}
+
+/// A `DrvOutput` together with its resolved store path and signatures.
+///
+/// JSON form: `{"key": <DrvOutput>, "value": <UnkeyedRealisation>}`.
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Deserialize, Serialize)]
+pub struct Realisation {
+    #[serde(rename = "key")]
+    pub id: DrvOutput,
+    #[serde(rename = "value")]
+    pub value: UnkeyedRealisation,
 }
 
 impl Realisation {
-    /// Compute the fingerprint used for signing.
+    /// Compute the fingerprint used for signing realisations.
+    ///
+    /// Matches `UnkeyedRealisation::fingerprint` in upstream Nix: the full
+    /// `{key,value}` JSON with `value.signatures` removed, serialized with
+    /// sorted keys.
     #[must_use]
     pub fn fingerprint(&self) -> String {
         let mut json = serde_json::to_value(self).expect("Realisation serialization cannot fail");
         json.as_object_mut()
             .expect("Realisation must serialize as object")
+            .get_mut("value")
+            .expect("Realisation must have 'value'")
+            .as_object_mut()
+            .expect("'value' must be an object")
             .remove("signatures");
         json.to_string()
     }
 
     /// Sign this realisation with the given secret keys, adding the resulting
-    /// signatures to the `signatures` set.
+    /// signatures to `value.signatures`.
     pub fn sign(&mut self, keys: &[crate::signature::SecretKey]) {
         let fp = self.fingerprint();
         for key in keys {
-            self.signatures.insert(key.sign(fp.as_bytes()));
+            self.value.signatures.insert(key.sign(fp.as_bytes()));
         }
     }
 }
-
-pub type DrvOutputs = BTreeMap<DrvOutput, Realisation>;
 
 #[cfg(any(test, feature = "test"))]
 pub mod arbitrary {
@@ -98,7 +116,6 @@ pub mod arbitrary {
 
     use super::*;
     use ::proptest::prelude::*;
-    use ::proptest::sample::SizeRange;
 
     impl Arbitrary for DrvOutput {
         type Parameters = ();
@@ -110,28 +127,34 @@ pub mod arbitrary {
     }
 
     prop_compose! {
-        pub fn arb_drv_output()
+        fn arb_drv_output()
         (
-            drv_hash in any::<harmonia_utils_hash::Hash>(),
+            drv_path in any::<StorePath>(),
             output_name in any::<OutputName>(),
         ) -> DrvOutput
         {
-            DrvOutput { drv_hash, output_name }
+            DrvOutput { drv_path, output_name }
         }
     }
 
-    pub fn arb_drv_outputs(size: impl Into<SizeRange>) -> impl Strategy<Value = DrvOutputs> {
-        let size = size.into();
-        let min_size = size.start();
-        prop::collection::vec(arb_realisation(), size)
-            .prop_map(|r| {
-                let mut ret = BTreeMap::new();
-                for value in r {
-                    ret.insert(value.id.clone(), value);
-                }
-                ret
-            })
-            .prop_filter("BTreeMap minimum size", move |m| m.len() >= min_size)
+    impl Arbitrary for UnkeyedRealisation {
+        type Parameters = ();
+        type Strategy = BoxedStrategy<UnkeyedRealisation>;
+
+        fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {
+            arb_unkeyed_realisation().boxed()
+        }
+    }
+
+    prop_compose! {
+        fn arb_unkeyed_realisation()
+        (
+            out_path in any::<StorePath>(),
+            signatures in arb_signatures(),
+        ) -> UnkeyedRealisation
+        {
+            UnkeyedRealisation { out_path, signatures }
+        }
     }
 
     impl Arbitrary for Realisation {
@@ -144,14 +167,13 @@ pub mod arbitrary {
     }
 
     prop_compose! {
-        pub fn arb_realisation()
+        fn arb_realisation()
         (
             id in any::<DrvOutput>(),
-            out_path in any::<StorePath>(),
-            signatures in arb_signatures(),
+            value in any::<UnkeyedRealisation>(),
         ) -> Realisation
         {
-            Realisation { id, out_path, signatures, dependent_realisations: Default::default() }
+            Realisation { id, value }
         }
     }
 }
@@ -161,25 +183,22 @@ mod unittests {
     use rstest::rstest;
 
     use crate::derived_path::OutputName;
-    use crate::set;
 
-    use harmonia_utils_hash::Hash;
-    use harmonia_utils_hash::fmt::Any;
-
-    use super::{DrvOutput, Realisation};
+    use super::{DrvOutput, Realisation, UnkeyedRealisation};
 
     #[rstest]
-    #[case("sha256:248d6a61d20638b8e5c026930c3e6039a33ce45964ff2167f6ecedd419db06c1!out", DrvOutput {
-        drv_hash: "sha256:248d6a61d20638b8e5c026930c3e6039a33ce45964ff2167f6ecedd419db06c1".parse::<Any<Hash>>().unwrap().into_hash(),
+    #[case("g1w7hy3qg1w7hy3qg1w7hy3qg1w7hy3q-bar.drv^out", DrvOutput {
+        drv_path: "g1w7hy3qg1w7hy3qg1w7hy3qg1w7hy3q-bar.drv".parse().unwrap(),
         output_name: OutputName::default(),
     })]
-    #[case("sha256:1h86vccx9vgcyrkj3zv4b7j3r8rrc0z0r4r6q3jvhf06s9hnm394!out_put", DrvOutput {
-        drv_hash: "sha256:1h86vccx9vgcyrkj3zv4b7j3r8rrc0z0r4r6q3jvhf06s9hnm394".parse::<Any<Hash>>().unwrap().into_hash(),
+    #[case("g1w7hy3qg1w7hy3qg1w7hy3qg1w7hy3q-bar.drv^out_put", DrvOutput {
+        drv_path: "g1w7hy3qg1w7hy3qg1w7hy3qg1w7hy3q-bar.drv".parse().unwrap(),
         output_name: "out_put".parse().unwrap(),
     })]
     fn parse_drv_output(#[case] value: &str, #[case] expected: DrvOutput) {
         let actual: DrvOutput = value.parse().unwrap();
         assert_eq!(actual, expected);
+        assert_eq!(actual.to_string(), value);
     }
 
     proptest::proptest! {
@@ -188,132 +207,35 @@ mod unittests {
             let s = d.to_string();
             proptest::prop_assert_eq!(s.parse::<DrvOutput>().unwrap(), d);
         }
-
-        #[test]
-        fn proptest_realisation_json_roundtrip(r in proptest::prelude::any::<Realisation>()) {
-            let json = serde_json::to_string(&r).unwrap();
-            proptest::prop_assert_eq!(serde_json::from_str::<Realisation>(&json).unwrap(), r);
-        }
     }
 
     #[rstest]
-    #[should_panic = "missing '!' in derivation output 'sha256:1h86vccx9vgcyrkj3zv4b7j3r8rrc0z0r4r6q3jvhf06s9hnm394'"]
-    #[case("sha256:1h86vccx9vgcyrkj3zv4b7j3r8rrc0z0r4r6q3jvhf06s9hnm394")]
-    #[should_panic = "derivation output hash 'sha256:1h86vccx9vgcyrkj3zv4b7j3r8rrc0z0r4r6q3jvhf06s9hnm39' has wrong length for hash type 'sha256'"]
-    #[case("sha256:1h86vccx9vgcyrkj3zv4b7j3r8rrc0z0r4r6q3jvhf06s9hnm39!out")]
+    #[should_panic = "missing '^' in derivation output id"]
+    #[case("g1w7hy3qg1w7hy3qg1w7hy3qg1w7hy3q-bar.drv")]
     #[should_panic = "derivation output has invalid name symbol '{' at position 3"]
-    #[case("sha256:1h86vccx9vgcyrkj3zv4b7j3r8rrc0z0r4r6q3jvhf06s9hnm394!out{put")]
+    #[case("g1w7hy3qg1w7hy3qg1w7hy3qg1w7hy3q-bar.drv^out{put")]
     fn parse_drv_output_failure(#[case] value: &str) {
         let actual = value.parse::<DrvOutput>().unwrap_err();
         panic!("{actual}");
     }
 
-    #[rstest]
-    #[case(DrvOutput {
-        drv_hash: "sha256:248d6a61d20638b8e5c026930c3e6039a33ce45964ff2167f6ecedd419db06c1".parse::<Any<Hash>>().unwrap().into_hash(),
-        output_name: OutputName::default(),
-    }, "sha256:248d6a61d20638b8e5c026930c3e6039a33ce45964ff2167f6ecedd419db06c1!out")]
-    #[case(DrvOutput {
-        drv_hash: "sha256:1h86vccx9vgcyrkj3zv4b7j3r8rrc0z0r4r6q3jvhf06s9hnm394".parse::<Any<Hash>>().unwrap().into_hash(),
-        output_name: OutputName::default(),
-    }, "sha256:248d6a61d20638b8e5c026930c3e6039a33ce45964ff2167f6ecedd419db06c1!out")]
-    #[case(DrvOutput {
-        drv_hash: "sha1:y5q4drg5558zk8aamsx6xliv3i23x644".parse::<Any<Hash>>().unwrap().into_hash(),
-        output_name: "out_put".parse().unwrap(),
-    }, "sha1:84983e441c3bd26ebaae4aa1f95129e5e54670f1!out_put")]
-    fn display_drv_output(#[case] value: DrvOutput, #[case] expected: &str) {
-        assert_eq!(value.to_string(), expected);
-    }
-
-    #[rstest]
-    #[case(
-        "{\"dependentRealisations\":{},\"id\":\"sha256:ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad!out\",\"outPath\":\"7h7qgvs4kgzsn8a6rb273saxyqh4jxlz-konsole-18.12.3\",\"signatures\":[\"cache.nixos.org-1:0CpHca+06TwFp9VkMyz5OaphT3E8mnS+1SWymYlvFaghKSYPCMQ66TS1XPAr1+y9rfQZPLaHrBjjnIRktE/nAA==\"]}",
-        Realisation {
-            id: DrvOutput {
-                drv_hash: "sha256:ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad".parse::<Any<Hash>>().unwrap().into_hash(),
-                output_name: OutputName::default(),
-            },
-            out_path: "7h7qgvs4kgzsn8a6rb273saxyqh4jxlz-konsole-18.12.3".parse().unwrap(),
-            signatures: set!["cache.nixos.org-1:0CpHca+06TwFp9VkMyz5OaphT3E8mnS+1SWymYlvFaghKSYPCMQ66TS1XPAr1+y9rfQZPLaHrBjjnIRktE/nAA=="],
-            dependent_realisations: Default::default(),
-        },
-    )]
-    fn parse_realisation(#[case] value: &str, #[case] expected: Realisation) {
-        let actual: Realisation = serde_json::from_str(value).unwrap();
-        assert_eq!(actual, expected);
-    }
-
-    #[rstest]
-    #[case(
-        Realisation {
-            id: DrvOutput {
-                drv_hash: "sha256:ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad".parse::<Any<Hash>>().unwrap().into_hash(),
-                output_name: OutputName::default(),
-            },
-            out_path: "7h7qgvs4kgzsn8a6rb273saxyqh4jxlz-konsole-18.12.3".parse().unwrap(),
-            signatures: set!["cache.nixos.org-1:0CpHca+06TwFp9VkMyz5OaphT3E8mnS+1SWymYlvFaghKSYPCMQ66TS1XPAr1+y9rfQZPLaHrBjjnIRktE/nAA=="],
-            dependent_realisations: Default::default(),
-        },
-    )]
-    fn write_realisation(#[case] value: Realisation) {
-        // Round-trip: serialize then deserialize & verify equality
-        let json = serde_json::to_string(&value).unwrap();
-        let parsed: Realisation = serde_json::from_str(&json).unwrap();
-        assert_eq!(parsed, value);
-        // Verify dependentRealisations is present in output (backwards compat)
-        let raw = serde_json::from_str::<serde_json::Value>(&json).unwrap();
-        assert!(raw.get("dependentRealisations").is_some());
-    }
-
     #[test]
-    fn fingerprint_strips_signatures() {
-        let r = Realisation {
-            id: DrvOutput {
-                drv_hash: "sha256:15e3c560894cbb27085cf65b5a2ecb18488c999497f4531b6907a7581ce6d527"
-                    .parse::<Any<Hash>>()
-                    .unwrap()
-                    .into_hash(),
-                output_name: "baz".parse().unwrap(),
-            },
-            out_path: "g1w7hy3qg1w7hy3qg1w7hy3qg1w7hy3q-foo".parse().unwrap(),
-            signatures: set![
-                "asdf:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
-                "qwer:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=="
-            ],
-            dependent_realisations: Default::default(),
-        };
-
-        let fp = r.fingerprint();
-        let parsed: serde_json::Value = serde_json::from_str(&fp).unwrap();
-        assert_eq!(
-            parsed["id"],
-            "sha256:15e3c560894cbb27085cf65b5a2ecb18488c999497f4531b6907a7581ce6d527!baz"
-        );
-        assert_eq!(parsed["outPath"], "g1w7hy3qg1w7hy3qg1w7hy3qg1w7hy3q-foo");
-        assert!(
-            parsed.get("signatures").is_none(),
-            "signatures must be stripped"
-        );
-    }
-
-    #[test]
-    fn sign_adds_signature() {
+    fn sign_produces_verifiable_signature() {
         let mut r = Realisation {
             id: DrvOutput {
-                drv_hash: "sha256:15e3c560894cbb27085cf65b5a2ecb18488c999497f4531b6907a7581ce6d527"
-                    .parse::<Any<Hash>>()
-                    .unwrap()
-                    .into_hash(),
-                output_name: "baz".parse().unwrap(),
+                drv_path: "g1w7hy3qg1w7hy3qg1w7hy3qg1w7hy3q-bar.drv".parse().unwrap(),
+                output_name: "foo".parse().unwrap(),
             },
-            out_path: "g1w7hy3qg1w7hy3qg1w7hy3qg1w7hy3q-foo".parse().unwrap(),
-            signatures: Default::default(),
-            dependent_realisations: Default::default(),
+            value: UnkeyedRealisation {
+                out_path: "g1w7hy3qg1w7hy3qg1w7hy3qg1w7hy3q-foo".parse().unwrap(),
+                signatures: Default::default(),
+            },
         };
-        assert!(r.signatures.is_empty());
         let sk = crate::signature::SecretKey::generate("test-key".to_string()).unwrap();
+        let pk = sk.to_public_key();
         r.sign(&[sk]);
-        assert_eq!(r.signatures.len(), 1);
-        assert_eq!(r.signatures.iter().next().unwrap().name(), "test-key");
+        let sig = r.value.signatures.iter().next().unwrap();
+        assert_eq!(sig.name(), "test-key");
+        assert!(pk.verify(r.fingerprint(), sig));
     }
 }

--- a/harmonia-store-core/src/signature.rs
+++ b/harmonia-store-core/src/signature.rs
@@ -8,6 +8,9 @@ use std::sync::Arc;
 use data_encoding::BASE64;
 
 use ed25519_dalek::{Signer, SigningKey, Verifier, VerifyingKey};
+use serde::de::{self, Deserializer, MapAccess, Visitor};
+use serde::ser::{SerializeStruct, Serializer};
+use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use tracing::error;
 
@@ -37,7 +40,6 @@ pub type SignatureSet = BTreeSet<Signature>;
 
 #[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Signature(Arc<String>, [u8; SIGNATURE_BYTES]);
-crate::impl_serde_via_string!(Signature);
 
 impl Signature {
     pub fn name(&self) -> &str {
@@ -83,6 +85,60 @@ impl<const N: usize> fmt::Display for Base64Display<'_, N> {
 impl fmt::Display for Signature {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}:{}", self.name(), self.signature())
+    }
+}
+
+/// JSON serialization matches upstream Nix `adl_serializer<Signature>`:
+/// always writes the structured `{"keyName": ..., "sig": <base64>}` form,
+/// accepts either that form or the legacy `"name:base64"` string when reading.
+impl Serialize for Signature {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut s = serializer.serialize_struct("Signature", 2)?;
+        s.serialize_field("keyName", self.name())?;
+        s.serialize_field("sig", &self.signature().to_string())?;
+        s.end()
+    }
+}
+
+impl<'de> Deserialize<'de> for Signature {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct SigVisitor;
+        impl<'de> Visitor<'de> for SigVisitor {
+            type Value = Signature;
+            fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
+                f.write_str("a signature string or {keyName, sig} object")
+            }
+            fn visit_str<E: de::Error>(self, v: &str) -> Result<Signature, E> {
+                v.parse().map_err(E::custom)
+            }
+            fn visit_map<A>(self, mut map: A) -> Result<Signature, A::Error>
+            where
+                A: MapAccess<'de>,
+            {
+                let mut key_name: Option<String> = None;
+                let mut sig: Option<String> = None;
+                while let Some(k) = map.next_key::<String>()? {
+                    match k.as_str() {
+                        "keyName" => key_name = Some(map.next_value()?),
+                        "sig" => sig = Some(map.next_value()?),
+                        _ => {
+                            let _ignored: de::IgnoredAny = map.next_value()?;
+                        }
+                    }
+                }
+                let key_name = key_name.ok_or_else(|| de::Error::missing_field("keyName"))?;
+                let sig = sig.ok_or_else(|| de::Error::missing_field("sig"))?;
+                let bytes = BASE64.decode(sig.as_bytes()).map_err(de::Error::custom)?;
+                Signature::from_parts(&key_name, &bytes).map_err(de::Error::custom)
+            }
+        }
+        deserializer.deserialize_any(SigVisitor)
     }
 }
 
@@ -481,6 +537,12 @@ mod unittests {
     }
 
     #[test]
+    fn test_serde_json_errors() {
+        assert!(serde_json::from_value::<Signature>(serde_json::json!({"keyName": "x"})).is_err());
+        assert!(serde_json::from_value::<Signature>(serde_json::json!({"sig": "x"})).is_err());
+    }
+
+    #[test]
     fn test_sign() {
         let data = "1;/nix/store/02bfycjg1607gpcnsg8l13lc45qa8qj3-libssh2-1.10.0;sha256:1l29f8r5q2739wnq4i7m2v545qx77b3wrdsw9xz2ajiy3hv1al8b;294664;/nix/store/02bfycjg1607gpcnsg8l13lc45qa8qj3-libssh2-1.10.0,/nix/store/1l4r0r4ab3v3a3ppir4jwiah3icalk9d-zlib-1.2.11,/nix/store/gf6j3k1flnhayvpnwnhikkg0s5dxrn1i-openssl-1.1.1l,/nix/store/z56jcx3j1gfyk4sv7g8iaan0ssbdkhz1-glibc-2.33-56";
         let sk_s = "cache.example.org-1:ZJui+kG6vPCSRD4+p1P4DyUVlASmp/zsaeN84PTFW28tj2/PtQWvFWK6Mw+ay8kGif8AZkR5KosHLvuwlzDlgg==";
@@ -513,6 +575,26 @@ mod unittests {
         fn proptest_signature_display_parse(sig in proptest::prelude::any::<Signature>()) {
             let s = sig.to_string();
             proptest::prop_assert_eq!(s.parse::<Signature>().unwrap(), sig);
+        }
+
+        /// `Serialize` always emits the `{keyName, sig}` object; `Deserialize`
+        /// must accept that, the legacy `"name:b64"` string, and ignore unknown
+        /// fields.
+        #[test]
+        fn proptest_signature_json(sig in proptest::prelude::any::<Signature>()) {
+            let json = serde_json::to_value(&sig).unwrap();
+            proptest::prop_assert_eq!(json["keyName"].as_str().unwrap(), sig.name());
+            proptest::prop_assert_eq!(serde_json::from_value::<Signature>(json).unwrap(), sig.clone());
+
+            let legacy = serde_json::Value::String(sig.to_string());
+            proptest::prop_assert_eq!(serde_json::from_value::<Signature>(legacy).unwrap(), sig.clone());
+
+            let with_extra = serde_json::json!({
+                "keyName": sig.name(),
+                "sig": sig.signature().to_string(),
+                "extra": 1,
+            });
+            proptest::prop_assert_eq!(serde_json::from_value::<Signature>(with_extra).unwrap(), sig);
         }
     }
 }

--- a/harmonia-store-core/tests/json_upstream/realisation.rs
+++ b/harmonia-store-core/tests/json_upstream/realisation.rs
@@ -2,70 +2,94 @@
 
 use crate::libstore_test_data_path;
 use crate::test_upstream_json;
-use harmonia_store_core::realisation::{DrvOutput, Realisation};
+use harmonia_store_core::realisation::{DrvOutput, Realisation, UnkeyedRealisation};
+use harmonia_store_core::signature::Signature;
+
+fn drv_output() -> DrvOutput {
+    DrvOutput {
+        drv_path: "g1w7hy3qg1w7hy3qg1w7hy3qg1w7hy3q-bar.drv".parse().unwrap(),
+        output_name: "foo".parse().unwrap(),
+    }
+}
+
+test_upstream_json!(
+    test_unkeyed_realisation_simple,
+    libstore_test_data_path("realisation/unkeyed-simple.json"),
+    {
+        UnkeyedRealisation {
+            out_path: "g1w7hy3qg1w7hy3qg1w7hy3qg1w7hy3q-foo".parse().unwrap(),
+            signatures: Default::default(),
+        }
+    }
+);
+
+test_upstream_json!(
+    test_unkeyed_realisation_with_signature,
+    libstore_test_data_path("realisation/unkeyed-with-signature.json"),
+    {
+        UnkeyedRealisation {
+            out_path: "g1w7hy3qg1w7hy3qg1w7hy3qg1w7hy3q-foo.drv".parse().unwrap(),
+            signatures: ["asdf:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==".parse::<Signature>().unwrap()].into(),
+        }
+    }
+);
 
 test_upstream_json!(
     test_realisation_simple,
     libstore_test_data_path("realisation/simple.json"),
     {
         Realisation {
-            id: "sha256:ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad!foo"
-                .parse::<DrvOutput>()
-                .unwrap(),
-            out_path: "g1w7hy3qg1w7hy3qg1w7hy3qg1w7hy3q-foo.drv".parse().unwrap(),
-            signatures: Default::default(),
-            dependent_realisations: Default::default(),
+            id: drv_output(),
+            value: UnkeyedRealisation {
+                out_path: "g1w7hy3qg1w7hy3qg1w7hy3qg1w7hy3q-foo".parse().unwrap(),
+                signatures: Default::default(),
+            },
         }
     }
 );
 
 test_upstream_json!(
-    test_realisation_with_dependent,
-    libstore_test_data_path("realisation/with-dependent-realisations.json"),
+    test_realisation_with_signature,
+    libstore_test_data_path("realisation/with-signature.json"),
     {
         Realisation {
-            id: "sha256:ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad!foo"
-                .parse::<DrvOutput>()
-                .unwrap(),
-            out_path: "g1w7hy3qg1w7hy3qg1w7hy3qg1w7hy3q-foo.drv".parse().unwrap(),
-            signatures: Default::default(),
-            dependent_realisations: [(
-                "sha256:ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad!foo"
-                    .parse::<DrvOutput>()
-                    .unwrap(),
-                "g1w7hy3qg1w7hy3qg1w7hy3qg1w7hy3q-foo.drv".parse().unwrap(),
-            )]
-            .into_iter()
-            .collect(),
+            id: drv_output(),
+            value: UnkeyedRealisation {
+                out_path: "g1w7hy3qg1w7hy3qg1w7hy3qg1w7hy3q-foo.drv".parse().unwrap(),
+                signatures: ["asdf:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==".parse::<Signature>().unwrap()].into(),
+            },
         }
     }
 );
 
-test_upstream_json!(
-    test_realisation_worker_protocol,
-    libstore_test_data_path("worker-protocol/realisation.json"),
-    vec![
-        Realisation {
-            id: "sha256:15e3c560894cbb27085cf65b5a2ecb18488c999497f4531b6907a7581ce6d527!baz"
-                .parse::<DrvOutput>()
-                .unwrap(),
+#[test]
+fn test_realisation_fingerprint_simple() {
+    let r = Realisation {
+        id: drv_output(),
+        value: UnkeyedRealisation {
             out_path: "g1w7hy3qg1w7hy3qg1w7hy3qg1w7hy3q-foo".parse().unwrap(),
             signatures: Default::default(),
-            dependent_realisations: Default::default(),
         },
-        Realisation {
-            id: "sha256:15e3c560894cbb27085cf65b5a2ecb18488c999497f4531b6907a7581ce6d527!baz"
-                .parse::<DrvOutput>()
-                .unwrap(),
-            out_path: "g1w7hy3qg1w7hy3qg1w7hy3qg1w7hy3q-foo".parse().unwrap(),
-            signatures: [
-                "asdf:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
-                "qwer:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
-            ]
-            .into_iter()
-            .map(|s| s.parse().unwrap())
-            .collect(),
-            dependent_realisations: Default::default(),
+    };
+    let expected = std::fs::read_to_string(libstore_test_data_path(
+        "realisation/simple-fingerprint.txt",
+    ))
+    .unwrap();
+    assert_eq!(r.fingerprint(), expected.trim_end());
+}
+
+#[test]
+fn test_realisation_fingerprint_with_signature() {
+    let r = Realisation {
+        id: drv_output(),
+        value: UnkeyedRealisation {
+            out_path: "g1w7hy3qg1w7hy3qg1w7hy3qg1w7hy3q-foo.drv".parse().unwrap(),
+            signatures: ["asdf:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==".parse::<Signature>().unwrap()].into(),
         },
-    ]
-);
+    };
+    let expected = std::fs::read_to_string(libstore_test_data_path(
+        "realisation/with-signature-fingerprint.txt",
+    ))
+    .unwrap();
+    assert_eq!(r.fingerprint(), expected.trim_end());
+}

--- a/harmonia-store-db/src/connection.rs
+++ b/harmonia-store-db/src/connection.rs
@@ -146,7 +146,7 @@ impl StoreDb {
     /// Check if the database has CA-derivations tables.
     pub fn has_ca_schema(&self) -> Result<bool> {
         let count: i32 = self.conn.query_row(
-            "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='Realisations'",
+            "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='BuildTraceV3'",
             [],
             |row| row.get(0),
         )?;

--- a/harmonia-store-db/src/query.rs
+++ b/harmonia-store-db/src/query.rs
@@ -244,7 +244,10 @@ impl StoreDb {
         Ok(count as u64)
     }
 
-    /// Query a realisation by derivation path and output name.
+    /// Query a realisation by derivation path base name and output name.
+    ///
+    /// `drv_path` is the *base name* of the derivation store path (without the
+    /// store directory prefix), matching how Nix populates `BuildTraceV3`.
     pub fn query_realisation(
         &self,
         drv_path: &str,
@@ -253,7 +256,7 @@ impl StoreDb {
         let mut stmt = self.conn.prepare_cached(
             r#"
             SELECT id, drvPath, outputName, outputPath, signatures
-            FROM Realisations
+            FROM BuildTraceV3
             WHERE drvPath = ?1 AND outputName = ?2
             "#,
         )?;
@@ -263,7 +266,7 @@ impl StoreDb {
                 id: row.get(0)?,
                 drv_path: row.get(1)?,
                 output_name: row.get(2)?,
-                output_path_id: row.get(3)?,
+                output_path: row.get(3)?,
                 signatures: row.get(4)?,
             })
         });

--- a/harmonia-store-db/src/schema.rs
+++ b/harmonia-store-db/src/schema.rs
@@ -46,36 +46,21 @@ create table if not exists DerivationOutputs (
 create index if not exists IndexDerivationOutputs on DerivationOutputs(path);
 "#;
 
-/// Content-addressed derivations schema (Realisations, RealisationsRefs)
+/// Content-addressed derivations schema (BuildTraceV3).
+///
+/// Upstream Nix versions the CA tables independently (Realisations →
+/// BuildTraceV3) so users can switch experiment versions without migration; we
+/// only target the current revision.
 pub const CA_SCHEMA_SQL: &str = r#"
-create table if not exists Realisations (
+create table if not exists BuildTraceV3 (
     id integer primary key autoincrement not null,
     drvPath text not null,
     outputName text not null,
-    outputPath integer not null,
-    signatures text,
-    foreign key (outputPath) references ValidPaths(id) on delete cascade
+    outputPath text not null,
+    signatures text
 );
 
-create index if not exists IndexRealisations on Realisations(drvPath, outputName);
-
-create trigger if not exists DeleteSelfRefsViaRealisations before delete on ValidPaths
-  begin
-    delete from RealisationsRefs where realisationReference in (
-      select id from Realisations where outputPath = old.id
-    );
-  end;
-
-create table if not exists RealisationsRefs (
-    referrer integer not null,
-    realisationReference integer,
-    foreign key (referrer) references Realisations(id) on delete cascade,
-    foreign key (realisationReference) references Realisations(id) on delete restrict
-);
-
-create index if not exists IndexRealisationsRefsRealisationReference on RealisationsRefs(realisationReference);
-create index if not exists IndexRealisationsRefs on RealisationsRefs(referrer);
-create index if not exists IndexRealisationsRefsOnOutputPath on Realisations(outputPath);
+create index if not exists IndexBuildTraceV3 on BuildTraceV3(drvPath, outputName);
 "#;
 
 /// Schema version (matches Nix 2.0+)

--- a/harmonia-store-db/src/types.rs
+++ b/harmonia-store-db/src/types.rs
@@ -68,28 +68,19 @@ pub struct DerivationOutput {
     pub path: String,
 }
 
-/// A content-addressed derivation realisation.
+/// A content-addressed derivation realisation (`BuildTraceV3` row).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Realisation {
     /// Database row ID
     pub id: i64,
-    /// Path to the derivation
+    /// Base name of the derivation store path (e.g. `xxxx-foo.drv`)
     pub drv_path: String,
     /// Output name (usually "out")
     pub output_name: String,
-    /// ID of the output path in ValidPaths
-    pub output_path_id: i64,
+    /// Full store path of the output
+    pub output_path: String,
     /// Space-separated signatures
     pub signatures: Option<String>,
-}
-
-/// A reference between realisations.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct RealisationRef {
-    /// ID of the realisation that has the reference
-    pub referrer_id: i64,
-    /// ID of the realisation being referenced
-    pub reference_id: Option<i64>,
 }
 
 /// Convert Unix timestamp to SystemTime.

--- a/harmonia-store-db/src/write.rs
+++ b/harmonia-store-db/src/write.rs
@@ -175,25 +175,16 @@ impl StoreDb {
         &self,
         drv_path: &str,
         output_name: &str,
-        output_path_id: i64,
+        output_path: &str,
         signatures: Option<&str>,
     ) -> Result<i64> {
         self.conn.execute(
             r#"
-            INSERT INTO Realisations (drvPath, outputName, outputPath, signatures)
+            INSERT INTO BuildTraceV3 (drvPath, outputName, outputPath, signatures)
             VALUES (?1, ?2, ?3, ?4)
             "#,
-            params![drv_path, output_name, output_path_id, signatures],
+            params![drv_path, output_name, output_path, signatures],
         )?;
         Ok(self.conn.last_insert_rowid())
-    }
-
-    /// Add a reference between realisations.
-    pub fn add_realisation_reference(&self, referrer_id: i64, reference_id: i64) -> Result<()> {
-        self.conn.execute(
-            "INSERT INTO RealisationsRefs (referrer, realisationReference) VALUES (?1, ?2)",
-            params![referrer_id, reference_id],
-        )?;
-        Ok(())
     }
 }

--- a/harmonia-store-db/tests/smoke.rs
+++ b/harmonia-store-db/tests/smoke.rs
@@ -122,6 +122,28 @@ fn test_derivation_outputs() {
     assert_eq!(derivers, vec![drv.path]);
 }
 
+/// Verify CA realisations roundtrip through the BuildTraceV3 table.
+#[test]
+fn test_realisation_roundtrip() {
+    let db = StoreDb::open_memory().unwrap();
+
+    let drv = "dddddddddddddddddddddddddddddddd-hello.drv";
+    let out = make_path("oooooooooooooooooooooooooooooooo", "hello");
+
+    assert!(db.query_realisation(drv, "out").unwrap().is_none());
+
+    db.register_realisation(drv, "out", &out, Some("k:sig1 k:sig2"))
+        .unwrap();
+
+    let r = db.query_realisation(drv, "out").unwrap().unwrap();
+    assert_eq!(r.drv_path, drv);
+    assert_eq!(r.output_name, "out");
+    assert_eq!(r.output_path, out);
+    assert_eq!(r.signatures.as_deref(), Some("k:sig1 k:sig2"));
+
+    assert!(db.query_realisation(drv, "dev").unwrap().is_none());
+}
+
 /// Verify path invalidation cascades correctly.
 #[test]
 fn test_invalidation_cascade() {

--- a/harmonia-store-remote/src/client.rs
+++ b/harmonia-store-remote/src/client.rs
@@ -5,7 +5,7 @@
 // This crate is derived from Nix.rs (https://github.com/griff/Nix.rs)
 // Upstream commit: f5d129b71bb30b476ce21e6da2a53dcb28607a89
 
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::BTreeMap;
 use std::fmt;
 use std::path::Path;
 use std::pin::Pin;
@@ -23,7 +23,6 @@ use tokio::sync::oneshot;
 use tracing::{debug, info, trace};
 
 // From harmonia-protocol
-use harmonia_protocol::ProtocolVersion;
 use harmonia_protocol::daemon_wire::logger::{
     FutureResultExt, ProcessStderr, RawLogMessage, ResultLog, ResultLogExt,
 };
@@ -41,12 +40,14 @@ use harmonia_protocol::types::{
     DaemonResultExt as _, DaemonStore, HandshakeDaemonStore, TrustLevel,
 };
 use harmonia_protocol::valid_path_info::{UnkeyedValidPathInfo, ValidPathInfo};
+use harmonia_protocol::version::{FeatureSet, supported_features};
+use harmonia_protocol::{FEATURE_REALISATION_WITH_PATH, ProtocolVersion};
 
 // From harmonia-store-core
 use harmonia_protocol::log::{LogMessage, Message, Verbosity};
 use harmonia_store_core::derivation::BasicDerivation;
 use harmonia_store_core::derived_path::{DerivedPath, OutputName};
-use harmonia_store_core::realisation::{DrvOutput, Realisation};
+use harmonia_store_core::realisation::{DrvOutput, Realisation, UnkeyedRealisation};
 use harmonia_store_core::signature::Signature;
 use harmonia_store_core::store_path::{
     ContentAddressMethodAlgorithm, StoreDir, StorePath, StorePathHash, StorePathSet,
@@ -240,9 +241,23 @@ where
                 .with_field("clientVersion")?;
             reader.set_version(version);
             writer.set_version(version);
+
+            // Exchange features (protocol >= 1.38).
+            let mut features = FeatureSet::new();
+            if version.minor() >= 38 {
+                let local = supported_features();
+                writer.write_value(&local).await.with_field("features")?;
+                writer.flush().await.with_field("features")?;
+                let daemon_features: FeatureSet =
+                    reader.read_value().await.with_field("features")?;
+                features = local.intersection(&daemon_features).cloned().collect();
+            }
+            reader.set_features(features.clone());
+            writer.set_features(features.clone());
             info!(
                 ?version,
                 ?server_version,
+                ?features,
                 "Client Version is {}, server version is {}",
                 version,
                 server_version
@@ -285,6 +300,7 @@ where
                         host,
                         reader,
                         writer,
+                        features,
                         daemon_nix_version,
                         remote_trusts_us,
                     })
@@ -303,6 +319,7 @@ pub struct DaemonClient<R, W> {
     host: String,
     reader: NixReader<Lending<BytesReader<R>, NarBytesReader<BytesReader<R>>>>,
     writer: NixWriter<W>,
+    features: FeatureSet,
     daemon_nix_version: Option<String>,
     remote_trusts_us: TrustLevel,
 }
@@ -320,6 +337,10 @@ impl<R, W> DaemonClient<R, W> {
 
     pub fn daemon_nix_version(&self) -> Option<&str> {
         self.daemon_nix_version.as_deref()
+    }
+
+    pub fn has_feature(&self, feature: &str) -> bool {
+        self.features.contains(feature)
     }
 }
 
@@ -639,8 +660,10 @@ where
             let driver = async {
                 let id = self.id;
                 let version = self.writer.version();
+                let features = self.writer.features().clone();
                 let mut writer = NixWriter::builder()
                     .set_version(version)
+                    .set_features(features)
                     .build(FramedWriter::new(&mut self.writer));
 
                 debug!(id, "Write write stream");
@@ -874,8 +897,14 @@ where
     fn query_realisation<'a>(
         &'a mut self,
         output_id: &'a DrvOutput,
-    ) -> impl ResultLog<Output = DaemonResult<BTreeSet<Realisation>>> + Send + 'a {
+    ) -> impl ResultLog<Output = DaemonResult<Option<UnkeyedRealisation>>> + Send + 'a {
         async move {
+            if !self.has_feature(FEATURE_REALISATION_WITH_PATH) {
+                return Err(DaemonErrorKind::Custom(format!(
+                    "the daemon is missing the '{FEATURE_REALISATION_WITH_PATH}' protocol feature, needed to support content-addressing derivations"
+                ))
+                .into());
+            }
             self.writer
                 .write_value(&Operation::QueryRealisation)
                 .await?;

--- a/nix/checks.nix
+++ b/nix/checks.nix
@@ -6,13 +6,6 @@
   packageSet,
   treefmt,
 }:
-let
-  testArgs = {
-    inherit pkgs self;
-  };
-  packages = lib.mapAttrs' (n: lib.nameValuePair "package-${n}") self.packages.${system};
-  devShells = lib.mapAttrs' (n: lib.nameValuePair "devShell-${n}") self.devShells.${system};
-in
 {
   inherit (packageSet) tests clippy;
   treefmt = treefmt.config.build.check self;
@@ -26,10 +19,13 @@ in
     ]
   );
 }
-// lib.optionalAttrs pkgs.stdenv.isLinux {
-  nix-daemon = import ./tests/nix-daemon.nix testArgs;
-  harmonia-daemon = import ./tests/harmonia-daemon.nix testArgs;
-  chroot-store = import ./tests/chroot-store.nix testArgs;
-}
-// packages
-// devShells
+// lib.optionalAttrs pkgs.stdenv.isLinux (
+  lib.mapAttrs' (
+    name: _:
+    lib.nameValuePair (lib.removeSuffix ".nix" name) (
+      import (./tests + "/${name}") { inherit pkgs self; }
+    )
+  ) (builtins.readDir ./tests)
+)
+// lib.mapAttrs' (n: lib.nameValuePair "package-${n}") self.packages.${system}
+// lib.mapAttrs' (n: lib.nameValuePair "devShell-${n}") self.devShells.${system}

--- a/nix/tests/ca-derivations.nix
+++ b/nix/tests/ca-derivations.nix
@@ -1,0 +1,135 @@
+{ pkgs, self }:
+let
+  # The build-trace-v2 endpoint and the `realisation-with-path-not-hash`
+  # worker-protocol feature only exist in unreleased Nix; pin both nodes to
+  # nixVersions.git so the daemon harmonia talks to and the client both
+  # understand the new format.
+  nixGit = pkgs.nixVersions.git;
+
+  caDrv = pkgs.writeText "ca.nix" ''
+    derivation {
+      name = "ca-test";
+      system = builtins.currentSystem;
+      builder = "/bin/sh";
+      args = [ "-c" "echo hello-from-ca > $out" ];
+      __contentAddressed = true;
+      outputHashMode = "recursive";
+      outputHashAlgo = "sha256";
+    }
+  '';
+in
+pkgs.testers.nixosTest {
+  name = "ca-derivations";
+
+  nodes = {
+    harmonia =
+      { ... }:
+      {
+        imports = [ self.nixosModules.harmonia ];
+
+        nix.package = nixGit;
+        nix.settings.experimental-features = [
+          "nix-command"
+          "ca-derivations"
+        ];
+        nix.settings.sandbox = false;
+
+        # First instance: harmonia-cache talking directly to nix-daemon.
+        services.harmonia-dev.cache.enable = true;
+        services.harmonia-dev.cache.signKeyPaths = [ "${../../tests/cache.sk}" ];
+
+        # Second instance: harmonia-cache backed by harmonia-daemon reading
+        # the SQLite DB directly, so we exercise harmonia-daemon's own
+        # QueryRealisation implementation.
+        services.harmonia-dev.daemon.enable = true;
+        systemd.services.harmonia-dev-via-daemon =
+          let
+            cfg = (pkgs.formats.toml { }).generate "harmonia.toml" {
+              bind = "[::]:5001";
+              daemon_socket = "/run/harmonia-daemon/socket";
+              priority = 30;
+            };
+          in
+          {
+            wantedBy = [ "multi-user.target" ];
+            after = [ "harmonia-daemon.service" ];
+            requires = [ "harmonia-daemon.service" ];
+            environment.CONFIG_FILE = "${cfg}";
+            serviceConfig.DynamicUser = true;
+            serviceConfig.ExecStart = "${
+              self.packages.${pkgs.stdenv.hostPlatform.system}.harmonia
+            }/bin/harmonia-cache";
+          };
+
+        networking.firewall.allowedTCPPorts = [
+          5000
+          5001
+        ];
+      };
+
+    client01 =
+      { lib, ... }:
+      {
+        nix.package = nixGit;
+        nix.settings.substituters = lib.mkForce [ "http://harmonia:5000" ];
+        nix.settings.trusted-public-keys = [ (builtins.readFile ../../tests/cache.pk) ];
+        nix.settings.experimental-features = [
+          "nix-command"
+          "ca-derivations"
+        ];
+        nix.settings.sandbox = false;
+      };
+  };
+
+  testScript = ''
+    import json
+
+    start_all()
+    harmonia.wait_for_unit("harmonia-dev.service")
+    harmonia.wait_for_open_port(5000)
+    client01.wait_until_succeeds("timeout 1 curl -f http://harmonia:5000/nix-cache-info")
+
+    # Build the CA derivation on the server so its realisation lands in both
+    # nix-daemon and the on-disk BuildTraceV3 table that harmonia-daemon reads.
+    drv = harmonia.succeed(
+        "nix-instantiate --extra-experimental-features ca-derivations ${caDrv}"
+    ).strip()
+    drv_base = drv.removeprefix("/nix/store/")
+    out = harmonia.succeed(f"nix-store --realise {drv}").strip()
+    print(f"CA drv {drv} -> {out}")
+
+    # harmonia-daemon opened the DB read-only before BuildTraceV3 existed; restart
+    # so it picks up the CA schema created by the build above.
+    harmonia.succeed("systemctl restart harmonia-daemon.service harmonia-dev-via-daemon.service")
+    harmonia.wait_for_open_port(5001)
+
+    for port in (5000, 5001):
+        # Harmonia must serve the build trace at the v2 endpoint, both when
+        # backed by nix-daemon (5000) and by harmonia-daemon (5001).
+        body = harmonia.succeed(
+            f"curl -sf http://localhost:{port}/build-trace-v2/{drv_base}/out.doi"
+        )
+        print(f"port {port}: {body}")
+        data = json.loads(body)
+        assert data["outPath"] == out.removeprefix("/nix/store/"), (port, data)
+        assert "signatures" in data, (port, data)
+
+        # The real test: the upstream Nix client must be able to substitute
+        # the CA derivation via harmonia. With -j0 it cannot build locally,
+        # so this only succeeds if the realisation lookup over HTTP works.
+        client01.succeed("nix-store --delete " + out + " || true")
+        client01.succeed(
+            f"nix-store --realise {drv} -j0 "
+            f"--option substituters http://harmonia:{port} "
+            "--option require-sigs false "
+            "--extra-experimental-features ca-derivations"
+        )
+        client01.succeed(f"grep -q hello-from-ca {out}")
+
+    # Verify the realisation was registered on the client side.
+    client01.succeed(
+        "nix --extra-experimental-features 'nix-command ca-derivations' "
+        f"realisation info {drv}^out"
+    )
+  '';
+}


### PR DESCRIPTION
Upstream Nix replaced the legacy hash-modulo realisation format with a store-path-keyed "build trace" representation, gated by the new `realisation-with-path-not-hash` worker-protocol feature negotiated at protocol >= 1.38. This adapts harmonia to speak only the new format.

Fixes: https://github.com/nix-community/harmonia/issues/202