### PR TITLE
store-remote: drain trailing reply words from nix-daemon

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1119,6 +1119,7 @@ dependencies = [
  "harmonia-store-core",
  "harmonia-utils-io",
  "prometheus",
+ "tempfile",
  "tokio",
  "tracing",
 ]

--- a/harmonia-protocol/src/store_impls.rs
+++ b/harmonia-protocol/src/store_impls.rs
@@ -10,14 +10,17 @@
 //! This module breaks the circular dependency: store-core has no protocol knowledge,
 //! but protocol can impl traits for external store-core types.
 
+use std::collections::BTreeMap;
 use std::str::FromStr;
+
+use bytes::Bytes;
 
 use crate::daemon_wire::logger::RawLogMessageType;
 use crate::de::{NixDeserialize, NixRead};
 use crate::log::{Activity, ActivityResult, LogMessage, StopActivity};
 use crate::ser::{NixSerialize, NixWrite};
 use harmonia_protocol_derive::{nix_deserialize_remote, nix_serialize_remote};
-use harmonia_store_core::derivation::{BasicDerivation, DerivationOutput};
+use harmonia_store_core::derivation::{BasicDerivation, DerivationOutput, StructuredAttrs};
 use harmonia_store_core::derived_path::{DerivedPath, LegacyDerivedPath, OutputName};
 use harmonia_store_core::realisation::Realisation;
 use harmonia_store_core::store_path::{
@@ -43,7 +46,21 @@ impl NixSerialize for (StorePath, BasicDerivation) {
         writer.write_value(&drv.platform).await?;
         writer.write_value(&drv.builder).await?;
         writer.write_value(&drv.args).await?;
-        writer.write_value(&drv.env).await?;
+        // The wire format (like ATerm) carries structured attrs as the
+        // `__json` env var, not as a separate field. Re-inject it so the
+        // remote daemon reconstructs the same derivation.
+        match &drv.structured_attrs {
+            None => writer.write_value(&drv.env).await?,
+            Some(sa) => {
+                use crate::ser::Error as _;
+                let mut env = drv.env.clone();
+                let json = serde_json::to_string(&sa.attrs).map_err(|e| {
+                    W::Error::custom(std::format_args!("failed to encode structured attrs: {e}"))
+                })?;
+                env.insert(Bytes::from_static(b"__json"), Bytes::from(json));
+                writer.write_value(&env).await?;
+            }
+        }
         Ok(())
     }
 }
@@ -72,7 +89,15 @@ impl NixDeserialize for (StorePath, BasicDerivation) {
             let platform = reader.read_value().await?;
             let builder = reader.read_value().await?;
             let args = reader.read_value().await?;
-            let env = reader.read_value().await?;
+            let mut env: BTreeMap<Bytes, Bytes> = reader.read_value().await?;
+            // Mirror `StructuredAttrs::tryExtract`: pull `__json` out
+            // of env into the dedicated field so round-tripping is lossless.
+            let structured_attrs = env.remove(b"__json".as_slice()).and_then(|json_bytes| {
+                let json_str = std::str::from_utf8(&json_bytes).ok()?;
+                let attrs: serde_json::Map<String, serde_json::Value> =
+                    serde_json::from_str(json_str).ok()?;
+                Some(StructuredAttrs { attrs })
+            });
 
             Ok(Some((
                 drv_path,
@@ -84,7 +109,7 @@ impl NixDeserialize for (StorePath, BasicDerivation) {
                     builder,
                     args,
                     env,
-                    structured_attrs: None, // TODO: Read from wire protocol if present
+                    structured_attrs,
                 },
             )))
         } else {

--- a/harmonia-store-remote/Cargo.toml
+++ b/harmonia-store-remote/Cargo.toml
@@ -35,5 +35,9 @@ tracing = { workspace = true }
 # Metrics (optional but commonly used)
 prometheus = { workspace = true }
 
+[dev-dependencies]
+tempfile = { workspace = true }
+tokio    = { workspace = true, features = [ "macros", "rt-multi-thread", "time", "process" ] }
+
 [lints]
 workspace = true

--- a/harmonia-store-remote/src/client.rs
+++ b/harmonia-store-remote/src/client.rs
@@ -32,7 +32,8 @@ use harmonia_protocol::daemon_wire::types2::{
     BuildMode, CollectGarbageResponse, GCAction, KeyedBuildResult, QueryMissingResult,
 };
 use harmonia_protocol::daemon_wire::{
-    CLIENT_MAGIC, FramedWriter, IgnoredOne, SERVER_MAGIC, write_add_multiple_to_store_stream,
+    CLIENT_MAGIC, FramedWriter, IgnoredOne, IgnoredZero, SERVER_MAGIC,
+    write_add_multiple_to_store_stream,
 };
 use harmonia_protocol::de::{NixDeserialize, NixRead as _, NixReader, NixReaderBuilder};
 use harmonia_protocol::ser::{NixWrite, NixWriter, NixWriterBuilder};
@@ -694,7 +695,7 @@ where
         async move {
             self.writer.write_value(&Operation::EnsurePath).await?;
             self.writer.write_value(path).await?;
-            Ok(self.process_stderr())
+            Ok(self.process_stderr().map_ok(|_: IgnoredOne| ()))
         }
         .future_result()
         .fill_operation(Operation::EnsurePath)
@@ -707,7 +708,7 @@ where
         async move {
             self.writer.write_value(&Operation::AddTempRoot).await?;
             self.writer.write_value(path).await?;
-            Ok(self.process_stderr())
+            Ok(self.process_stderr().map_ok(|_: IgnoredOne| ()))
         }
         .future_result()
         .fill_operation(Operation::AddTempRoot)
@@ -720,7 +721,7 @@ where
         async move {
             self.writer.write_value(&Operation::AddIndirectRoot).await?;
             self.writer.write_value(path).await?;
-            Ok(self.process_stderr())
+            Ok(self.process_stderr().map_ok(|_: IgnoredOne| ()))
         }
         .future_result()
         .fill_operation(Operation::AddIndirectRoot)
@@ -750,6 +751,10 @@ where
             self.writer.write_value(paths_to_delete).await?;
             self.writer.write_value(&ignore_liveness).await?;
             self.writer.write_value(&max_freed).await?;
+            // obsolete fields the daemon still reads
+            self.writer.write_value(&IgnoredZero).await?;
+            self.writer.write_value(&IgnoredZero).await?;
+            self.writer.write_value(&IgnoredZero).await?;
             Ok(self.process_stderr())
         }
         .future_result()
