### PR TITLE
protocol: return Option<Realisation> from query_realisation

### DIFF
--- a/harmonia-daemon/src/server/mod.rs
+++ b/harmonia-daemon/src/server/mod.rs
@@ -1008,7 +1008,19 @@ where
             QueryRealisation(output_id) => {
                 let logs = store.query_realisation(&output_id);
                 let value = self.process_logs(logs).await?;
-                self.writer.write_value(&value).await?;
+                /*
+                ### Outputs
+                realisations :: [Set][se-Set] of [Realisation][se-Realisation]
+
+                The daemon protocol encodes this as a set, but Nix only ever
+                returns 0 or 1 entries, so the trait exposes it as Option.
+                */
+                if let Some(value) = value {
+                    self.writer.write_number(1).await?;
+                    self.writer.write_value(&value).await?;
+                } else {
+                    self.writer.write_number(0).await?;
+                }
             }
             AddMultipleToStore(req) => {
                 let builder = NixReader::builder()

--- a/harmonia-store-remote/src/client.rs
+++ b/harmonia-store-remote/src/client.rs
@@ -914,7 +914,13 @@ where
                 .write_value(&Operation::QueryRealisation)
                 .await?;
             self.writer.write_value(output_id).await?;
-            Ok(self.process_stderr())
+            Ok(self.process_stderr::<Vec<Realisation>>().map_ok(|mut r| {
+                if r.is_empty() {
+                    None
+                } else {
+                    Some(r.swap_remove(0))
+                }
+            }))
         }
         .future_result()
         .fill_operation(Operation::QueryRealisation)


### PR DESCRIPTION
The Nix daemon QueryRealisation op encodes its reply as a set on the wire, but the C++ implementation only ever returns 0 or 1 entries. Exposing this as BTreeSet<Realisation> in the DaemonStore trait was misleading and forced callers to handle a multi-result case that does not exist.

Change the trait, client and server to use Option<Realisation> instead. The client decodes the wire-level Vec and pops the single entry; the server writes a length-prefixed 0 or 1 to keep the wire format unchanged.

Ported from Nix.rs eaeaf61 ("fix(nixrs): QueryRealisation actually returns an option").