### PR TITLE
Crypto/TLS hardening

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1137,6 +1137,7 @@ dependencies = [
  "rstest",
  "serde",
  "serde_json",
+ "subtle",
  "tempfile",
  "thiserror",
  "tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1141,6 +1141,7 @@ dependencies = [
  "thiserror",
  "tracing",
  "zerocopy",
+ "zeroize",
 ]
 
 [[package]]

--- a/harmonia-cache/src/config.rs
+++ b/harmonia-cache/src/config.rs
@@ -169,6 +169,7 @@ pub(crate) fn load() -> Result<Config> {
         }
     }
     for sign_key_path in &settings.sign_key_paths {
+        crate::tls::warn_insecure_permissions(sign_key_path);
         let key_content =
             read_to_string(sign_key_path).map_err(|e| ConfigError::InvalidSigningKey {
                 reason: format!(

--- a/harmonia-cache/src/narinfo.rs
+++ b/harmonia-cache/src/narinfo.rs
@@ -98,13 +98,9 @@ fn build_narinfo(
         res.sigs
             .push(sk.sign(&fingerprint).to_string().into_bytes());
     }
-    if res.sigs.is_empty() {
-        res.sigs = info
-            .signatures()
-            .iter()
-            .map(|s| s.as_bytes().to_vec())
-            .collect();
-    }
+    // Keep db sigs (e.g. cache.nixos.org) so upstream-only clients still verify.
+    res.sigs
+        .extend(info.signatures().iter().map(|s| s.as_bytes().to_vec()));
 
     Ok(res)
 }

--- a/harmonia-cache/src/tls.rs
+++ b/harmonia-cache/src/tls.rs
@@ -1,12 +1,13 @@
 use crate::error::{IoErrorContext, Result, ServerError as ServerErrorType};
 use rustls::ServerConfig;
-use rustls_pemfile::{certs, pkcs8_private_keys, rsa_private_keys};
-use rustls_pki_types::PrivateKeyDer;
+use rustls_pemfile::{certs, private_key};
 use std::fs::File;
 use std::io::BufReader;
+use std::os::unix::fs::PermissionsExt;
 use std::path::Path;
 
 pub fn load_tls_config(cert_path: &Path, key_path: &Path) -> Result<ServerConfig> {
+    warn_insecure_permissions(key_path);
     // Load certificate chain
     let cert_file = File::open(cert_path).io_context("Failed to open certificate file")?;
     let mut cert_reader = BufReader::new(cert_file);
@@ -17,43 +18,19 @@ pub fn load_tls_config(cert_path: &Path, key_path: &Path) -> Result<ServerConfig
         })?);
     }
 
-    // Load private key from PEM file - try PKCS8 first
+    // Accepts PKCS8/PKCS1/SEC1 and surfaces the real parse error.
     let key_file = File::open(key_path).io_context("Failed to open private key file")?;
     let mut key_reader = BufReader::new(key_file);
-    let pkcs8_keys: Vec<_> = pkcs8_private_keys(&mut key_reader)
-        .filter_map(|k| k.ok())
-        .collect();
-
-    let key = if !pkcs8_keys.is_empty() {
-        PrivateKeyDer::Pkcs8(
-            pkcs8_keys
-                .into_iter()
-                .next()
-                .expect("failed to extract first PKCS8 private key from non-empty key collection"),
-        )
-    } else {
-        // Try RSA format
-        let key_file = File::open(key_path).io_context("Failed to reopen private key file")?;
-        let mut key_reader = BufReader::new(key_file);
-        let rsa_keys: Vec<_> = rsa_private_keys(&mut key_reader)
-            .filter_map(|k| k.ok())
-            .collect();
-
-        if rsa_keys.is_empty() {
-            return Err(ServerErrorType::TlsSetup {
-                reason: "No valid private key found in PEM file (tried PKCS8 and RSA formats)"
-                    .to_string(),
-            }
-            .into());
-        }
-
-        PrivateKeyDer::Pkcs1(
-            rsa_keys
-                .into_iter()
-                .next()
-                .expect("rsa keys vector is not empty but iterator returned None"),
-        )
-    };
+    let key = private_key(&mut key_reader)
+        .map_err(|e| ServerErrorType::TlsSetup {
+            reason: format!("Failed to parse private key {}: {e}", key_path.display()),
+        })?
+        .ok_or_else(|| ServerErrorType::TlsSetup {
+            reason: format!(
+                "No PKCS8/PKCS1/SEC1 private key found in {}",
+                key_path.display()
+            ),
+        })?;
 
     // Create rustls config
     ServerConfig::builder()
