### PR TITLE
harmonia-cache: replace actix Compress with tuned zstd middleware

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -73,7 +73,6 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
- "zstd",
 ]
 
 [[package]]
@@ -937,6 +936,7 @@ dependencies = [
  "actix-web",
  "askama_escape",
  "async-compression",
+ "bytes",
  "futures-core",
  "futures-util",
  "harmonia-nar",
@@ -962,6 +962,8 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "url",
+ "zstd",
+ "zstd-safe",
 ]
 
 [[package]]

--- a/harmonia-bench/benches/common/mod.rs
+++ b/harmonia-bench/benches/common/mod.rs
@@ -49,6 +49,7 @@ pub async fn start_harmonia(bin_path: &str) -> (u16, HarmoniaGuard) {
         r#"
 bind = "127.0.0.1:{}"
 priority = 30
+enable_compression = true
 "#,
         port
     );
@@ -57,11 +58,22 @@ priority = 30
     write!(config_file, "{}", config).expect("failed to write config");
     config_file.flush().expect("failed to flush config");
 
-    let child = Command::new(bin_path)
-        .env("CONFIG_FILE", config_file.path())
-        .env("RUST_LOG", "warn")
-        .spawn()
-        .expect("failed to start harmonia");
+    // Optionally wrap the server in `perf record` so profiles cover only the
+    // server process, not the bench client / build children.
+    let child = if let Ok(perf_out) = std::env::var("HARMONIA_PERF_RECORD") {
+        Command::new("perf")
+            .args(["record", "-F", "497", "-g", "-o", &perf_out, "--", bin_path])
+            .env("CONFIG_FILE", config_file.path())
+            .env("RUST_LOG", "warn")
+            .spawn()
+            .expect("failed to start perf record harmonia")
+    } else {
+        Command::new(bin_path)
+            .env("CONFIG_FILE", config_file.path())
+            .env("RUST_LOG", "warn")
+            .spawn()
+            .expect("failed to start harmonia")
+    };
 
     let pid = child.id();
 

--- a/harmonia-bench/benches/http_download.rs
+++ b/harmonia-bench/benches/http_download.rs
@@ -10,6 +10,11 @@ use tokio::net::TcpStream;
 /// per-read syscall overhead while staying well inside L2.
 const DRAIN_BUF: usize = 64 * 1024;
 
+enum BodyFraming {
+    Length(u64),
+    Chunked,
+}
+
 /// A persistent HTTP/1.1 keep-alive connection.
 ///
 /// Response bodies are drained into a fixed scratch buffer rather than
