### PR TITLE
nar: zero-copy NAR streaming and serving-path CPU reductions

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,3 @@
+# Keep frame pointers so `perf record --call-graph fp` works without slow DWARF unwinding.
+[target.'cfg(not(target_arch = "x86"))']
+rustflags = [ "-Cforce-frame-pointers=yes" ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,8 @@ tokio = { version = "1", features = [
     "time",
     "net",
     "signal",
+    "process",
+    "test-util",
 ] }
 tokio-util = "0.7"
 toml = "1.1"

--- a/harmonia-bench/benches/http_download.rs
+++ b/harmonia-bench/benches/http_download.rs
@@ -6,6 +6,98 @@ use std::time::{Duration, Instant};
 use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
 use tokio::net::TcpStream;
 
+/// Scratch buffer for draining response bodies. Large enough to amortise
+/// per-read syscall overhead while staying well inside L2.
+const DRAIN_BUF: usize = 64 * 1024;
+
+/// A persistent HTTP/1.1 keep-alive connection.
+///
+/// Response bodies are drained into a fixed scratch buffer rather than
+/// accumulated, so the client side contributes only socket reads to the
+/// measured wall-clock and the benchmark reflects server throughput.
+struct Conn {
+    reader: BufReader<TcpStream>,
+    host: String,
+    drain: Box<[u8; DRAIN_BUF]>,
+}
+
+impl Conn {
+    async fn connect(addr: &str) -> Self {
+        let stream = TcpStream::connect(addr).await.expect("connect failed");
+        stream.set_nodelay(true).ok();
+        Self {
+            reader: BufReader::new(stream),
+            host: addr.to_string(),
+            drain: Box::new([0u8; DRAIN_BUF]),
+        }
+    }
+
+    /// Issue a GET and parse status + Content-Length, leaving the body unread.
+    async fn get_head(&mut self, path: &str) -> (u16, u64) {
+        let request = format!(
+            "GET {} HTTP/1.1\r\nHost: {}\r\nConnection: keep-alive\r\n\r\n",
+            path, self.host
+        );
+        self.reader
+            .get_mut()
+            .write_all(request.as_bytes())
+            .await
+            .expect("write failed");
+
+        let mut status_line = String::new();
+        self.reader
+            .read_line(&mut status_line)
+            .await
+            .expect("read status");
+        let status: u16 = status_line
+            .split_whitespace()
+            .nth(1)
+            .and_then(|s| s.parse().ok())
+            .expect("bad status line");
+
+        let mut content_length: u64 = 0;
+        loop {
+            let mut line = String::new();
+            self.reader.read_line(&mut line).await.expect("read header");
+            if line == "\r\n" || line == "\n" {
+                break;
+            }
+            if let Some(val) = line
+                .strip_prefix("Content-Length: ")
+                .or_else(|| line.strip_prefix("content-length: "))
+            {
+                content_length = val.trim().parse().expect("bad content-length");
+            }
+        }
+        (status, content_length)
+    }
+
+    /// GET `path` and return the full body (for small responses like narinfo).
+    async fn get_body(&mut self, path: &str) -> (u16, Vec<u8>) {
+        let (status, len) = self.get_head(path).await;
+        let mut body = vec![0u8; len as usize];
+        self.reader.read_exact(&mut body).await.expect("read body");
+        (status, body)
+    }
+
+    /// GET `path` and discard the body, returning the number of bytes drained.
+    async fn get_drain(&mut self, path: &str) -> (u16, u64) {
+        let (status, len) = self.get_head(path).await;
+        let mut remaining = len;
+        while remaining > 0 {
+            let want = remaining.min(DRAIN_BUF as u64) as usize;
+            let n = self
+                .reader
+                .read(&mut self.drain[..want])
+                .await
+                .expect("read body");
+            assert!(n > 0, "unexpected EOF with {} bytes remaining", remaining);
+            remaining -= n as u64;
+        }
+        (status, len)
+    }
+}
+
 /// Get all store paths in the closure of a path.
 fn get_closure_paths(store_path: &str) -> Vec<String> {
     let output = Command::new("nix")
@@ -43,63 +135,9 @@ struct NarInfo {
     nar_size: u64,
 }
 
-/// Send an HTTP/1.1 GET request and return (status_code, headers, body_bytes).
-async fn http_get(addr: &str, path: &str) -> (u16, Vec<u8>) {
-    let mut stream = TcpStream::connect(addr).await.expect("connect failed");
-    let request = format!(
-        "GET {} HTTP/1.1\r\nHost: {}\r\nConnection: close\r\n\r\n",
-        path, addr
-    );
-    stream
-        .write_all(request.as_bytes())
-        .await
-        .expect("write failed");
-
-    let mut reader = BufReader::new(stream);
-
-    // Parse status line
-    let mut status_line = String::new();
-    reader
-        .read_line(&mut status_line)
-        .await
-        .expect("read status");
-    let status_code: u16 = status_line
-        .split_whitespace()
-        .nth(1)
-        .and_then(|s| s.parse().ok())
-        .expect("bad status line");
-
-    // Parse headers
-    let mut content_length: Option<u64> = None;
-    loop {
-        let mut line = String::new();
-        reader.read_line(&mut line).await.expect("read header");
-        if line == "\r\n" || line == "\n" {
-            break;
-        }
-        if let Some(val) = line
-            .strip_prefix("Content-Length: ")
-            .or_else(|| line.strip_prefix("content-length: "))
-        {
-            content_length = val.trim().parse().ok();
-        }
-    }
-
-    // Read body
-    let mut body = Vec::new();
-    if let Some(len) = content_length {
-        body.resize(len as usize, 0);
-        reader.read_exact(&mut body).await.expect("read body");
-    } else {
-        reader.read_to_end(&mut body).await.expect("read body");
-    }
-
-    (status_code, body)
-}
-
-async fn fetch_narinfo(addr: &str, hash: &str) -> NarInfo {
+async fn fetch_narinfo(conn: &mut Conn, hash: &str) -> NarInfo {
     let path = format!("/{}.narinfo", hash);
-    let (status, body) = http_get(addr, &path).await;
+    let (status, body) = conn.get_body(&path).await;
     assert!(
         (200..300).contains(&status),
         "narinfo {}: status {}",
@@ -125,16 +163,16 @@ async fn fetch_narinfo(addr: &str, hash: &str) -> NarInfo {
     }
 }
 
-async fn download_nar(addr: &str, nar_url: &str) -> u64 {
+async fn download_nar(conn: &mut Conn, nar_url: &str) -> u64 {
     let path = format!("/{}", nar_url);
-    let (status, body) = http_get(addr, &path).await;
+    let (status, len) = conn.get_drain(&path).await;
     assert!(
         (200..300).contains(&status),
         "NAR {}: status {}",
         path,
         status
     );
-    body.len() as u64
+    len
 }
 
 fn benchmark_http_download(c: &mut Criterion) {
@@ -151,10 +189,11 @@ fn benchmark_http_download(c: &mut Criterion) {
 
     // Pre-fetch all narinfos
     let narinfos: Vec<(String, NarInfo)> = rt.block_on(async {
+        let mut conn = Conn::connect(&addr).await;
         let mut results = Vec::new();
         for path in &paths {
             let hash = store_path_hash(path);
-            let narinfo = fetch_narinfo(&addr, &hash).await;
+            let narinfo = fetch_narinfo(&mut conn, &hash).await;
             results.push((path.clone(), narinfo));
         }
         results
@@ -172,13 +211,16 @@ fn benchmark_http_download(c: &mut Criterion) {
     group.measurement_time(Duration::from_secs(5));
 
     group.bench_function("sequential", |b| {
+        // One persistent connection reused across all iterations so we measure
+        // server-side NAR throughput, not TCP handshake latency.
+        let mut conn = rt.block_on(Conn::connect(&addr));
         b.iter_custom(|iters| {
             let mut total = Duration::ZERO;
             for _ in 0..iters {
                 let start = Instant::now();
                 rt.block_on(async {
                     for (_, narinfo) in &narinfos {
-                        download_nar(&addr, &narinfo.url).await;
+                        download_nar(&mut conn, &narinfo.url).await;
                     }
                 });
                 total += start.elapsed();
@@ -187,6 +229,9 @@ fn benchmark_http_download(c: &mut Criterion) {
         })
     });
 
+    let nar_urls: std::sync::Arc<Vec<String>> =
+        std::sync::Arc::new(narinfos.iter().map(|(_, ni)| ni.url.clone()).collect());
+
     for concurrency in [4, 16] {
         group.bench_function(format!("concurrent_{}", concurrency), |b| {
             b.iter_custom(|iters| {
@@ -194,17 +239,24 @@ fn benchmark_http_download(c: &mut Criterion) {
                 for _ in 0..iters {
                     let start = Instant::now();
                     rt.block_on(async {
-                        let semaphore =
-                            std::sync::Arc::new(tokio::sync::Semaphore::new(concurrency));
-                        let mut handles = Vec::new();
-
-                        for (_, narinfo) in &narinfos {
+                        // One persistent connection per worker. NAR sizes are
+                        // heavily skewed, so workers pull from a shared atomic
+                        // cursor to stay busy until the queue drains.
+                        let next = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+                        let mut handles = Vec::with_capacity(concurrency);
+                        for _ in 0..concurrency {
                             let addr = addr.clone();
-                            let nar_url = narinfo.url.clone();
-                            let sem = semaphore.clone();
+                            let urls = nar_urls.clone();
+                            let next = next.clone();
                             handles.push(tokio::spawn(async move {
-                                let _permit = sem.acquire().await.unwrap();
-                                download_nar(&addr, &nar_url).await
+                                let mut conn = Conn::connect(&addr).await;
+                                let mut bytes = 0u64;
+                                loop {
+                                    let i = next.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                                    let Some(url) = urls.get(i) else { break };
+                                    bytes += download_nar(&mut conn, url).await;
+                                }
+                                bytes
                             }));
                         }
                         for handle in handles {

--- a/harmonia-cache/src/main.rs
+++ b/harmonia-cache/src/main.rs
@@ -192,6 +192,10 @@ async fn inner_main() -> Result<()> {
     })
     // default is 5 seconds, which is too small when doing mass requests on slow machines
     .client_request_timeout(Duration::from_secs(30))
+    // Disable Nagle so the short trailing chunk at the end of each response is
+    // sent immediately instead of waiting for a delayed ACK; on keep-alive
+    // connections that wait would otherwise serialize onto every request.
+    .tcp_nodelay(true)
     .workers(c.workers)
     .max_connection_rate(c.max_connection_rate);
 

--- a/harmonia-nar/src/archive/byte_stream.rs
+++ b/harmonia-nar/src/archive/byte_stream.rs
@@ -7,7 +7,7 @@ use bytes::{BufMut, Bytes, BytesMut};
 use futures_core::Stream;
 
 use super::NarEvent;
-use super::dumper::{DumpOptions, DumpedFile, NarDumper};
+use super::dumper::{DumpOptions, NarDumper};
 use super::read_nar::{
     TOK_DIR, TOK_ENTRY, TOK_FILE, TOK_FILE_E, TOK_NODE, TOK_PAR, TOK_ROOT, TOK_SYM,
 };
@@ -29,11 +29,6 @@ const FILE_CHUNK_SIZE: usize = 256 * 1024;
 enum Phase {
     /// Pull the next [`NarEvent`] from the dumper and encode framing.
     Event,
-    /// Waiting for a file's open/read/mmap to complete on the blocking pool.
-    Load {
-        file: DumpedFile,
-        size: u64,
-    },
     /// Yield file content (possibly in multiple slices), then append the
     /// trailing padding/`)` tokens to `frame` and go back to [`Phase::Event`].
     Emit {
@@ -47,10 +42,10 @@ enum Phase {
 ///
 /// Drives a [`NarDumper`] directly and emits the NAR wire format without
 /// intermediate copies: framing tokens are accumulated in a small reusable
-/// buffer, and file payloads are forwarded as the original `Bytes` obtained
-/// from [`DumpedFile::poll_bytes`] (heap buffer for small files, mmap-backed
-/// for large ones). The only per-byte copy on the serving path is the one the
-/// HTTP layer performs into its socket write buffer.
+/// buffer, and file payloads are forwarded as the `Bytes` already loaded by
+/// the dumper (heap buffer for small files, mmap-backed for large ones). The
+/// only per-byte copy on the serving path is the one the HTTP layer performs
+/// into its socket write buffer.
 pub struct NarByteStream {
     dumper: NarDumper,
     /// Scratch buffer for NAR structure tokens between file payloads.
@@ -143,7 +138,10 @@ impl Stream for NarByteStream {
                                         TOK_FILE
                                     });
                                     this.frame.put_u64_le(size);
-                                    this.phase = Phase::Load { file: reader, size };
+                                    this.phase = Phase::Emit {
+                                        data: reader.into_bytes(),
+                                        size,
+                                    };
                                     // Flush framing now so file bytes follow
                                     // immediately without being copied into
                                     // the frame buffer.
@@ -161,11 +159,6 @@ impl Stream for NarByteStream {
                             }
                         }
                     }
-                }
-                Phase::Load { file, size } => {
-                    let data = ready!(Pin::new(file).poll_bytes(cx))?;
-                    let size = *size;
-                    this.phase = Phase::Emit { data, size };
                 }
                 Phase::Emit { data, size } => {
                     if !data.is_empty() {

--- a/harmonia-nar/src/archive/byte_stream.rs
+++ b/harmonia-nar/src/archive/byte_stream.rs
@@ -3,149 +3,235 @@ use std::path::PathBuf;
 use std::pin::Pin;
 use std::task::{Context, Poll, ready};
 
-use bytes::{Bytes, BytesMut};
+use bytes::{BufMut, Bytes, BytesMut};
 use futures_core::Stream;
-use futures_util::{SinkExt, StreamExt};
-use tokio::io::AsyncWrite;
-use tokio::sync::mpsc;
-use tokio_util::sync::PollSender;
 
-use super::dumper::DumpOptions;
-use super::writer::NarWriter;
+use super::NarEvent;
+use super::dumper::{DumpOptions, DumpedFile, NarDumper};
+use super::read_nar::{
+    TOK_DIR, TOK_ENTRY, TOK_FILE, TOK_FILE_E, TOK_NODE, TOK_PAR, TOK_ROOT, TOK_SYM,
+};
+use crate::wire::calc_padding;
 
-/// Default chunk size for yielded Bytes (64 KiB).
-const DEFAULT_CHUNK_SIZE: usize = 64 * 1024;
+/// Flush accumulated framing once it exceeds this many bytes so a long run of
+/// tiny entries (symlinks, empty dirs) does not buffer unbounded amounts of
+/// metadata before yielding to the consumer.
+const FRAME_FLUSH_THRESHOLD: usize = 32 * 1024;
 
-/// Number of Bytes chunks to buffer in the channel.
-/// Provides pipelining: the NAR encoder can work ahead while the HTTP layer
-/// is sending previous chunks, without unbounded memory growth.
-const CHANNEL_CAPACITY: usize = 4;
-
-/// An [`AsyncWrite`] that collects bytes into [`Bytes`] chunks and sends them
-/// through a bounded mpsc channel via [`PollSender`].
+/// Max size of a single file-content chunk yielded downstream.
 ///
-/// When the internal buffer reaches `chunk_size`, it is frozen into a
-/// [`Bytes`] and sent through the channel. If the channel is full,
-/// `poll_write` returns [`Poll::Pending`] until the consumer drains a slot,
-/// providing natural back-pressure.
-struct ChannelWriter {
-    sender: PollSender<Bytes>,
-    buffer: BytesMut,
-    chunk_size: usize,
+/// Large mmap'd files are sliced into pieces of this size so the HTTP layer
+/// can interleave socket writes with further NAR encoding work and so a slow
+/// client does not pin a multi-GiB `Bytes` in actix's write buffer at once.
+/// Slicing a `Bytes` is just a refcount bump — no copy.
+const FILE_CHUNK_SIZE: usize = 256 * 1024;
+
+enum Phase {
+    /// Pull the next [`NarEvent`] from the dumper and encode framing.
+    Event,
+    /// Waiting for a file's open/read/mmap to complete on the blocking pool.
+    Load {
+        file: DumpedFile,
+        size: u64,
+    },
+    /// Yield file content (possibly in multiple slices), then append the
+    /// trailing padding/`)` tokens to `frame` and go back to [`Phase::Event`].
+    Emit {
+        data: Bytes,
+        size: u64,
+    },
+    Done,
 }
 
-impl ChannelWriter {
-    fn new(sender: PollSender<Bytes>, chunk_size: usize) -> Self {
-        Self {
-            sender,
-            buffer: BytesMut::with_capacity(chunk_size),
-            chunk_size,
-        }
-    }
-
-    /// Try to send the current buffer contents as a chunk.
-    /// Returns `Poll::Pending` if the channel is full (back-pressure).
-    fn poll_emit_chunk(&mut self, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
-        if self.buffer.is_empty() {
-            return Poll::Ready(Ok(()));
-        }
-
-        // Reserve a slot in the channel before sending.
-        ready!(self.sender.poll_reserve(cx))
-            .map_err(|_| io::Error::new(io::ErrorKind::BrokenPipe, "channel closed"))?;
-
-        let chunk = std::mem::replace(&mut self.buffer, BytesMut::with_capacity(self.chunk_size));
-        self.sender
-            .send_item(chunk.freeze())
-            .map_err(|_| io::Error::new(io::ErrorKind::BrokenPipe, "channel closed"))?;
-
-        Poll::Ready(Ok(()))
-    }
-}
-
-impl AsyncWrite for ChannelWriter {
-    fn poll_write(
-        mut self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
-        buf: &[u8],
-    ) -> Poll<io::Result<usize>> {
-        // If the buffer is already full, flush it first (may return Pending).
-        if self.buffer.len() >= self.chunk_size {
-            ready!(self.poll_emit_chunk(cx))?;
-        }
-
-        let n = buf.len().min(self.chunk_size - self.buffer.len());
-        self.buffer.extend_from_slice(&buf[..n]);
-        Poll::Ready(Ok(n))
-    }
-
-    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
-        ready!(self.poll_emit_chunk(cx))?;
-        Poll::Ready(Ok(()))
-    }
-
-    fn poll_shutdown(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
-        ready!(self.poll_emit_chunk(cx))?;
-        Poll::Ready(Ok(()))
-    }
-}
-
-/// A [`Stream`] of [`Bytes`] chunks containing NAR-encoded data.
+/// A [`Stream`] of [`Bytes`] chunks containing NAR-encoded data for a path.
 ///
-/// Spawns a background task that walks the filesystem and encodes the NAR
-/// wire format, sending `Bytes` chunks through a bounded mpsc channel. This
-/// provides natural pipelining: the encoder runs concurrently with the HTTP
-/// send path, while back-pressure from the channel prevents unbounded memory
-/// growth for large store paths.
+/// Drives a [`NarDumper`] directly and emits the NAR wire format without
+/// intermediate copies: framing tokens are accumulated in a small reusable
+/// buffer, and file payloads are forwarded as the original `Bytes` obtained
+/// from [`DumpedFile::poll_bytes`] (heap buffer for small files, mmap-backed
+/// for large ones). The only per-byte copy on the serving path is the one the
+/// HTTP layer performs into its socket write buffer.
 pub struct NarByteStream {
-    rx: mpsc::Receiver<Bytes>,
+    dumper: NarDumper,
+    /// Scratch buffer for NAR structure tokens between file payloads.
+    frame: BytesMut,
+    /// Directory nesting depth, mirroring [`NarWriter`]'s `level` so the
+    /// emitted token sequence is byte-identical.
+    level: u32,
+    phase: Phase,
 }
 
 impl NarByteStream {
     /// Create a new `NarByteStream` for the given filesystem path.
     pub fn new(path: PathBuf) -> Self {
-        Self::with_chunk_size(path, DEFAULT_CHUNK_SIZE)
+        Self {
+            dumper: DumpOptions::new().dump(path),
+            frame: BytesMut::with_capacity(FRAME_FLUSH_THRESHOLD),
+            level: 0,
+            phase: Phase::Event,
+        }
     }
 
-    /// Create a new `NarByteStream` with a custom output chunk size.
-    pub fn with_chunk_size(path: PathBuf, chunk_size: usize) -> Self {
-        let (tx, rx) = mpsc::channel(CHANNEL_CAPACITY);
-        let sender = PollSender::new(tx);
-
-        tokio::task::spawn(async move {
-            let writer = ChannelWriter::new(sender, chunk_size);
-            let mut nar_writer = NarWriter::new(writer);
-            let events = DumpOptions::new().dump(path);
-
-            futures_util::pin_mut!(events);
-            while let Some(event_result) = events.next().await {
-                match event_result {
-                    Ok(event) => {
-                        if let Err(e) = nar_writer.send(event).await {
-                            tracing::error!("Error writing NAR event: {}", e);
-                            return;
-                        }
-                    }
-                    Err(e) => {
-                        tracing::error!("Error reading path for NAR dump: {}", e);
-                        return;
-                    }
-                }
-            }
-
-            if let Err(e) = nar_writer.close().await {
-                tracing::error!("Error closing NAR writer: {}", e);
-            }
-        });
-
-        Self { rx }
+    /// Append the entry-prefix tokens that precede every non-root node.
+    fn put_entry_header(frame: &mut BytesMut, name: &[u8]) {
+        frame.put_slice(TOK_ENTRY);
+        put_nix_slice(frame, name);
+        frame.put_slice(TOK_NODE);
     }
+}
+
+fn put_nix_slice(buf: &mut BytesMut, src: &[u8]) {
+    buf.put_u64_le(src.len() as u64);
+    buf.put_slice(src);
+    buf.put_bytes(0, calc_padding(src.len() as u64));
 }
 
 impl Stream for NarByteStream {
     type Item = io::Result<Bytes>;
 
-    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        self.rx.poll_recv(cx).map(|opt| opt.map(Ok))
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let this = self.get_mut();
+        loop {
+            match &mut this.phase {
+                Phase::Event => {
+                    if this.frame.len() >= FRAME_FLUSH_THRESHOLD {
+                        return Poll::Ready(Some(Ok(this.frame.split().freeze())));
+                    }
+                    match ready!(Pin::new(&mut this.dumper).poll_next(cx)) {
+                        Some(Ok(event)) => {
+                            if this.level == 0 {
+                                this.frame.put_slice(TOK_ROOT);
+                            }
+                            match event {
+                                NarEvent::StartDirectory { name } => {
+                                    if this.level > 0 {
+                                        Self::put_entry_header(&mut this.frame, &name);
+                                    }
+                                    this.frame.put_slice(TOK_DIR);
+                                    this.level += 1;
+                                }
+                                NarEvent::EndDirectory => {
+                                    this.frame.put_slice(TOK_PAR);
+                                    this.level -= 1;
+                                    if this.level > 0 {
+                                        this.frame.put_slice(TOK_PAR);
+                                    }
+                                }
+                                NarEvent::Symlink { name, target } => {
+                                    if this.level > 0 {
+                                        Self::put_entry_header(&mut this.frame, &name);
+                                    }
+                                    this.frame.put_slice(TOK_SYM);
+                                    put_nix_slice(&mut this.frame, &target);
+                                    this.frame.put_slice(TOK_PAR);
+                                    if this.level > 0 {
+                                        this.frame.put_slice(TOK_PAR);
+                                    }
+                                }
+                                NarEvent::File {
+                                    name,
+                                    executable,
+                                    size,
+                                    reader,
+                                } => {
+                                    if this.level > 0 {
+                                        Self::put_entry_header(&mut this.frame, &name);
+                                    }
+                                    this.frame.put_slice(if executable {
+                                        TOK_FILE_E
+                                    } else {
+                                        TOK_FILE
+                                    });
+                                    this.frame.put_u64_le(size);
+                                    this.phase = Phase::Load { file: reader, size };
+                                    // Flush framing now so file bytes follow
+                                    // immediately without being copied into
+                                    // the frame buffer.
+                                    if !this.frame.is_empty() {
+                                        return Poll::Ready(Some(Ok(this.frame.split().freeze())));
+                                    }
+                                }
+                            }
+                        }
+                        Some(Err(e)) => return Poll::Ready(Some(Err(e))),
+                        None => {
+                            this.phase = Phase::Done;
+                            if !this.frame.is_empty() {
+                                return Poll::Ready(Some(Ok(this.frame.split().freeze())));
+                            }
+                        }
+                    }
+                }
+                Phase::Load { file, size } => {
+                    let data = ready!(Pin::new(file).poll_bytes(cx))?;
+                    let size = *size;
+                    this.phase = Phase::Emit { data, size };
+                }
+                Phase::Emit { data, size } => {
+                    if !data.is_empty() {
+                        let n = data.len().min(FILE_CHUNK_SIZE);
+                        let chunk = data.split_to(n);
+                        return Poll::Ready(Some(Ok(chunk)));
+                    }
+                    // File fully emitted; append trailer and resume framing.
+                    this.frame.put_bytes(0, calc_padding(*size));
+                    this.frame.put_slice(TOK_PAR);
+                    if this.level > 0 {
+                        this.frame.put_slice(TOK_PAR);
+                    }
+                    this.phase = Phase::Event;
+                }
+                Phase::Done => return Poll::Ready(None),
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::archive::test_data;
+    use crate::archive::write_nar;
+    use futures_util::StreamExt as _;
+
+    async fn collect(path: PathBuf) -> Vec<u8> {
+        let mut s = NarByteStream::new(path);
+        let mut out = Vec::new();
+        while let Some(chunk) = s.next().await {
+            out.extend_from_slice(&chunk.unwrap());
+        }
+        out
+    }
+
+    /// The zero-copy byte stream must produce the exact same bytes as the
+    /// reference [`NarWriter`] for every test fixture.
+    #[tokio::test]
+    async fn byte_stream_matches_nar_writer() {
+        let dir = tempfile::Builder::new()
+            .prefix("nar_byte_stream")
+            .tempdir()
+            .unwrap();
+        let path = dir.path().join("nar");
+        // `NarByteStream::new` uses the platform default for case-hack
+        // (enabled on macOS, disabled elsewhere); the on-disk fixture must be
+        // created with the matching flag so the case-colliding `Deep`/`deep`
+        // pair round-trips on case-insensitive filesystems.
+        let case_hack = cfg!(target_os = "macos");
+        test_data::create_dir_example(&path, case_hack).unwrap();
+
+        let got = collect(path.clone()).await;
+        let want = write_nar(test_data::dir_example().iter());
+        assert_eq!(got, want.to_vec());
+    }
+
+    #[tokio::test]
+    async fn byte_stream_single_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("hello.txt");
+        std::fs::write(&path, b"Hello world!").unwrap();
+
+        let got = collect(path).await;
+        let want = write_nar(test_data::text_file().iter());
+        assert_eq!(got, want.to_vec());
     }
 }

--- a/harmonia-nar/src/archive/dumper.rs
+++ b/harmonia-nar/src/archive/dumper.rs
@@ -53,21 +53,19 @@ impl DumpOptions {
 
     pub fn dump<P: Into<PathBuf>>(self, path: P) -> NarDumper {
         let root = path.into();
-        let dir = root.clone();
         let mut walker = walkdir::WalkDir::new(&root)
             .follow_links(false)
             .follow_root_links(false);
         walker = if self.use_case_hack {
             walker.sort_by(sort_case_hack)
         } else {
-            walker.sort_by_file_name()
+            walker.sort_by(|a, b| fast_file_name(a.path()).cmp(fast_file_name(b.path())))
         };
         let walker = walker.into_iter();
         NarDumper {
             state: State::Idle(Some((VecDeque::with_capacity(CHUNK_SIZE), walker, true))),
             next: None,
             level: 0,
-            dir,
             use_case_hack: self.use_case_hack,
             semaphore: Arc::new(Semaphore::new(self.max_open_files)),
         }
@@ -84,6 +82,21 @@ pub fn dump<P: Into<PathBuf>>(
     path: P,
 ) -> impl Stream<Item = io::Result<NarEvent<impl AsyncBufRead>>> {
     DumpOptions::new().dump(path)
+}
+
+/// Return the final path segment as raw bytes.
+///
+/// Uses a byte-level search instead of `Path::file_name`, which performs a
+/// full `Components` parse on every call. This is safe because walkdir builds
+/// entry paths as `parent.join(file_name)`, so on Unix the segment after the
+/// last `/` is exactly the file name with no `.`/`..` to normalise.
+#[cfg(unix)]
+fn fast_file_name(p: &Path) -> &[u8] {
+    let b = p.as_os_str().as_bytes();
+    match b.rfind_byte(b'/') {
+        Some(i) => &b[i + 1..],
+        None => b,
+    }
 }
 
 fn sort_case_hack(left: &DirEntry, right: &DirEntry) -> Ordering {
@@ -248,15 +261,18 @@ impl AsyncRead for DumpedFile {
 #[derive(Debug)]
 enum Entry {
     File {
+        depth: usize,
         path: PathBuf,
         size: u64,
         executable: bool,
     },
     Symlink {
+        depth: usize,
         path: PathBuf,
         target: PathBuf,
     },
     Directory {
+        depth: usize,
         path: PathBuf,
     },
 }
@@ -264,13 +280,17 @@ enum Entry {
 impl Entry {
     fn path(&self) -> &Path {
         match self {
-            Entry::File {
-                path,
-                size: _,
-                executable: _,
-            } => path,
-            Entry::Symlink { path, target: _ } => path,
-            Entry::Directory { path } => path,
+            Entry::File { path, .. } => path,
+            Entry::Symlink { path, .. } => path,
+            Entry::Directory { path, .. } => path,
+        }
+    }
+
+    fn depth(&self) -> usize {
+        match self {
+            Entry::File { depth, .. } => *depth,
+            Entry::Symlink { depth, .. } => *depth,
+            Entry::Directory { depth, .. } => *depth,
         }
     }
 }
@@ -311,9 +331,11 @@ impl State {
             match iter.next() {
                 Some(res) => {
                     let res = res.map_err(io::Error::from).and_then(|entry| {
+                        let depth = entry.depth();
                         let m = entry.metadata()?;
                         if m.is_dir() {
                             Ok(Entry::Directory {
+                                depth,
                                 path: entry.into_path(),
                             })
                         } else if m.is_file() {
@@ -328,6 +350,7 @@ impl State {
                                 executable = false;
                             }
                             Ok(Entry::File {
+                                depth,
                                 path: entry.into_path(),
                                 size: m.len(),
                                 executable,
@@ -335,6 +358,7 @@ impl State {
                         } else if m.is_symlink() {
                             let target = read_link(entry.path())?;
                             Ok(Entry::Symlink {
+                                depth,
                                 path: entry.into_path(),
                                 target,
                             })
@@ -358,7 +382,6 @@ pub struct NarDumper {
     state: State,
     next: Option<Entry>,
     level: u32,
-    dir: PathBuf,
     semaphore: Arc<Semaphore>,
     use_case_hack: bool,
 }
@@ -389,20 +412,18 @@ impl Stream for NarDumper {
         cx: &mut std::task::Context<'_>,
     ) -> Poll<Option<Self::Item>> {
         loop {
+            // Close directories until the pending entry is at the current
+            // nesting level. walkdir's `depth()` gives this directly, so no
+            // path comparison is needed.
             if let Some(entry) = self.next.as_ref()
-                && !entry.path().starts_with(&self.dir)
+                && entry.depth() < self.level as usize
             {
-                self.dir.pop();
                 self.level -= 1;
                 return Poll::Ready(Some(Ok(NarEvent::EndDirectory)));
             }
             if let Some(entry) = self.next.take() {
                 let name = if self.level > 0 {
-                    let filename = entry.path().file_name().unwrap();
-                    let n = <[u8]>::from_os_str(filename).ok_or_else(|| {
-                        io::Error::other(format!("filename {filename:?} not valid UTF-8"))
-                    })?;
-                    let mut name = Bytes::copy_from_slice(n);
+                    let mut name = Bytes::copy_from_slice(fast_file_name(entry.path()));
                     if self.use_case_hack {
                         remove_case_hack(&mut name);
                     }
@@ -411,8 +432,7 @@ impl Stream for NarDumper {
                     Bytes::new()
                 };
                 let event = match entry {
-                    Entry::Directory { path } => {
-                        self.dir = path;
+                    Entry::Directory { path: _, .. } => {
                         self.level += 1;
                         NarEvent::StartDirectory { name }
                     }
@@ -420,6 +440,7 @@ impl Stream for NarDumper {
                         path,
                         size,
                         executable,
+                        ..
                     } => {
                         let reader =
                             BufReader::new(DumpedFile::new(path, size, self.semaphore.clone()));
@@ -430,7 +451,7 @@ impl Stream for NarDumper {
                             reader,
                         }
                     }
-                    Entry::Symlink { path: _, target } => {
+                    Entry::Symlink { target, .. } => {
                         let target = Vec::from_os_string(target.into_os_string())
                             .map_err(|target_s| {
                                 io::Error::other(format!("target {target_s:?} not valid UTF-8"))
@@ -449,7 +470,6 @@ impl Stream for NarDumper {
                 Some(Err(err)) => return Poll::Ready(Some(Err(err))),
                 None => {
                     if self.level > 0 {
-                        self.dir.pop();
                         self.level -= 1;
                         return Poll::Ready(Some(Ok(NarEvent::EndDirectory)));
                     }

--- a/harmonia-nar/src/archive/dumper.rs
+++ b/harmonia-nar/src/archive/dumper.rs
@@ -4,13 +4,15 @@ use std::fs::read_link;
 use std::future::Future as _;
 use std::os::unix::ffi::OsStrExt;
 #[cfg(unix)]
+use std::os::unix::ffi::OsStringExt;
+#[cfg(unix)]
 use std::os::unix::fs::PermissionsExt as _;
 use std::path::{Path, PathBuf};
 use std::pin::Pin;
 use std::task::{Context, Poll, ready};
 use std::{collections::VecDeque, io};
 
-use bstr::{ByteSlice as _, ByteVec as _};
+use bstr::ByteSlice as _;
 use bytes::Bytes;
 use futures_core::Stream;
 use tokio::io::AsyncRead;
@@ -50,10 +52,14 @@ impl DumpOptions {
         };
         let walker = walker.into_iter();
         NarDumper {
-            state: State::Idle(Some((VecDeque::with_capacity(CHUNK_SIZE), walker, true))),
+            state: State::Idle(Some(Box::new(BatchState {
+                buf: VecDeque::with_capacity(CHUNK_SIZE),
+                walker,
+                remain: true,
+                use_case_hack: self.use_case_hack,
+            }))),
             next: None,
             level: 0,
-            use_case_hack: self.use_case_hack,
         }
     }
 }
@@ -107,6 +113,28 @@ fn remove_case_hack(name: &mut Bytes) {
     }
 }
 
+/// Turn a walkdir entry into the NAR entry name.
+///
+/// The root node carries no name in the NAR format. For deeper entries the
+/// final path segment is copied into a fresh small `Bytes`; the entry's
+/// `PathBuf` is then dropped here on the blocking thread.
+fn entry_name(entry: DirEntry, use_case_hack: bool) -> Bytes {
+    if entry.depth() == 0 {
+        return Bytes::new();
+    }
+    let mut name = Bytes::copy_from_slice(fast_file_name(entry.path()));
+    if use_case_hack {
+        remove_case_hack(&mut name);
+    }
+    name
+}
+
+/// Convert an `OsString` (symlink target) into `Bytes` by moving its buffer.
+#[cfg(unix)]
+fn os_string_into_bytes(s: std::ffi::OsString) -> Bytes {
+    Bytes::from(s.into_vec())
+}
+
 use super::mmap::MappedFile;
 
 /// Files up to this size are read into a heap buffer; larger files are
@@ -116,9 +144,17 @@ const SMALL_FILE_THRESHOLD: u64 = 256 * 1024; // 256 KiB
 /// Load a file as a single `Bytes` value without intermediate copies:
 /// small files become `Bytes::from(Vec)`, large files become a refcounted
 /// view over the mmap via `Bytes::from_owner`.
+///
+/// `size` comes from the directory walk's `lstat`, so the small-file branch
+/// allocates exactly once at the right capacity instead of letting
+/// `std::fs::read` issue its own `fstat` to size the buffer.
 fn load_file_bytes(path: &Path, size: u64) -> io::Result<Bytes> {
     if size <= SMALL_FILE_THRESHOLD {
-        Ok(Bytes::from(std::fs::read(path)?))
+        use std::io::Read as _;
+        let mut f = std::fs::File::open(path)?;
+        let mut buf = Vec::with_capacity(size as usize);
+        f.read_to_end(&mut buf)?;
+        Ok(Bytes::from(buf))
     } else {
         Ok(Bytes::from_owner(MappedFile::open(path, size)?))
     }
@@ -160,34 +196,28 @@ impl AsyncRead for DumpedFile {
     }
 }
 
+/// A fully prepared directory entry: everything the async side needs to emit
+/// the corresponding [`NarEvent`] without touching the filesystem again.
 enum Entry {
     File {
         depth: usize,
-        path: PathBuf,
+        name: Bytes,
         size: u64,
         executable: bool,
         data: Bytes,
     },
     Symlink {
         depth: usize,
-        path: PathBuf,
-        target: PathBuf,
+        name: Bytes,
+        target: Bytes,
     },
     Directory {
         depth: usize,
-        path: PathBuf,
+        name: Bytes,
     },
 }
 
 impl Entry {
-    fn path(&self) -> &Path {
-        match self {
-            Entry::File { path, .. } => path,
-            Entry::Symlink { path, .. } => path,
-            Entry::Directory { path, .. } => path,
-        }
-    }
-
     fn depth(&self) -> usize {
         match self {
             Entry::File { depth, .. } => *depth,
@@ -197,10 +227,17 @@ impl Entry {
     }
 }
 
+struct BatchState {
+    buf: VecDeque<io::Result<Entry>>,
+    walker: IntoIter,
+    remain: bool,
+    use_case_hack: bool,
+}
+
 #[allow(clippy::large_enum_variant)]
 enum State {
-    Idle(Option<(VecDeque<io::Result<Entry>>, IntoIter, bool)>),
-    Pending(JoinHandle<(VecDeque<io::Result<Entry>>, IntoIter, bool)>),
+    Idle(Option<Box<BatchState>>),
+    Pending(JoinHandle<Box<BatchState>>),
 }
 
 const CHUNK_SIZE: usize = 25;
@@ -210,16 +247,17 @@ impl State {
         loop {
             match self {
                 State::Idle(data) => {
-                    let (buf, _, remain) = data.as_mut().unwrap();
-                    if let Some(entry) = buf.pop_front() {
+                    let st = data.as_mut().unwrap();
+                    if let Some(entry) = st.buf.pop_front() {
                         return Poll::Ready(Some(entry));
-                    } else if !*remain {
+                    } else if !st.remain {
                         return Poll::Ready(None);
                     }
-                    let (mut buf, mut walker, _) = data.take().unwrap();
-                    *self = State::Pending(spawn_blocking(|| {
-                        let remain = State::next_chunk(&mut buf, &mut walker);
-                        (buf, walker, remain)
+                    let mut st = data.take().unwrap();
+                    *self = State::Pending(spawn_blocking(move || {
+                        st.remain =
+                            State::next_chunk(&mut st.buf, &mut st.walker, st.use_case_hack);
+                        st
                     }));
                 }
                 State::Pending(handler) => {
@@ -228,56 +266,61 @@ impl State {
             }
         }
     }
-    fn next_chunk(buf: &mut VecDeque<io::Result<Entry>>, iter: &mut IntoIter) -> bool {
+    fn next_chunk(
+        buf: &mut VecDeque<io::Result<Entry>>,
+        iter: &mut IntoIter,
+        use_case_hack: bool,
+    ) -> bool {
         for _ in 0..CHUNK_SIZE {
             match iter.next() {
                 Some(res) => {
                     let res = res.map_err(io::Error::from).and_then(|entry| {
                         let depth = entry.depth();
-                        let m = entry.metadata()?;
-                        if m.is_dir() {
-                            Ok(Entry::Directory {
+                        // `file_type()` is cached from `readdir`'s `d_type`
+                        // and needs no syscall; only regular files require an
+                        // additional `lstat` for size and the exec bit.
+                        let ft = entry.file_type();
+                        let entry = if ft.is_dir() {
+                            Entry::Directory {
                                 depth,
-                                path: entry.into_path(),
-                            })
-                        } else if m.is_file() {
+                                name: entry_name(entry, use_case_hack),
+                            }
+                        } else if ft.is_file() {
+                            let m = entry.metadata()?;
                             let executable;
                             #[cfg(unix)]
                             {
-                                let mode = m.permissions().mode();
-                                executable = mode & 0o100 == 0o100;
+                                executable = m.permissions().mode() & 0o100 == 0o100;
                             }
                             #[cfg(not(unix))]
                             {
                                 executable = false;
                             }
                             let size = m.len();
-                            let path = entry.into_path();
                             // Load the content here, in the same blocking
                             // task that is already iterating the directory,
                             // so the async side receives ready-to-stream
                             // bytes without a second pool round-trip.
-                            let data = load_file_bytes(&path, size)?;
-                            Ok(Entry::File {
+                            let data = load_file_bytes(entry.path(), size)?;
+                            Entry::File {
                                 depth,
-                                path,
+                                name: entry_name(entry, use_case_hack),
                                 size,
                                 executable,
                                 data,
-                            })
-                        } else if m.is_symlink() {
-                            let target = read_link(entry.path())?;
-                            Ok(Entry::Symlink {
+                            }
+                        } else if ft.is_symlink() {
+                            let target =
+                                os_string_into_bytes(read_link(entry.path())?.into_os_string());
+                            Entry::Symlink {
                                 depth,
-                                path: entry.into_path(),
+                                name: entry_name(entry, use_case_hack),
                                 target,
-                            })
+                            }
                         } else {
-                            Err(io::Error::other(format!(
-                                "unsupported file type {:?}",
-                                m.file_type()
-                            )))
-                        }
+                            return Err(io::Error::other(format!("unsupported file type {ft:?}")));
+                        };
+                        Ok(entry)
                     });
                     buf.push_back(res);
                 }
@@ -292,7 +335,6 @@ pub struct NarDumper {
     state: State,
     next: Option<Entry>,
     level: u32,
-    use_case_hack: bool,
 }
 
 impl NarDumper {
@@ -322,43 +364,24 @@ impl Stream for NarDumper {
                 return Poll::Ready(Some(Ok(NarEvent::EndDirectory)));
             }
             if let Some(entry) = self.next.take() {
-                let name = if self.level > 0 {
-                    let mut name = Bytes::copy_from_slice(fast_file_name(entry.path()));
-                    if self.use_case_hack {
-                        remove_case_hack(&mut name);
-                    }
-                    name
-                } else {
-                    Bytes::new()
-                };
                 let event = match entry {
-                    Entry::Directory { path: _, .. } => {
+                    Entry::Directory { name, .. } => {
                         self.level += 1;
                         NarEvent::StartDirectory { name }
                     }
                     Entry::File {
+                        name,
                         size,
                         executable,
                         data,
                         ..
-                    } => {
-                        let reader = DumpedFile::new(data);
-                        NarEvent::File {
-                            name,
-                            executable,
-                            size,
-                            reader,
-                        }
-                    }
-                    Entry::Symlink { target, .. } => {
-                        let target = Vec::from_os_string(target.into_os_string())
-                            .map_err(|target_s| {
-                                io::Error::other(format!("target {target_s:?} not valid UTF-8"))
-                            })?
-                            .into();
-
-                        NarEvent::Symlink { name, target }
-                    }
+                    } => NarEvent::File {
+                        name,
+                        executable,
+                        size,
+                        reader: DumpedFile::new(data),
+                    },
+                    Entry::Symlink { name, target, .. } => NarEvent::Symlink { name, target },
                 };
                 return Poll::Ready(Some(Ok(event)));
             }

--- a/harmonia-nar/src/archive/dumper.rs
+++ b/harmonia-nar/src/archive/dumper.rs
@@ -15,7 +15,7 @@ use bstr::{ByteSlice as _, ByteVec as _};
 use bytes::Bytes;
 use futures_core::Stream;
 use pin_project_lite::pin_project;
-use tokio::io::{AsyncBufRead, AsyncRead, BufReader};
+use tokio::io::AsyncRead;
 use tokio::sync::{OwnedSemaphorePermit, Semaphore};
 use tokio::task::{JoinHandle, spawn_blocking};
 use tokio_util::sync::PollSemaphore;
@@ -78,9 +78,7 @@ impl Default for DumpOptions {
     }
 }
 
-pub fn dump<P: Into<PathBuf>>(
-    path: P,
-) -> impl Stream<Item = io::Result<NarEvent<impl AsyncBufRead>>> {
+pub fn dump<P: Into<PathBuf>>(path: P) -> NarDumper {
     DumpOptions::new().dump(path)
 }
 
@@ -130,18 +128,14 @@ use super::mmap::MappedFile;
 /// streaming without unbounded memory allocation.
 const SMALL_FILE_THRESHOLD: u64 = 256 * 1024; // 256 KiB
 
-/// Loaded file data — either in-memory for small files or mmap'd for large ones.
-enum FileData {
-    InMemory(Vec<u8>),
-    Mapped(MappedFile),
-}
-
-impl FileData {
-    fn as_slice(&self) -> &[u8] {
-        match self {
-            FileData::InMemory(v) => v,
-            FileData::Mapped(m) => m.as_slice(),
-        }
+/// Load a file as a single `Bytes` value without intermediate copies:
+/// small files become `Bytes::from(Vec)`, large files become a refcounted
+/// view over the mmap via `Bytes::from_owner`.
+fn load_file_bytes(path: &Path, size: u64) -> io::Result<Bytes> {
+    if size <= SMALL_FILE_THRESHOLD {
+        Ok(Bytes::from(std::fs::read(path)?))
+    } else {
+        Ok(Bytes::from_owner(MappedFile::open(path, size)?))
     }
 }
 
@@ -155,10 +149,10 @@ pin_project! {
         },
         OpenFile {
             #[pin]
-            handle: JoinHandle<io::Result<(FileData, OwnedSemaphorePermit)>>,
+            handle: JoinHandle<io::Result<(Bytes, OwnedSemaphorePermit)>>,
         },
         Reading {
-            data: FileData,
+            data: Bytes,
             offset: usize,
             _permit: OwnedSemaphorePermit,
         },
@@ -187,12 +181,10 @@ impl DumpedFile {
     }
 }
 
-impl AsyncRead for DumpedFile {
-    fn poll_read(
-        self: Pin<&mut Self>,
-        cx: &mut std::task::Context<'_>,
-        buf: &mut tokio::io::ReadBuf<'_>,
-    ) -> Poll<io::Result<()>> {
+impl DumpedFile {
+    /// Drive the open/mmap state machine until file data is available.
+    /// Shared by both [`AsyncRead`] and [`DumpedFile::poll_bytes`].
+    fn poll_load(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
         let mut this = self.project();
         loop {
             match this.states.as_mut().project() {
@@ -202,14 +194,8 @@ impl AsyncRead for DumpedFile {
                 } => match ready!(semaphore.poll_acquire(cx)) {
                     Some(permit) => {
                         let (path, size) = file.take().unwrap();
-                        let handle = spawn_blocking(move || {
-                            let data = if size <= SMALL_FILE_THRESHOLD {
-                                FileData::InMemory(std::fs::read(&path)?)
-                            } else {
-                                FileData::Mapped(MappedFile::open(&path, size)?)
-                            };
-                            Ok((data, permit))
-                        });
+                        let handle =
+                            spawn_blocking(move || Ok((load_file_bytes(&path, size)?, permit)));
                         this.states.set(DumpedFileStates::OpenFile { handle });
                     }
                     None => {
@@ -240,18 +226,49 @@ impl AsyncRead for DumpedFile {
                         )));
                     }
                 },
-                DumpedFileStatesProj::Reading { data, offset, .. } => {
-                    let remaining = &data.as_slice()[*offset..];
-                    if remaining.is_empty() {
-                        this.states.set(DumpedFileStates::Eof);
-                    } else {
-                        let to_copy = remaining.len().min(buf.remaining());
-                        buf.put_slice(&remaining[..to_copy]);
-                        *offset += to_copy;
-                    }
-                    break;
+                DumpedFileStatesProj::Reading { .. } | DumpedFileStatesProj::Eof => {
+                    return Poll::Ready(Ok(()));
                 }
-                DumpedFileStatesProj::Eof => break,
+            }
+        }
+    }
+
+    /// Resolve the entire file content as a single zero-copy [`Bytes`].
+    ///
+    /// For small files this is the heap buffer moved into `Bytes`; for large
+    /// files it's a refcounted view over the mmap. The semaphore permit is
+    /// released immediately since neither holds an open file descriptor.
+    pub fn poll_bytes(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<Bytes>> {
+        ready!(self.as_mut().poll_load(cx))?;
+        let mut this = self.project();
+        match this.states.as_mut().project() {
+            DumpedFileStatesProj::Reading { data, .. } => {
+                let out = std::mem::take(data);
+                this.states.set(DumpedFileStates::Eof);
+                Poll::Ready(Ok(out))
+            }
+            DumpedFileStatesProj::Eof => Poll::Ready(Ok(Bytes::new())),
+            _ => unreachable!("poll_load returned Ready without reaching terminal state"),
+        }
+    }
+}
+
+impl AsyncRead for DumpedFile {
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+        buf: &mut tokio::io::ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        ready!(self.as_mut().poll_load(cx))?;
+        let mut this = self.project();
+        if let DumpedFileStatesProj::Reading { data, offset, .. } = this.states.as_mut().project() {
+            let remaining = &data[*offset..];
+            if remaining.is_empty() {
+                this.states.set(DumpedFileStates::Eof);
+            } else {
+                let to_copy = remaining.len().min(buf.remaining());
+                buf.put_slice(&remaining[..to_copy]);
+                *offset += to_copy;
             }
         }
         Poll::Ready(Ok(()))
@@ -405,7 +422,7 @@ impl NarDumper {
 }
 
 impl Stream for NarDumper {
-    type Item = io::Result<NarEvent<BufReader<DumpedFile>>>;
+    type Item = io::Result<NarEvent<DumpedFile>>;
 
     fn poll_next(
         mut self: std::pin::Pin<&mut Self>,
@@ -442,8 +459,7 @@ impl Stream for NarDumper {
                         executable,
                         ..
                     } => {
-                        let reader =
-                            BufReader::new(DumpedFile::new(path, size, self.semaphore.clone()));
+                        let reader = DumpedFile::new(path, size, self.semaphore.clone());
                         NarEvent::File {
                             name,
                             executable,

--- a/harmonia-nar/src/archive/dumper.rs
+++ b/harmonia-nar/src/archive/dumper.rs
@@ -7,18 +7,14 @@ use std::os::unix::ffi::OsStrExt;
 use std::os::unix::fs::PermissionsExt as _;
 use std::path::{Path, PathBuf};
 use std::pin::Pin;
-use std::sync::Arc;
 use std::task::{Context, Poll, ready};
 use std::{collections::VecDeque, io};
 
 use bstr::{ByteSlice as _, ByteVec as _};
 use bytes::Bytes;
 use futures_core::Stream;
-use pin_project_lite::pin_project;
 use tokio::io::AsyncRead;
-use tokio::sync::{OwnedSemaphorePermit, Semaphore};
 use tokio::task::{JoinHandle, spawn_blocking};
-use tokio_util::sync::PollSemaphore;
 use tracing::debug;
 use walkdir::{DirEntry, IntoIter};
 
@@ -26,7 +22,6 @@ use super::{CASE_HACK_SUFFIX, NarEvent};
 
 pub struct DumpOptions {
     use_case_hack: bool,
-    max_open_files: usize,
 }
 
 impl DumpOptions {
@@ -35,19 +30,11 @@ impl DumpOptions {
         let use_case_hack = true;
         #[cfg(not(target_os = "macos"))]
         let use_case_hack = false;
-        Self {
-            use_case_hack,
-            max_open_files: OPEN_FILES,
-        }
+        Self { use_case_hack }
     }
 
     pub fn use_case_hack(mut self, use_case_hack: bool) -> Self {
         self.use_case_hack = use_case_hack;
-        self
-    }
-
-    pub fn max_open_files(mut self, max_open_files: usize) -> Self {
-        self.max_open_files = max_open_files;
         self
     }
 
@@ -67,7 +54,6 @@ impl DumpOptions {
             next: None,
             level: 0,
             use_case_hack: self.use_case_hack,
-            semaphore: Arc::new(Semaphore::new(self.max_open_files)),
         }
     }
 }
@@ -123,9 +109,8 @@ fn remove_case_hack(name: &mut Bytes) {
 
 use super::mmap::MappedFile;
 
-/// Files smaller than this are read into memory in one `spawn_blocking` call,
-/// avoiding per-read context switches. Larger files use mmap for zero-copy
-/// streaming without unbounded memory allocation.
+/// Files up to this size are read into a heap buffer; larger files are
+/// memory-mapped so streaming a multi-gigabyte store path stays bounded.
 const SMALL_FILE_THRESHOLD: u64 = 256 * 1024; // 256 KiB
 
 /// Load a file as a single `Bytes` value without intermediate copies:
@@ -139,149 +124,49 @@ fn load_file_bytes(path: &Path, size: u64) -> io::Result<Bytes> {
     }
 }
 
-pin_project! {
-    #[project = DumpedFileStatesProj]
-    enum DumpedFileStates {
-        WaitPermit {
-            #[pin]
-            semaphore: PollSemaphore,
-            file: Option<(PathBuf, u64)>,
-        },
-        OpenFile {
-            #[pin]
-            handle: JoinHandle<io::Result<(Bytes, OwnedSemaphorePermit)>>,
-        },
-        Reading {
-            data: Bytes,
-            offset: usize,
-            _permit: OwnedSemaphorePermit,
-        },
-        Eof,
-    }
-}
-
-pin_project! {
-    pub struct DumpedFile {
-        #[pin]
-        states: DumpedFileStates,
-    }
+/// File contents for a [`NarEvent::File`], already loaded into memory (or
+/// memory-mapped) by the same blocking task that walked the directory.
+///
+/// The data is fetched eagerly so the async consumer never has to round-trip
+/// to the blocking pool per file; neither representation holds an open file
+/// descriptor, so at most [`CHUNK_SIZE`] entries worth of small-file buffers
+/// plus mappings are resident at a time.
+pub struct DumpedFile {
+    data: Bytes,
 }
 
 impl DumpedFile {
-    pub fn new<P>(path: P, size: u64, semaphore: Arc<Semaphore>) -> Self
-    where
-        P: Into<PathBuf>,
-    {
-        Self {
-            states: DumpedFileStates::WaitPermit {
-                semaphore: PollSemaphore::new(semaphore),
-                file: Some((path.into(), size)),
-            },
-        }
-    }
-}
-
-impl DumpedFile {
-    /// Drive the open/mmap state machine until file data is available.
-    /// Shared by both [`AsyncRead`] and [`DumpedFile::poll_bytes`].
-    fn poll_load(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
-        let mut this = self.project();
-        loop {
-            match this.states.as_mut().project() {
-                DumpedFileStatesProj::WaitPermit {
-                    mut semaphore,
-                    file,
-                } => match ready!(semaphore.poll_acquire(cx)) {
-                    Some(permit) => {
-                        let (path, size) = file.take().unwrap();
-                        let handle =
-                            spawn_blocking(move || Ok((load_file_bytes(&path, size)?, permit)));
-                        this.states.set(DumpedFileStates::OpenFile { handle });
-                    }
-                    None => {
-                        this.states.set(DumpedFileStates::Eof);
-                        return Poll::Ready(Err(io::Error::new(
-                            io::ErrorKind::BrokenPipe,
-                            "semaphore closed",
-                        )));
-                    }
-                },
-                DumpedFileStatesProj::OpenFile { handle } => match ready!(handle.poll(cx)) {
-                    Ok(Ok((data, permit))) => {
-                        this.states.set(DumpedFileStates::Reading {
-                            data,
-                            offset: 0,
-                            _permit: permit,
-                        });
-                    }
-                    Ok(Err(err)) => {
-                        this.states.set(DumpedFileStates::Eof);
-                        return Poll::Ready(Err(err));
-                    }
-                    Err(_) => {
-                        this.states.set(DumpedFileStates::Eof);
-                        return Poll::Ready(Err(io::Error::new(
-                            io::ErrorKind::BrokenPipe,
-                            "spawned task failed",
-                        )));
-                    }
-                },
-                DumpedFileStatesProj::Reading { .. } | DumpedFileStatesProj::Eof => {
-                    return Poll::Ready(Ok(()));
-                }
-            }
-        }
+    fn new(data: Bytes) -> Self {
+        Self { data }
     }
 
-    /// Resolve the entire file content as a single zero-copy [`Bytes`].
-    ///
-    /// For small files this is the heap buffer moved into `Bytes`; for large
-    /// files it's a refcounted view over the mmap. The semaphore permit is
-    /// released immediately since neither holds an open file descriptor.
-    pub fn poll_bytes(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<Bytes>> {
-        ready!(self.as_mut().poll_load(cx))?;
-        let mut this = self.project();
-        match this.states.as_mut().project() {
-            DumpedFileStatesProj::Reading { data, .. } => {
-                let out = std::mem::take(data);
-                this.states.set(DumpedFileStates::Eof);
-                Poll::Ready(Ok(out))
-            }
-            DumpedFileStatesProj::Eof => Poll::Ready(Ok(Bytes::new())),
-            _ => unreachable!("poll_load returned Ready without reaching terminal state"),
-        }
+    /// Take the file content as a zero-copy [`Bytes`].
+    pub fn into_bytes(self) -> Bytes {
+        self.data
     }
 }
 
 impl AsyncRead for DumpedFile {
     fn poll_read(
         mut self: Pin<&mut Self>,
-        cx: &mut std::task::Context<'_>,
+        _cx: &mut Context<'_>,
         buf: &mut tokio::io::ReadBuf<'_>,
     ) -> Poll<io::Result<()>> {
-        ready!(self.as_mut().poll_load(cx))?;
-        let mut this = self.project();
-        if let DumpedFileStatesProj::Reading { data, offset, .. } = this.states.as_mut().project() {
-            let remaining = &data[*offset..];
-            if remaining.is_empty() {
-                this.states.set(DumpedFileStates::Eof);
-            } else {
-                let to_copy = remaining.len().min(buf.remaining());
-                buf.put_slice(&remaining[..to_copy]);
-                *offset += to_copy;
-            }
-        }
+        let n = self.data.len().min(buf.remaining());
+        buf.put_slice(&self.data[..n]);
+        // `Bytes::advance` on an owned/mmap-backed buffer just bumps an offset.
+        bytes::Buf::advance(&mut self.data, n);
         Poll::Ready(Ok(()))
     }
 }
 
-#[derive(Debug)]
 enum Entry {
     File {
         depth: usize,
         path: PathBuf,
         size: u64,
         executable: bool,
+        data: Bytes,
     },
     Symlink {
         depth: usize,
@@ -366,11 +251,19 @@ impl State {
                             {
                                 executable = false;
                             }
+                            let size = m.len();
+                            let path = entry.into_path();
+                            // Load the content here, in the same blocking
+                            // task that is already iterating the directory,
+                            // so the async side receives ready-to-stream
+                            // bytes without a second pool round-trip.
+                            let data = load_file_bytes(&path, size)?;
                             Ok(Entry::File {
                                 depth,
-                                path: entry.into_path(),
-                                size: m.len(),
+                                path,
+                                size,
                                 executable,
+                                data,
                             })
                         } else if m.is_symlink() {
                             let target = read_link(entry.path())?;
@@ -399,25 +292,15 @@ pub struct NarDumper {
     state: State,
     next: Option<Entry>,
     level: u32,
-    semaphore: Arc<Semaphore>,
     use_case_hack: bool,
 }
-
-const OPEN_FILES: usize = 100;
 
 impl NarDumper {
     pub fn new<P>(root: P) -> Self
     where
         P: Into<PathBuf>,
     {
-        Self::with_max_open_files(root, OPEN_FILES)
-    }
-
-    pub fn with_max_open_files<P>(root: P, max_open_files: usize) -> Self
-    where
-        P: Into<PathBuf>,
-    {
-        DumpOptions::new().max_open_files(max_open_files).dump(root)
+        DumpOptions::new().dump(root)
     }
 }
 
@@ -454,12 +337,12 @@ impl Stream for NarDumper {
                         NarEvent::StartDirectory { name }
                     }
                     Entry::File {
-                        path,
                         size,
                         executable,
+                        data,
                         ..
                     } => {
-                        let reader = DumpedFile::new(path, size, self.semaphore.clone());
+                        let reader = DumpedFile::new(data);
                         NarEvent::File {
                             name,
                             executable,

--- a/harmonia-nar/src/archive/mmap.rs
+++ b/harmonia-nar/src/archive/mmap.rs
@@ -80,6 +80,15 @@ impl MappedFile {
     }
 }
 
+// Allow `Bytes::from_owner(MappedFile)` so the mapping can be handed out as a
+// zero-copy `Bytes` whose refcount keeps the mmap alive until the last slice
+// is dropped.
+impl AsRef<[u8]> for MappedFile {
+    fn as_ref(&self) -> &[u8] {
+        self.as_slice()
+    }
+}
+
 impl Drop for MappedFile {
     fn drop(&mut self) {
         if self.len > 0 {


### PR DESCRIPTION
Profiling the `http_download` benchmark with `perf` showed the NAR serving path spending most of its CPU shuffling file bytes through `AsyncRead`/`AsyncWrite` adaptors and bouncing to the blocking pool once per file, plus a measurable chunk in `std::path::Components` parsing and a Nagle stall on keep-alive connections. This reworks `NarByteStream` to drive `NarDumper` directly and forward file payloads as the original `Bytes` (heap or mmap-backed) without copying, folds file open/read/mmap into the existing batched directory walk so there is one blocking-pool round-trip per batch instead of per file, replaces component-wise path operations with `walkdir` depth and a byte-level `rfind`, and enables `TCP_NODELAY` on accepted sockets. The bench client is also rewritten to use keep-alive and discard bodies so it measures the server rather than itself, and frame pointers are enabled in cargo builds for cheap `perf` callgraphs. On the 500 MiB python closure this takes sequential/4-way/16-way download from 839/394/284 ms to 401/179/154 ms (~2×, ~3.2 GiB/s at 16 conns); harmonia-side `memmove` drops from ~21% of server CPU to ~0.3%, with the remainder dominated by actix's socket-buffer copy and walkdir-internal allocation.