@@ -63,4 +40,18 @@ pub fn load_tls_config(cert_path: &Path, key_path: &Path) -> Result<ServerConfig
             reason: format!("Failed to create TLS config: {e}"),
         })
         .map_err(Into::into)
+}
+
+/// Warn (not fail) when a secret file is group/other-readable.
+pub(crate) fn warn_insecure_permissions(path: &Path) {
+    if let Ok(meta) = std::fs::metadata(path) {
+        let mode = meta.permissions().mode() & 0o777;
+        if mode & 0o077 != 0 {
+            tracing::warn!(
+                "{} has insecure permissions {:#o}; recommend 0600",
+                path.display(),
+                mode
+            );
+        }
+    }
 }

--- a/harmonia-store-core/Cargo.toml
+++ b/harmonia-store-core/Cargo.toml
@@ -29,6 +29,7 @@ serde_json                   = { workspace = true }
 thiserror                    = { workspace = true }
 tracing                      = { workspace = true }
 zerocopy                     = { version = "0.8", features = [ "derive" ] }
+zeroize                      = { version = "1" }
 
 [dev-dependencies]
 harmonia-store-core = { path = ".", features = [ "test" ] }

--- a/harmonia-store-core/Cargo.toml
+++ b/harmonia-store-core/Cargo.toml
@@ -26,6 +26,7 @@ proptest                     = { workspace = true, optional = true }
 proptest-derive              = { workspace = true, optional = true }
 serde                        = { workspace = true }
 serde_json                   = { workspace = true }
+subtle                       = { version = "2", default-features = false }
 thiserror                    = { workspace = true }
 tracing                      = { workspace = true }
 zerocopy                     = { version = "0.8", features = [ "derive" ] }

--- a/harmonia-store-core/src/signature.rs
+++ b/harmonia-store-core/src/signature.rs
@@ -13,6 +13,7 @@ use serde::ser::{SerializeStruct, Serializer};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use tracing::error;
+use zeroize::{Zeroize, Zeroizing};
 
 use crate::store_path::{StoreDir, StorePath};
 use harmonia_utils_base_encoding::base64_len;