@@ -804,7 +809,7 @@ where
     fn optimise_store(&mut self) -> impl ResultLog<Output = DaemonResult<()>> + Send + '_ {
         async move {
             self.writer.write_value(&Operation::OptimiseStore).await?;
-            Ok(self.process_stderr())
+            Ok(self.process_stderr().map_ok(|_: IgnoredOne| ()))
         }
         .future_result()
         .fill_operation(Operation::OptimiseStore)
@@ -834,7 +839,7 @@ where
             self.writer.write_value(&Operation::AddSignatures).await?;
             self.writer.write_value(path).await?;
             self.writer.write_value(&signatures).await?;
-            Ok(self.process_stderr())
+            Ok(self.process_stderr().map_ok(|_: IgnoredOne| ()))
         }
         .future_result()
         .fill_operation(Operation::AddSignatures)
@@ -902,6 +907,7 @@ where
             self.writer.flush().await?;
             Ok(ProcessStderr::new(&mut self.reader)
                 .stream()
+                .map_ok(|_: IgnoredOne| ())
                 .drive_result(async {
                     let mut source = source;
                     let mut framed = FramedWriter::new(&mut self.writer);

--- a/harmonia-store-remote/tests/nix_daemon.rs
+++ b/harmonia-store-remote/tests/nix_daemon.rs
@@ -1,0 +1,136 @@
+// SPDX-FileCopyrightText: 2025 Jörg Thalheim
+// SPDX-License-Identifier: EUPL-1.2 OR MIT
+//
+// Integration tests that talk to a real cppnix `nix-daemon` over a Unix
+// socket. These exist to catch wire-protocol mismatches between our client
+// and the C++ daemon that self-tests (client <-> our own server) cannot
+// detect.
+//
+// Regression test for https://github.com/nix-community/harmonia/issues/954:
+// several operations (AddTempRoot, EnsurePath, AddIndirectRoot, OptimiseStore,
+// AddSignatures, AddBuildLog) are followed by a trailing `1` on the wire that
+// the client used to leave unread. The stale word then desynced the *next*
+// request on the same connection. We only ever observed this when reusing a
+// connection, which is why the tests below always issue a second request.
+
+use std::path::PathBuf;
+use std::process::Stdio;
+use std::time::Duration;
+
+use harmonia_protocol::types::DaemonStore;
+use harmonia_store_core::store_path::{StoreDir, StorePath};
+use harmonia_store_remote::DaemonClient;
+use tokio::process::{Child, Command};
+use tokio::time::{sleep, timeout};
+
+type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
+
+struct NixDaemon {
+    _tmp: tempfile::TempDir,
+    child: Child,
+    socket: PathBuf,
+    store_dir: StoreDir,
+}
+
+impl Drop for NixDaemon {
+    fn drop(&mut self) {
+        let _ = self.child.start_kill();
+    }
+}
+
+async fn spawn_nix_daemon() -> Result<NixDaemon> {
+    // Canonicalise so the (typically short) macOS /var -> /private/var symlink
+    // does not push the socket path past sun_path's 104/108 byte limit.
+    let tmp = tempfile::tempdir()?;
+    let root = tmp.path().canonicalize()?;
+    let store_dir = root.join("store");
+    let state_dir = root.join("state");
+    let log_dir = state_dir.join("log");
+    let conf_dir = root.join("etc");
+    let socket = root.join("d.sock");
+    std::fs::create_dir_all(&store_dir)?;
+    std::fs::create_dir_all(&state_dir)?;
+    std::fs::create_dir_all(&log_dir)?;
+    std::fs::create_dir_all(&conf_dir)?;
+
+    let init = Command::new("nix-store")
+        .args([
+            "--init",
+            "--store",
+            &format!(
+                "local?store={}&state={}",
+                store_dir.display(),
+                state_dir.display()
+            ),
+        ])
+        .output()
+        .await?;
+    if !init.status.success() {
+        return Err(format!(
+            "nix-store --init failed: {}",
+            String::from_utf8_lossy(&init.stderr)
+        )
+        .into());
+    }
+
+    let child = Command::new("nix-daemon")
+        .env("NIX_STORE_DIR", &store_dir)
+        .env("NIX_STATE_DIR", &state_dir)
+        .env("NIX_LOG_DIR", &log_dir)
+        .env("NIX_CONF_DIR", &conf_dir)
+        .env("NIX_DAEMON_SOCKET_PATH", &socket)
+        .env_remove("NIX_REMOTE")
+        .stdin(Stdio::null())
+        .kill_on_drop(true)
+        .spawn()?;
+
+    // Wait for the socket to appear.
+    timeout(Duration::from_secs(30), async {
+        while !socket.exists() {
+            sleep(Duration::from_millis(50)).await;
+        }
+    })
+    .await
+    .map_err(|_| "timed out waiting for nix-daemon socket")?;
+
+    Ok(NixDaemon {
+        _tmp: tmp,
+        child,
+        socket,
+        store_dir: StoreDir::new(store_dir)?,
+    })
+}
+
+fn dummy_path() -> StorePath {
+    // Any syntactically valid store path will do; the daemon does not
+    // validate existence for AddTempRoot/IsValidPath.
+    StorePath::from_bytes(b"00000000000000000000000000000000-x").expect("valid store path")
+}
+
+/// Core regression scenario: an op that returns a trailing `1`, followed by a
+/// second op on the *same* connection. Before the fix the second call failed
+/// with "No discriminant in enum `RawLogMessageType` matches the value `1`".
+#[tokio::test]
+async fn add_temp_root_then_reuse_connection() -> Result<()> {
+    let daemon = spawn_nix_daemon().await?;
+    let mut client = DaemonClient::builder()
+        .set_store_dir(&daemon.store_dir)
+        .connect_unix(&daemon.socket)
+        .await?;
+
+    let path = dummy_path();
+
+    client.add_temp_root(&path).await?;
+    // Second request must still parse cleanly.
+    let valid = client.is_valid_path(&path).await?;
+    assert!(!valid, "dummy path should not be valid in fresh store");
+
+    // Exercise the other ops that share the same wire shape so we don't
+    // regress them individually.
+    client.add_temp_root(&path).await?;
+    client.add_temp_root(&path).await?;
+    client.optimise_store().await?;
+    let _ = client.is_valid_path(&path).await?;
+
+    Ok(())
+}


### PR DESCRIPTION
For several worker protocol operations (AddTempRoot, EnsurePath, AddIndirectRoot, OptimiseStore, AddSignatures, AddBuildLog) the C++ daemon writes a single `1` after STDERR_LAST. Our client typed these as returning `()`, so the word was left in the socket buffer and the next request on the same connection misparsed it as a RawLogMessageType, yielding "No discriminant in enum `RawLogMessageType` matches the value `1`". This never showed up in harmonia itself because the HTTP cache does not use these ops; only library users that reuse a DaemonClient hit it. Consume the value as IgnoredOne the same way build_paths already does.

While auditing the wire shapes against cppnix daemon.cc, also fix CollectGarbage to send the three obsolete zero fields the daemon still reads, and make BasicDerivation (de)serialisation round-trip structured_attrs via the `__json` env var so remote builds do not silently lose __structuredAttrs.

Add an integration test that spawns a real nix-daemon in a tempdir and issues add_temp_root followed by another op on the same connection, so a future regression is caught without a NixOS VM.

Fixes: https://github.com/nix-community/harmonia/issues/954