### PR TITLE
utils-io: drop noisy "buffer is still shared" warning

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1171,7 +1171,6 @@ dependencies = [
  "rstest",
  "tokio",
  "tokio-test",
- "tracing",
 ]
 
 [[package]]

--- a/harmonia-utils-io/Cargo.toml
+++ b/harmonia-utils-io/Cargo.toml
@@ -18,7 +18,6 @@ bytes            = { workspace = true }
 futures-util     = { workspace = true }
 pin-project-lite = { workspace = true }
 tokio            = { workspace = true, features = [ "io-util", "sync" ] }
-tracing          = { workspace = true }
 
 [dev-dependencies]
 hex-literal = { workspace = true }

--- a/harmonia-utils-io/src/bytes_reader/buffer/buffer_mut.rs
+++ b/harmonia-utils-io/src/bytes_reader/buffer/buffer_mut.rs
@@ -7,7 +7,6 @@ use std::sync::Arc;
 use std::{cmp, slice};
 
 use bytes::{Buf, BufMut};
-use tracing::warn;
 
 pub struct Filled {
     ptr: NonNull<u8>,
@@ -279,8 +278,9 @@ impl BufferMut {
         if !allocate {
             return false;
         }
-        warn!(additional, "buffer is still shared");
-
+        // Arc is still shared (a `Filled`/`Bytes` handle outlives this reserve),
+        // so we cannot grow in place and must reallocate + copy. This is normal
+        // during streaming.
         new_cap = cmp::max(new_cap, self.data.capacity());
 
         // Create a new vector to store the data


### PR DESCRIPTION

The warning fired on the normal streaming path whenever reserve() ran
while a downstream consumer still held a Bytes slice of the buffer,
which is expected behaviour and not an error. In production this flooded
journald with thousands of lines per NAR. The reallocation it flagged is
a benign performance detail, so remove the log and the now-unused
tracing dependency.

See https://github.com/nix-community/harmonia/issues/979#issuecomment-1