@@ -19,24 +24,30 @@ struct Conn {
     reader: BufReader<TcpStream>,
     host: String,
     drain: Box<[u8; DRAIN_BUF]>,
+    accept_encoding: &'static str,
 }
 
 impl Conn {
     async fn connect(addr: &str) -> Self {
+        Self::connect_with_encoding(addr, "identity").await
+    }
+
+    async fn connect_with_encoding(addr: &str, accept_encoding: &'static str) -> Self {
         let stream = TcpStream::connect(addr).await.expect("connect failed");
         stream.set_nodelay(true).ok();
         Self {
             reader: BufReader::new(stream),
             host: addr.to_string(),
             drain: Box::new([0u8; DRAIN_BUF]),
+            accept_encoding,
         }
     }
 
-    /// Issue a GET and parse status + Content-Length, leaving the body unread.
-    async fn get_head(&mut self, path: &str) -> (u16, u64) {
+    /// Issue a GET and parse status + framing, leaving the body unread.
+    async fn get_head(&mut self, path: &str) -> (u16, BodyFraming) {
         let request = format!(
-            "GET {} HTTP/1.1\r\nHost: {}\r\nConnection: keep-alive\r\n\r\n",
-            path, self.host
+            "GET {} HTTP/1.1\r\nHost: {}\r\nAccept-Encoding: {}\r\nConnection: keep-alive\r\n\r\n",
+            path, self.host, self.accept_encoding
         );
         self.reader
             .get_mut()
@@ -56,6 +67,7 @@ impl Conn {
             .expect("bad status line");
 
         let mut content_length: Option<u64> = None;
+        let mut chunked = false;
         let mut line = String::new();
         loop {
             line.clear();
@@ -63,33 +75,27 @@ impl Conn {
             if line == "\r\n" || line == "\n" {
                 break;
             }
-            if let Some(val) = line
-                .strip_prefix("Content-Length: ")
-                .or_else(|| line.strip_prefix("content-length: "))
-            {
+            let lower = line.to_ascii_lowercase();
+            if let Some(val) = lower.strip_prefix("content-length: ") {
                 content_length = Some(val.trim().parse().expect("bad content-length"));
+            } else if lower
+                .strip_prefix("transfer-encoding: ")
+                .is_some_and(|v| v.trim() == "chunked")
+            {
+                chunked = true;
             }
         }
         // The keep-alive connection relies on draining exactly the declared
-        // body length; fail loudly rather than desync on the next request.
-        (
-            status,
-            content_length.expect("response missing Content-Length"),
-        )
+        // framing; fail loudly rather than desync on the next request.
+        let framing = if chunked {
+            BodyFraming::Chunked
+        } else {
+            BodyFraming::Length(content_length.expect("response missing Content-Length"))
+        };
+        (status, framing)
     }
 
-    /// GET `path` and return the full body (for small responses like narinfo).
-    async fn get_body(&mut self, path: &str) -> (u16, Vec<u8>) {
-        let (status, len) = self.get_head(path).await;
-        let mut body = vec![0u8; len as usize];
-        self.reader.read_exact(&mut body).await.expect("read body");
-        (status, body)
-    }
-
-    /// GET `path` and discard the body, returning the number of bytes drained.
-    async fn get_drain(&mut self, path: &str) -> (u16, u64) {
-        let (status, len) = self.get_head(path).await;
-        let mut remaining = len;
+    async fn drain_exact(&mut self, mut remaining: u64) {
         while remaining > 0 {
             let want = remaining.min(DRAIN_BUF as u64) as usize;
             let n = self
@@ -100,6 +106,69 @@ impl Conn {
             assert!(n > 0, "unexpected EOF with {} bytes remaining", remaining);
             remaining -= n as u64;
         }
+    }
+
+    /// Drain a chunked-encoded body and return total payload bytes.
+    async fn drain_chunked(&mut self) -> u64 {
+        let mut total = 0u64;
+        let mut line = String::new();
+        loop {
+            line.clear();
+            self.reader
+                .read_line(&mut line)
+                .await
+                .expect("read chunk size");
+            let size_str = line.trim_end();
+            // Ignore chunk extensions after ';'
+            let size_hex = size_str.split(';').next().unwrap();
+            let size = u64::from_str_radix(size_hex, 16)
+                .unwrap_or_else(|_| panic!("bad chunk size: {line:?}"));
+            if size == 0 {
+                // trailer + final CRLF
+                loop {
+                    line.clear();
+                    self.reader
+                        .read_line(&mut line)
+                        .await
+                        .expect("read trailer");
+                    if line == "\r\n" || line == "\n" {
+                        break;
+                    }
+                }
+                return total;
+            }
+            self.drain_exact(size).await;
+            total += size;
+            // CRLF after chunk data
+            line.clear();
+            self.reader
+                .read_line(&mut line)
+                .await
+                .expect("read chunk CRLF");
+        }
+    }
+
+    /// GET `path` and return the full body (for small responses like narinfo).
+    async fn get_body(&mut self, path: &str) -> (u16, Vec<u8>) {
+        let (status, framing) = self.get_head(path).await;
+        let BodyFraming::Length(len) = framing else {
+            panic!("get_body requires Content-Length")
+        };
+        let mut body = vec![0u8; len as usize];
+        self.reader.read_exact(&mut body).await.expect("read body");
+        (status, body)
+    }
+
+    /// GET `path` and discard the body, returning the number of bytes drained.
+    async fn get_drain(&mut self, path: &str) -> (u16, u64) {
+        let (status, framing) = self.get_head(path).await;
+        let len = match framing {
+            BodyFraming::Length(len) => {
+                self.drain_exact(len).await;
+                len
+            }
+            BodyFraming::Chunked => self.drain_chunked().await,
+        };
         (status, len)
     }
 }
@@ -212,34 +281,51 @@ fn benchmark_http_download(c: &mut Criterion) {
         narinfos.len()
     );
 
+    // One-off wire-size probe per encoding, printed alongside the timing runs.
+    rt.block_on(async {
+        for encoding in ["identity", "zstd"] {
+            let mut conn = Conn::connect_with_encoding(&addr, encoding).await;
+            let mut wire = 0u64;
+            for (_, ni) in &narinfos {
+                wire += download_nar(&mut conn, &ni.url).await;
+            }
+            eprintln!(
+                "encoding={:<8} wire={:>9.2} MiB  ratio={:.3}",
+                encoding,
+                wire as f64 / 1024.0 / 1024.0,
+                wire as f64 / total_nar_bytes as f64,
+            );
+        }
+    });
+
     let mut group = c.benchmark_group("http");
     group.sample_size(10);
     group.measurement_time(Duration::from_secs(5));
 
-    group.bench_function("sequential", |b| {
-        // One persistent connection reused across all iterations so we measure
-        // server-side NAR throughput, not TCP handshake latency.
-        let mut conn = rt.block_on(Conn::connect(&addr));
-        b.iter_custom(|iters| {
-            let mut total = Duration::ZERO;
-            for _ in 0..iters {
-                let start = Instant::now();
-                rt.block_on(async {
-                    for (_, narinfo) in &narinfos {
-                        download_nar(&mut conn, &narinfo.url).await;
-                    }
-                });
-                total += start.elapsed();
-            }
-            total
-        })
-    });
+    for encoding in ["identity", "zstd"] {
+        group.bench_function(format!("sequential_{encoding}"), |b| {
+            let mut conn = rt.block_on(Conn::connect_with_encoding(&addr, encoding));
+            b.iter_custom(|iters| {
+                let mut total = Duration::ZERO;
+                for _ in 0..iters {
+                    let start = Instant::now();
+                    rt.block_on(async {
+                        for (_, narinfo) in &narinfos {
+                            download_nar(&mut conn, &narinfo.url).await;
+                        }
+                    });
+                    total += start.elapsed();
+                }
+                total
+            })
+        });
+    }
 
     let nar_urls: std::sync::Arc<Vec<String>> =
         std::sync::Arc::new(narinfos.iter().map(|(_, ni)| ni.url.clone()).collect());
 
-    for concurrency in [4, 16] {
-        group.bench_function(format!("concurrent_{}", concurrency), |b| {
+    for (concurrency, encoding) in [(4, "identity"), (16, "identity"), (4, "zstd"), (16, "zstd")] {
+        group.bench_function(format!("concurrent_{concurrency}_{encoding}"), |b| {
             b.iter_custom(|iters| {
                 let mut total = Duration::ZERO;
                 for _ in 0..iters {
@@ -255,7 +341,7 @@ fn benchmark_http_download(c: &mut Criterion) {
                             let urls = nar_urls.clone();
                             let next = next.clone();
                             handles.push(tokio::spawn(async move {
-                                let mut conn = Conn::connect(&addr).await;
+                                let mut conn = Conn::connect_with_encoding(&addr, encoding).await;
                                 let mut bytes = 0u64;
                                 loop {
                                     let i = next.fetch_add(1, std::sync::atomic::Ordering::Relaxed);

--- a/harmonia-cache/Cargo.toml
+++ b/harmonia-cache/Cargo.toml
@@ -14,11 +14,7 @@ path = "src/main.rs"
 
 [dependencies]
 actix-files = "0.6.10"
-actix-web = { version = "4", default-features = false, features = [
-    "macros",
-    "compress-zstd",
-    "rustls-0_23",
-] }
+actix-web = { version = "4", default-features = false, features = [ "macros", "rustls-0_23" ] }
 askama_escape = "0.15.6"
 async-compression = { version = "0.4.41", features = [ "tokio", "bzip2" ] }
 http-range = "0.1"
@@ -41,7 +37,10 @@ toml = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 url = "2.5.7"
+zstd = "0.13"
+zstd-safe = "7"
 # Nix.rs-based crates
+bytes                 = { workspace = true }
 futures-core          = { workspace = true }
 futures-util          = { workspace = true }
 harmonia-nar          = { version = "3.0.0" }

--- a/harmonia-cache/src/config.rs
+++ b/harmonia-cache/src/config.rs
@@ -27,6 +27,43 @@ fn default_enable_compression() -> bool {
     false
 }
 
+/// zstd parameters applied to on-the-fly NAR encoding when the client sends
+/// `Accept-Encoding: zstd`. Defaults are tuned for a substitution cache:
+/// level 1 with long-distance matching beats the libzstd default (level 3)
+/// on both ratio and throughput for typical NARs, and the window cap keeps
+/// per-stream decoder memory bounded under parallel `nix copy`.
+#[derive(Clone, Copy, Debug, Deserialize)]
+pub(crate) struct ZstdConfig {
+    #[serde(default = "ZstdConfig::default_level")]
+    pub(crate) level: i32,
+    #[serde(default = "ZstdConfig::default_long_distance")]
+    pub(crate) long_distance_matching: bool,
+    /// log2 of the match window. 0 = auto: with LDM, cap at 25 (32 MiB) so
+    /// decoder memory stays bounded; without LDM, use the level default so
+    /// the encoder doesn't allocate a large window it can't fill.
+    #[serde(default)]
+    pub(crate) window_log: u32,
+}
+
+impl ZstdConfig {
+    fn default_level() -> i32 {
+        1
+    }
+    fn default_long_distance() -> bool {
+        true
+    }
+}
+
+impl Default for ZstdConfig {
+    fn default() -> Self {
+        Self {
+            level: Self::default_level(),
+            long_distance_matching: Self::default_long_distance(),
+            window_log: 0,
+        }
+    }
+}
+
 fn default_virtual_store() -> PathBuf {
     PathBuf::from("/nix/store")
 }
@@ -56,6 +93,9 @@ pub(crate) struct Config {
 
     #[serde(default = "default_enable_compression")]
     pub(crate) enable_compression: bool,
+
+    #[serde(default)]
+    pub(crate) zstd: ZstdConfig,
 
     #[serde(default)]
     pub(crate) sign_key_path: Option<String>,

--- a/harmonia-cache/src/main.rs
+++ b/harmonia-cache/src/main.rs
@@ -43,6 +43,7 @@ mod store;
 mod template;
 mod tls;
 mod version;
+mod zstd_body;
 
 async fn nixhash(settings: &web::Data<Config>, hash: &[u8]) -> Result<Option<StorePath>> {
     // Parse the hash bytes into a StorePathHash
@@ -166,7 +167,7 @@ async fn inner_main() -> Result<()> {
         App::new()
             .wrap(middleware::Condition::new(
                 config_data.enable_compression,
-                middleware::Compress::default(),
+                zstd_body::ZstdMiddleware::new(config_data.zstd),
             ))
             .wrap(prometheus::PrometheusMiddleware::new(metrics.clone()))
             .app_data(config_data.clone())

--- a/harmonia-cache/src/nar.rs
+++ b/harmonia-cache/src/nar.rs
@@ -149,7 +149,8 @@ pub(crate) async fn get(
                 let offset = ranges[0].start;
 
                 if settings.enable_compression {
-                    // don't allow compression middleware to modify partial content
+                    // The zstd middleware skips responses that already carry a
+                    // Content-Encoding; partial content must stay byte-exact.
                     res.insert_header((
                         http::header::CONTENT_ENCODING,
                         http::header::HeaderValue::from_static("none"),
@@ -194,6 +195,7 @@ pub(crate) async fn get(
         .insert_header((http::header::CONTENT_TYPE, "application/x-nix-archive"))
         .insert_header((http::header::ACCEPT_RANGES, "bytes"))
         .insert_header(cache_control_max_age_1y())
+        // Sized so the zstd middleware can pledge the exact length.
         .body(actix_web::body::SizedStream::new(rlength, stream)))
 }
 

--- a/harmonia-cache/src/zstd_body.rs
+++ b/harmonia-cache/src/zstd_body.rs
@@ -1,0 +1,491 @@
+//! App-wide zstd response compression.
+//!
+//! actix-web's `Compress` middleware hard-codes zstd level 3 and exposes no
+//! tuning. NAR responses have two properties it can't exploit: the
+//! uncompressed size is known up front, and large NARs contain long-range
+//! repetition (near-duplicate ELF sections, vendored sources) beyond the
+//! ~2 MiB level-3 window. Pledging the size and enabling long-distance
+//! matching at level 1 is both smaller and faster on representative
+//! closures, so this middleware replaces `Compress` entirely.
+//!
+//! Chunks above [`INLINE_THRESHOLD`] are compressed on the blocking pool so
+//! a single large NAR can't stall the reactor.
+
+use std::future::{Ready, ready as fut_ready};
+use std::io::{self, Write};
+use std::pin::Pin;
+use std::rc::Rc;
+use std::task::{Context, Poll, ready};
+
+use actix_web::Error;
+use actix_web::body::{BodySize, MessageBody};
+use actix_web::dev::{Service, ServiceRequest, ServiceResponse, Transform, forward_ready};
+use actix_web::http::header::{ACCEPT_ENCODING, CONTENT_ENCODING, HeaderMap, HeaderValue, VARY};
+use actix_web::rt::task::{JoinHandle, spawn_blocking};
+use actix_web::web::Bytes;
+use bytes::BytesMut;
+use futures_core::{Stream, future::LocalBoxFuture};
+
+use crate::config::ZstdConfig;
+
+/// LDM would otherwise raise windowLog to 27 (128 MiB decoder buffer); 25
+/// keeps almost all of the ratio at 32 MiB.
+const LDM_WINDOW_LOG_CAP: u32 = 25;
+
+/// Responses smaller than this stay uncompressed; the zstd frame header and
+/// chunked-encoding overhead would erase any win.
+const MIN_COMPRESS_SIZE: u64 = 256;
+
+/// Body chunks below this size are encoded on the reactor thread; the
+/// `spawn_blocking` round-trip would dominate the actual compression work.
+const INLINE_THRESHOLD: usize = 1024;
+
+type ZstdEncoder = zstd::stream::write::Encoder<'static, Writer>;
+
+struct Writer {
+    buf: BytesMut,
+}
+
+impl Writer {
+    fn new() -> Self {
+        Self {
+            buf: BytesMut::with_capacity(8 * 1024),
+        }
+    }
+    fn take(&mut self) -> Bytes {
+        self.buf.split().freeze()
+    }
+}
+
+impl Write for Writer {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.buf.extend_from_slice(buf);
+        Ok(buf.len())
+    }
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+/// Minimal `Accept-Encoding` check. We only need to know whether the client
+/// will accept zstd at all; quality ranking against other codings is
+/// irrelevant because zstd is the only on-the-fly encoding we offer.
+fn accepts_zstd(headers: &HeaderMap) -> bool {
+    headers
+        .get_all(ACCEPT_ENCODING)
+        .filter_map(|v| v.to_str().ok())
+        .flat_map(|v| v.split(','))
+        .any(|tok| {
+            let mut parts = tok.trim().split(';');
+            if !parts
+                .next()
+                .is_some_and(|c| c.trim().eq_ignore_ascii_case("zstd"))
+            {
+                return false;
+            }
+            // Honour an explicit q=0 / Q=0 opt-out among any parameters.
+            parts
+                .filter_map(|p| {
+                    p.trim()
+                        .strip_prefix("q=")
+                        .or_else(|| p.trim().strip_prefix("Q="))
+                })
+                .find_map(|q| q.trim().parse::<f32>().ok())
+                .is_none_or(|q| q > 0.0)
+        })
+}
+
+fn build_encoder(cfg: &ZstdConfig, pledged_size: Option<u64>) -> io::Result<ZstdEncoder> {
+    use zstd_safe::CParameter;
+
+    let mut enc = ZstdEncoder::new(Writer::new(), cfg.level)?;
+    if let Some(size) = pledged_size {
+        enc.set_pledged_src_size(Some(size))?;
+    }
+    if cfg.long_distance_matching {
+        enc.set_parameter(CParameter::EnableLongDistanceMatching(true))?;
+    }
+    let window_log = match cfg.window_log {
+        0 if cfg.long_distance_matching => LDM_WINDOW_LOG_CAP,
+        n => n,
+    };
+    if window_log != 0 {
+        enc.set_parameter(CParameter::WindowLog(window_log))?;
+    }
+    Ok(enc)
+}
+
+/// View a `MessageBody` as a `Stream<Item = io::Result<Bytes>>` so the same
+/// `ZstdBody` poll loop works for both NAR streams and in-memory responses.
+pub(crate) struct BodyAsStream<B>(B);
+
+impl<B> Stream for BodyAsStream<B>
+where
+    B: MessageBody + Unpin,
+{
+    type Item = io::Result<Bytes>;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        Pin::new(&mut self.get_mut().0).poll_next(cx).map_err(|e| {
+            // `MessageBody::Error` only guarantees `Into<Box<dyn Error>>`,
+            // which `io::Error` won't accept without `Send + Sync`; flatten
+            // to a string so the encoder pipeline stays `io::Error`-typed.
+            io::Error::other(e.into().to_string())
+        })
+    }
+}
+
+enum State {
+    /// Encoder is parked; ready to accept the next input chunk or to finish.
+    Idle(Box<ZstdEncoder>),
+    /// Encoder is on the blocking pool consuming a chunk. Returns the encoder
+    /// and any compressed bytes produced.
+    Encoding(JoinHandle<io::Result<(Box<ZstdEncoder>, Bytes)>>),
+    /// Input exhausted; flushing the final frame on the blocking pool.
+    Finishing(JoinHandle<io::Result<Bytes>>),
+    Done,
+}
+
+/// Adapts a `Stream<Bytes>` into a zstd-encoded `Stream<Bytes>`.
+pub(crate) struct ZstdBody<S> {
+    inner: S,
+    state: State,
+}
+
+impl<S> ZstdBody<S> {
+    fn new(inner: S, enc: Box<ZstdEncoder>) -> Self {
+        Self {
+            inner,
+            state: State::Idle(enc),
+        }
+    }
+}
+
+impl<S> Stream for ZstdBody<S>
+where
+    S: Stream<Item = io::Result<Bytes>> + Unpin,
+{
+    type Item = io::Result<Bytes>;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let this = self.get_mut();
+        loop {
+            match &mut this.state {
+                State::Done => return Poll::Ready(None),
+
+                State::Finishing(handle) => {
+                    let chunk = ready!(Pin::new(handle).poll(cx))
+                        .map_err(|e| io::Error::other(e.to_string()))??;
+                    this.state = State::Done;
+                    if chunk.is_empty() {
+                        return Poll::Ready(None);
+                    }
+                    return Poll::Ready(Some(Ok(chunk)));
+                }
+
+                State::Encoding(handle) => {
+                    let (enc, chunk) = ready!(Pin::new(handle).poll(cx))
+                        .map_err(|e| io::Error::other(e.to_string()))??;
+                    this.state = State::Idle(enc);
+                    if !chunk.is_empty() {
+                        return Poll::Ready(Some(Ok(chunk)));
+                    }
+                    // Output buffer still empty (encoder buffered internally);
+                    // pull the next input chunk.
+                }
+
+                State::Idle(_) => match ready!(Pin::new(&mut this.inner).poll_next(cx)) {
+                    Some(Ok(chunk)) => {
+                        let State::Idle(mut enc) = std::mem::replace(&mut this.state, State::Done)
+                        else {
+                            unreachable!()
+                        };
+                        if chunk.len() < INLINE_THRESHOLD {
+                            if let Err(e) = enc.write_all(&chunk) {
+                                return Poll::Ready(Some(Err(e)));
+                            }
+                            let out = enc.get_mut().take();
+                            this.state = State::Idle(enc);
+                            if !out.is_empty() {
+                                return Poll::Ready(Some(Ok(out)));
+                            }
+                        } else {
+                            this.state = State::Encoding(spawn_blocking(move || {
+                                enc.write_all(&chunk)?;
+                                let out = enc.get_mut().take();
+                                Ok((enc, out))
+                            }));
+                        }
+                    }
+                    Some(Err(e)) => {
+                        this.state = State::Done;
+                        return Poll::Ready(Some(Err(e)));
+                    }
+                    None => {
+                        let State::Idle(enc) = std::mem::replace(&mut this.state, State::Done)
+                        else {
+                            unreachable!()
+                        };
+                        // `finish()` still has the tail block to compress.
+                        this.state = State::Finishing(spawn_blocking(move || {
+                            let mut writer = enc.finish()?;
+                            Ok(writer.take())
+                        }));
+                    }
+                },
+            }
+        }
+    }
+}
+
+pub(crate) enum CompressedBody<B>
+where
+    B: MessageBody + Unpin,
+{
+    Identity(B),
+    Zstd(Box<ZstdBody<BodyAsStream<B>>>),
+}
+
+impl<B> MessageBody for CompressedBody<B>
+where
+    B: MessageBody + Unpin,
+{
+    type Error = Box<dyn std::error::Error>;
+
+    fn size(&self) -> BodySize {
+        match self {
+            Self::Identity(b) => b.size(),
+            // Compressed length is unknown up front; chunked transfer.
+            Self::Zstd(_) => BodySize::Stream,
+        }
+    }
+
+    fn poll_next(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<Result<Bytes, Self::Error>>> {
+        match self.get_mut() {
+            Self::Identity(b) => Pin::new(b).poll_next(cx).map_err(Into::into),
+            Self::Zstd(s) => Pin::new(s).poll_next(cx).map_err(Into::into),
+        }
+    }
+}
+
+/// App-wide zstd response compression with the tuned parameters from
+/// [`ZstdConfig`]. Replaces `actix_web::middleware::Compress` so a single
+/// configuration governs every route.
+pub(crate) struct ZstdMiddleware {
+    cfg: Rc<ZstdConfig>,
+}
+
+impl ZstdMiddleware {
+    pub(crate) fn new(cfg: ZstdConfig) -> Self {
+        Self { cfg: Rc::new(cfg) }
+    }
+}
+
+impl<S, B> Transform<S, ServiceRequest> for ZstdMiddleware
+where
+    S: Service<ServiceRequest, Response = ServiceResponse<B>, Error = Error>,
+    S::Future: 'static,
+    B: MessageBody + Unpin + 'static,
+{
+    type Response = ServiceResponse<CompressedBody<B>>;
+    type Error = Error;
+    type Transform = ZstdMiddlewareService<S>;
+    type InitError = ();
+    type Future = Ready<Result<Self::Transform, Self::InitError>>;
+
+    fn new_transform(&self, service: S) -> Self::Future {
+        fut_ready(Ok(ZstdMiddlewareService {
+            service,
+            cfg: self.cfg.clone(),
+        }))
+    }
+}
+
+pub(crate) struct ZstdMiddlewareService<S> {
+    service: S,
+    cfg: Rc<ZstdConfig>,
+}
+
+impl<S, B> Service<ServiceRequest> for ZstdMiddlewareService<S>
+where
+    S: Service<ServiceRequest, Response = ServiceResponse<B>, Error = Error>,
+    S::Future: 'static,
+    B: MessageBody + Unpin + 'static,
+{
+    type Response = ServiceResponse<CompressedBody<B>>;
+    type Error = Error;
+    type Future = LocalBoxFuture<'static, Result<Self::Response, Self::Error>>;
+
+    forward_ready!(service);
+
+    fn call(&self, req: ServiceRequest) -> Self::Future {
+        // HEAD must mirror GET headers but the body is never sent, so a
+        // pledged size would not be honoured; pass through untouched.
+        let wants_zstd =
+            req.method() != actix_web::http::Method::HEAD && accepts_zstd(req.headers());
+        let cfg = self.cfg.clone();
+        let fut = self.service.call(req);
+        Box::pin(async move {
+            let res = fut.await?;
+            Ok(res.map_body(|head, body| {
+                // A handler-set Content-Encoding also covers range responses,
+                // which set `none` to keep partial content byte-exact.
+                if !wants_zstd
+                    || head.headers().contains_key(CONTENT_ENCODING)
+                    || head.status.is_redirection()
+                    || head.status == actix_web::http::StatusCode::NO_CONTENT
+                {
+                    return CompressedBody::Identity(body);
+                }
+                let pledge = match body.size() {
+                    BodySize::None => return CompressedBody::Identity(body),
+                    BodySize::Sized(n) if n < MIN_COMPRESS_SIZE => {
+                        return CompressedBody::Identity(body);
+                    }
+                    BodySize::Sized(n) => Some(n),
+                    BodySize::Stream => None,
+                };
+                match build_encoder(&cfg, pledge) {
+                    Ok(enc) => {
+                        head.headers_mut()
+                            .insert(CONTENT_ENCODING, HeaderValue::from_static("zstd"));
+                        head.headers_mut()
+                            .append(VARY, HeaderValue::from_static("accept-encoding"));
+                        head.no_chunking(false);
+                        CompressedBody::Zstd(Box::new(ZstdBody::new(
+                            BodyAsStream(body),
+                            Box::new(enc),
+                        )))
+                    }
+                    // Only reachable with an invalid `[zstd]` config.
+                    Err(e) => {
+                        tracing::warn!("zstd encoder init failed, serving identity: {e}");
+                        CompressedBody::Identity(body)
+                    }
+                }
+            }))
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use actix_web::http::header::HeaderValue;
+    use futures_util::{StreamExt, stream};
+
+    #[test]
+    fn accept_encoding_parse() {
+        let mut h = HeaderMap::new();
+        assert!(!accepts_zstd(&h));
+        h.insert(ACCEPT_ENCODING, HeaderValue::from_static("gzip, br"));
+        assert!(!accepts_zstd(&h));
+        h.insert(ACCEPT_ENCODING, HeaderValue::from_static("zstd"));
+        assert!(accepts_zstd(&h));
+        h.insert(
+            ACCEPT_ENCODING,
+            HeaderValue::from_static("gzip, zstd;q=0.9, br"),
+        );
+        assert!(accepts_zstd(&h));
+        h.insert(ACCEPT_ENCODING, HeaderValue::from_static("zstd;q=0"));
+        assert!(!accepts_zstd(&h));
+        h.insert(ACCEPT_ENCODING, HeaderValue::from_static("zstd; Q=0"));
+        assert!(!accepts_zstd(&h));
+        h.insert(
+            ACCEPT_ENCODING,
+            HeaderValue::from_static("zstd;foo=bar;q=0"),
+        );
+        assert!(!accepts_zstd(&h));
+        // Second header line still counts.
+        h.insert(ACCEPT_ENCODING, HeaderValue::from_static("gzip"));
+        h.append(ACCEPT_ENCODING, HeaderValue::from_static("zstd"));
+        assert!(accepts_zstd(&h));
+    }
+
+    #[actix_web::test]
+    async fn round_trip() {
+        // Mix of tiny and large chunks to cover both inline and blocking paths.
+        let chunks: Vec<Bytes> = vec![
+            Bytes::from_static(b"nix-archive-1"),
+            Bytes::from(vec![0xabu8; 4 * 1024]),
+            Bytes::from(
+                (0..200_000u32)
+                    .flat_map(|i| i.to_le_bytes())
+                    .collect::<Vec<u8>>(),
+            ),
+            Bytes::from_static(b")"),
+        ];
+        let original: Vec<u8> = chunks.iter().flat_map(|b| b.iter().copied()).collect();
+
+        let inner = stream::iter(chunks.into_iter().map(Ok::<_, io::Error>));
+        let enc = build_encoder(&ZstdConfig::default(), Some(original.len() as u64)).unwrap();
+        let body = ZstdBody::new(inner, Box::new(enc));
+        futures_util::pin_mut!(body);
+
+        let mut compressed = Vec::new();
+        while let Some(chunk) = body.next().await {
+            compressed.extend_from_slice(&chunk.unwrap());
+        }
+        assert!(compressed.len() < original.len());
+
+        let decoded = zstd::stream::decode_all(&compressed[..]).unwrap();
+        assert_eq!(decoded, original);
+    }
+
+    #[actix_web::test]
+    async fn middleware_integration() {
+        use actix_web::{App, HttpResponse, test, web};
+
+        let big = Bytes::from(vec![b'x'; 64 * 1024]);
+        let big_for_handler = big.clone();
+        let app = test::init_service(
+            App::new()
+                .wrap(ZstdMiddleware::new(ZstdConfig::default()))
+                .route(
+                    "/big",
+                    web::get().to(move || {
+                        let b = big_for_handler.clone();
+                        async move { HttpResponse::Ok().body(b) }
+                    }),
+                )
+                .route(
+                    "/tiny",
+                    web::get().to(|| async { HttpResponse::Ok().body("ok") }),
+                ),
+        )
+        .await;
+
+        let res = test::call_service(&app, test::TestRequest::get().uri("/big").to_request()).await;
+        assert!(res.headers().get(CONTENT_ENCODING).is_none());
+        let body = test::read_body(res).await;
+        assert_eq!(body, big);
+
+        let res = test::call_service(
+            &app,
+            test::TestRequest::get()
+                .uri("/big")
+                .insert_header((ACCEPT_ENCODING, "zstd"))
+                .to_request(),
+        )
+        .await;
+        assert_eq!(res.headers().get(CONTENT_ENCODING).unwrap(), "zstd");
+        let body = test::read_body(res).await;
+        assert!(body.len() < big.len());
+        assert_eq!(zstd::stream::decode_all(&body[..]).unwrap(), big);
+
+        // Below MIN_COMPRESS_SIZE stays identity even when zstd accepted.
+        let res = test::call_service(
+            &app,
+            test::TestRequest::get()
+                .uri("/tiny")
+                .insert_header((ACCEPT_ENCODING, "zstd"))
+                .to_request(),
+        )
+        .await;
+        assert!(res.headers().get(CONTENT_ENCODING).is_none());
+        assert_eq!(test::read_body(res).await, "ok");
+    }
+}


### PR DESCRIPTION
actix-web's Compress middleware hard-codes zstd level 3 and exposes no parameters, so it cannot exploit two properties every NAR response has: the exact uncompressed size is known from the path-info lookup, and large NARs contain long-range repetition (near-duplicate ELF sections, vendored sources) far beyond the ~2 MiB level-3 window.

Add a dedicated ZstdMiddleware that pledges the body size to libzstd and defaults to level 1 with long-distance matching (windowLog capped at 25, 32 MiB decoder buffer). On a 500 MiB python3+numpy+pandas closure this is both smaller and roughly twice as fast as the previous level-3 path:

  wire ratio          0.276 -> 0.262
  http/concurrent_16  1268 ms -> 611 ms

The middleware wraps every route, so narinfo/narlist/buildlog get the same encoder and the compress-zstd actix feature can be dropped. Bodies under 256 B, HEAD requests and responses that already carry a Content-Encoding (range requests) pass through unchanged. Compression stays off by default; operators opt in via enable_compression and may retune via the new [zstd] config section.

The bench gains Accept-Encoding/chunked support, identity vs zstd variants, a one-shot wire-size probe, and a HARMONIA_PERF_RECORD hook that profiles only the server process so call-graph captures stay manageable.