### PR TITLE
nar: zero-copy streaming follow-ups (review + mmap test)

### DIFF
--- a/harmonia-bench/benches/http_download.rs
+++ b/harmonia-bench/benches/http_download.rs
@@ -55,9 +55,10 @@ impl Conn {
             .and_then(|s| s.parse().ok())
             .expect("bad status line");
 
-        let mut content_length: u64 = 0;
+        let mut content_length: Option<u64> = None;
+        let mut line = String::new();
         loop {
-            let mut line = String::new();
+            line.clear();
             self.reader.read_line(&mut line).await.expect("read header");
             if line == "\r\n" || line == "\n" {
                 break;
@@ -66,10 +67,15 @@ impl Conn {
                 .strip_prefix("Content-Length: ")
                 .or_else(|| line.strip_prefix("content-length: "))
             {
-                content_length = val.trim().parse().expect("bad content-length");
+                content_length = Some(val.trim().parse().expect("bad content-length"));
             }
         }
-        (status, content_length)
+        // The keep-alive connection relies on draining exactly the declared
+        // body length; fail loudly rather than desync on the next request.
+        (
+            status,
+            content_length.expect("response missing Content-Length"),
+        )
     }
 
     /// GET `path` and return the full body (for small responses like narinfo).

--- a/harmonia-nar/src/archive/byte_stream.rs
+++ b/harmonia-nar/src/archive/byte_stream.rs
@@ -227,4 +227,28 @@ mod tests {
         let want = write_nar(test_data::text_file().iter());
         assert_eq!(got, want.to_vec());
     }
+
+    /// Exercise the mmap-backed `Bytes::from_owner` path and the
+    /// `FILE_CHUNK_SIZE` slicing of large payloads.
+    #[tokio::test]
+    async fn byte_stream_large_file_matches_nix_store_dump() {
+        // Larger than SMALL_FILE_THRESHOLD and not a multiple of
+        // FILE_CHUNK_SIZE / 8, so padding and the final short slice are both
+        // covered.
+        const LEN: usize = 300 * 1024 + 5;
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("big");
+        let data: Vec<u8> = (0..LEN).map(|i| (i % 251) as u8).collect();
+        std::fs::write(&path, &data).unwrap();
+
+        let got = collect(path.clone()).await;
+
+        let want = std::process::Command::new("nix-store")
+            .arg("--dump")
+            .arg(&path)
+            .output()
+            .expect("nix-store --dump failed");
+        assert!(want.status.success());
+        assert_eq!(got, want.stdout);
+    }
 }

--- a/harmonia-nar/src/archive/dumper.rs
+++ b/harmonia-nar/src/archive/dumper.rs
@@ -154,6 +154,15 @@ fn load_file_bytes(path: &Path, size: u64) -> io::Result<Bytes> {
         let mut f = std::fs::File::open(path)?;
         let mut buf = Vec::with_capacity(size as usize);
         f.read_to_end(&mut buf)?;
+        // The NAR length prefix has already been derived from `size`; if the
+        // file changed under us the archive would silently desync, so surface
+        // it as an explicit error instead.
+        if buf.len() as u64 != size {
+            return Err(io::Error::other(format!(
+                "file {path:?} changed size during dump: stat {size}, read {}",
+                buf.len()
+            )));
+        }
         Ok(Bytes::from(buf))
     } else {
         Ok(Bytes::from_owner(MappedFile::open(path, size)?))


### PR DESCRIPTION
Follow-ups to #980 addressing the actionable CodeRabbit findings and a test gap.