@@ -268,12 +269,12 @@ pub struct SecretKey {
 impl SecretKey {
     pub fn generate(name: String) -> Result<SecretKey, GenerateKeyError> {
         let name = Arc::new(name);
-        let mut seed = [0u8; SEED_BYTES];
-        getrandom::fill(&mut seed).map_err(|_| GenerateKeyError)?;
+        let mut seed = Zeroizing::new([0u8; SEED_BYTES]);
+        getrandom::fill(&mut *seed).map_err(|_| GenerateKeyError)?;
         let key = SigningKey::from_bytes(&seed);
         let pk = key.verifying_key();
         let mut key_data = [0u8; SECRET_KEY_BYTES];
-        key_data[0..SEED_BYTES].copy_from_slice(&seed);
+        key_data[0..SEED_BYTES].copy_from_slice(&*seed);
         key_data[SEED_BYTES..SECRET_KEY_BYTES].copy_from_slice(pk.as_bytes());
         Ok(SecretKey {
             name,
@@ -308,11 +309,19 @@ impl SecretKey {
     }
 }
 
+impl Drop for SecretKey {
+    fn drop(&mut self) {
+        // Wipe our copy of seed||pubkey; SigningKey zeroizes itself.
+        self.key_data.zeroize();
+    }
+}
+
 impl fmt::Debug for SecretKey {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // Redacted: Debug output reaches logs/panics.
         f.debug_struct("SecretKey")
             .field("name", &self.name)
-            .field("key", &format_args!("{}", self.key()))
+            .field("key", &"<redacted>")
             .finish()
     }
 }
@@ -330,12 +339,6 @@ impl PartialEq for SecretKey {
 
 impl Eq for SecretKey {}
 
-impl From<SecretKey> for PublicKey {
-    fn from(v: SecretKey) -> Self {
-        v.to_public_key()
-    }
-}
-
 impl<'a> From<&'a SecretKey> for PublicKey {
     fn from(v: &'a SecretKey) -> Self {
         v.to_public_key()
@@ -352,16 +355,16 @@ impl FromStr for SecretKey {
         if key_s.len() != SECRET_KEY_BASE64_LEN {
             return Err(ParseKeyError::InvalidSecretKey);
         }
-        let mut key_b = [0u8; SECRET_KEY_BASE64_DECODED_LEN];
+        let mut key_b = Zeroizing::new([0u8; SECRET_KEY_BASE64_DECODED_LEN]);
         let len = BASE64
-            .decode_mut(key_s.as_bytes(), &mut key_b)
+            .decode_mut(key_s.as_bytes(), &mut *key_b)
             .map_err(|_| ParseKeyError::InvalidSecretKey)?;
         if len != SECRET_KEY_BYTES {
             return Err(ParseKeyError::InvalidSecretKey);
         }
         let mut key_data = [0u8; SECRET_KEY_BYTES];
         key_data.copy_from_slice(&key_b[..SECRET_KEY_BYTES]);
-        let mut seed = [0u8; SEED_BYTES];
+        let mut seed = Zeroizing::new([0u8; SEED_BYTES]);
         seed.copy_from_slice(&key_data[0..SEED_BYTES]);
         let public_key = &key_data[SEED_BYTES..SECRET_KEY_BYTES];
         let key = SigningKey::from_bytes(&seed);
@@ -506,6 +509,14 @@ mod unittests {
         assert_eq!(sk.to_public_key(), pk);
         assert_eq!(sk.to_string(), sk_s);
         assert_eq!(pk.to_string(), pk_s);
+    }
+
+    /// `Debug` must redact key material so it can't leak via logs/panics.
+    #[test]
+    fn test_secret_key_debug_redacts_key() {
+        let sk = SecretKey::generate("k".into()).unwrap();
+        let dbg = format!("{sk:?}");
+        assert!(!dbg.contains(&sk.key().to_string()), "leaked: {dbg}");
     }
 
     #[test]

--- a/harmonia-store-core/src/signature.rs
+++ b/harmonia-store-core/src/signature.rs
@@ -11,6 +11,7 @@ use ed25519_dalek::{Signer, SigningKey, Verifier, VerifyingKey};
 use serde::de::{self, Deserializer, MapAccess, Visitor};
 use serde::ser::{SerializeStruct, Serializer};
 use serde::{Deserialize, Serialize};
+use subtle::ConstantTimeEq;
 use thiserror::Error;
 use tracing::error;
 use zeroize::{Zeroize, Zeroizing};
@@ -333,7 +334,8 @@ impl fmt::Display for SecretKey {
 
 impl PartialEq for SecretKey {
     fn eq(&self, other: &Self) -> bool {
-        self.name == other.name && self.key_data == other.key_data
+        // Constant-time on the secret bytes to avoid a timing oracle.
+        self.name == other.name && bool::from(self.key_data.ct_eq(&other.key_data))
     }
 }
 


### PR DESCRIPTION

Check on permissions for tls keys.
Constant time signature verification.
Redact debug output for key material.
Pass through db signatures alongside local ones.
