### PR TITLE
Security hardening: dependencies, unsafe code & NAR parser bounds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -994,7 +994,6 @@ dependencies = [
  "percent-encoding",
  "prometheus",
  "rustls",
- "rustls-pemfile",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -2100,15 +2099,6 @@ dependencies = [
  "rustls-webpki",
  "subtle",
  "zeroize",
-]
-
-[[package]]
-name = "rustls-pemfile"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
-dependencies = [
- "rustls-pki-types",
 ]
 
 [[package]]

--- a/harmonia-cache/Cargo.toml
+++ b/harmonia-cache/Cargo.toml
@@ -26,8 +26,7 @@ rustls = { version = "0.23", default-features = false, features = [
     "tls12",
     "logging",
 ] }
-rustls-pemfile = "2"
-rustls-pki-types = "1"
+rustls-pki-types = { version = "1", features = [ "std" ] }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/harmonia-cache/src/nar.rs
+++ b/harmonia-cache/src/nar.rs
@@ -138,16 +138,18 @@ pub(crate) async fn get(
     // Credit actix_web actix-files: https://github.com/actix/actix-web/blob/master/actix-files/src/named.rs#L525
     if let Some(ranges) = req.headers().get(http::header::RANGE) {
         if let Ok(ranges_header) = ranges.to_str() {
-            if let Ok(ranges) = HttpRange::parse(ranges_header, rlength) {
-                let range_length = ranges[0].length;
-                let offset = ranges[0].start;
+            if let Ok(ranges) = HttpRange::parse(ranges_header, rlength)
+                && let Some(first) = ranges.first()
+            {
+                let range_length = first.length;
+                let offset = first.start;
 
                 if settings.enable_compression {
                     // The zstd middleware skips responses that already carry a
                     // Content-Encoding; partial content must stay byte-exact.
                     res.insert_header((
                         http::header::CONTENT_ENCODING,
-                        http::header::HeaderValue::from_static("none"),
+                        http::header::HeaderValue::from_static("identity"),
                     ));
                 }
 

--- a/harmonia-cache/src/tls.rs
+++ b/harmonia-cache/src/tls.rs
@@ -1,38 +1,33 @@
-use crate::error::{IoErrorContext, Result, ServerError as ServerErrorType};
+use crate::error::{Result, ServerError as ServerErrorType};
 use rustls::ServerConfig;
-use rustls_pemfile::{certs, private_key};
-use std::fs::File;
-use std::io::BufReader;
+use rustls_pki_types::pem::PemObject;
+use rustls_pki_types::{CertificateDer, PrivateKeyDer};
 use std::os::unix::fs::PermissionsExt;
 use std::path::Path;
 
 pub fn load_tls_config(cert_path: &Path, key_path: &Path) -> Result<ServerConfig> {
     warn_insecure_permissions(key_path);
-    // Load certificate chain
-    let cert_file = File::open(cert_path).io_context("Failed to open certificate file")?;
-    let mut cert_reader = BufReader::new(cert_file);
-    let mut cert_chain = Vec::new();
-    for cert in certs(&mut cert_reader) {
-        cert_chain.push(cert.map_err(|e| ServerErrorType::TlsSetup {
-            reason: format!("Failed to parse certificate: {e}"),
-        })?);
-    }
 
-    // Accepts PKCS8/PKCS1/SEC1 and surfaces the real parse error.
-    let key_file = File::open(key_path).io_context("Failed to open private key file")?;
-    let mut key_reader = BufReader::new(key_file);
-    let key = private_key(&mut key_reader)
+    let cert_chain = CertificateDer::pem_file_iter(cert_path)
         .map_err(|e| ServerErrorType::TlsSetup {
-            reason: format!("Failed to parse private key {}: {e}", key_path.display()),
-        })?
-        .ok_or_else(|| ServerErrorType::TlsSetup {
             reason: format!(
-                "No PKCS8/PKCS1/SEC1 private key found in {}",
-                key_path.display()
+                "Failed to open certificate file {}: {e}",
+                cert_path.display()
             ),
+        })?
+        .collect::<std::result::Result<Vec<_>, _>>()
+        .map_err(|e| ServerErrorType::TlsSetup {
+            reason: format!("Failed to parse certificate: {e}"),
         })?;
 
-    // Create rustls config
+    // `PrivateKeyDer::from_pem_file` accepts PKCS#8, PKCS#1 and SEC1.
+    let key = PrivateKeyDer::from_pem_file(key_path).map_err(|e| ServerErrorType::TlsSetup {
+        reason: format!(
+            "Failed to read private key from {}: {e}",
+            key_path.display()
+        ),
+    })?;
+
     ServerConfig::builder()
         .with_no_client_auth()
         .with_single_cert(cert_chain, key)

--- a/harmonia-cache/src/zstd_body.rs
+++ b/harmonia-cache/src/zstd_body.rs
@@ -332,7 +332,7 @@ where
             let res = fut.await?;
             Ok(res.map_body(|head, body| {
                 // A handler-set Content-Encoding also covers range responses,
-                // which set `none` to keep partial content byte-exact.
+                // which set `identity` to keep partial content byte-exact.
                 if !wants_zstd
                     || head.headers().contains_key(CONTENT_ENCODING)
                     || head.status.is_redirection()

--- a/harmonia-nar/src/archive/parser.rs
+++ b/harmonia-nar/src/archive/parser.rs
@@ -15,6 +15,11 @@ use harmonia_utils_io::{AsyncBufReadCompat, AsyncBytesRead, BytesReader, Lending
 use super::NarEvent;
 use super::read_nar::{Inner, InnerState, NodeType};
 
+// Cap fully-buffered length fields so a hostile NAR cannot force unbounded
+// allocation; both well above NAME_MAX/PATH_MAX.
+const MAX_ENTRY_NAME_LEN: u64 = 4096;
+const MAX_SYMLINK_TARGET_LEN: u64 = 64 * 1024;
+
 pin_project! {
     pub struct NarParser<R> {
         #[pin]
@@ -94,32 +99,40 @@ where
                     })));
                 }
                 InnerState::ReadContents(NodeType::Symlink, len, aligned) => {
-                    let aligned = aligned.try_into().map_err(|_| {
-                        io::Error::new(io::ErrorKind::InvalidData, "Symlink target way too long")
-                    })?;
+                    if len > MAX_SYMLINK_TARGET_LEN {
+                        return Poll::Ready(Some(Err(io::Error::new(
+                            io::ErrorKind::InvalidData,
+                            "symlink target too long",
+                        ))));
+                    }
+                    let (len, aligned) = (len as usize, aligned as usize);
                     while buf.len() < aligned {
                         buf = ready!(reader.as_mut().poll_force_fill_buf(cx))?;
                     }
 
-                    let target = buf.split_to(len as usize);
-                    buf.advance(aligned - len as usize);
+                    let target = buf.split_to(len);
+                    buf.advance(aligned - len);
                     reader.as_mut().consume(aligned);
                     this.state.bump_next();
                     let name = this.name.take().unwrap_or_default();
                     return Poll::Ready(Some(Ok(NarEvent::Symlink { name, target })));
                 }
                 InnerState::ReadEntryName(len, aligned) => {
-                    let aligned = aligned.try_into().map_err(|_| {
-                        io::Error::new(io::ErrorKind::InvalidData, "Entry name way too long")
-                    })?;
+                    if len > MAX_ENTRY_NAME_LEN {
+                        return Poll::Ready(Some(Err(io::Error::new(
+                            io::ErrorKind::InvalidData,
+                            "directory entry name too long",
+                        ))));
+                    }
+                    let (len, aligned) = (len as usize, aligned as usize);
                     while buf.len() < aligned {
                         buf = ready!(reader.as_mut().poll_force_fill_buf(cx))?;
                         trace!(len = buf.len(), "Reading name");
                     }
-                    let name_buf = buf.split_to(len as usize);
+                    let name_buf = buf.split_to(len);
                     trace!(len = buf.len(), ?name_buf, "Read name");
                     *this.name = Some(name_buf);
-                    buf.advance(aligned - len as usize);
+                    buf.advance(aligned - len);
                     reader.as_mut().consume(aligned);
                     this.state.bump_next();
                 }
@@ -161,14 +174,12 @@ where
 
 #[cfg(test)]
 mod unittests {
-    use std::io::Cursor;
+    use std::io::{self, Cursor};
 
-    use bytes::Bytes;
-    use futures_util::TryStreamExt;
     use rstest::rstest;
     use tokio::fs::File;
-    use tokio::io::AsyncReadExt as _;
 
+    use crate::archive::read_nar::{TOK_DIR, TOK_ENTRY, TOK_ROOT, TOK_SYM};
     use crate::archive::{test_data, write_nar};
 
     use super::*;
@@ -180,33 +191,25 @@ mod unittests {
     #[case::text_file("test-data/test-text.nar", test_data::text_file())]
     async fn test_parse_nar(#[case] file: &str, #[case] expected: test_data::TestNarEvents) {
         let io = File::open(file).await.unwrap();
-        let s = parse_nar(io)
-            .and_then(|event| async {
-                Ok(match event {
-                    NarEvent::File {
-                        name,
-                        executable,
-                        size,
-                        mut reader,
-                    } => {
-                        let mut content = Vec::new();
-                        reader.read_to_end(&mut content).await?;
-                        NarEvent::File {
-                            name,
-                            executable,
-                            size,
-                            reader: Cursor::new(Bytes::from(content)),
-                        }
-                    }
-                    NarEvent::Symlink { name, target } => NarEvent::Symlink { name, target },
-                    NarEvent::StartDirectory { name } => NarEvent::StartDirectory { name },
-                    NarEvent::EndDirectory => NarEvent::EndDirectory,
-                })
-            })
-            .try_collect::<test_data::TestNarEvents>()
-            .await
-            .unwrap();
-        assert_eq!(s, expected);
+        let actual = read_nar(io).await.unwrap();
+        assert_eq!(actual, expected);
+    }
+
+    /// Hostile length fields must yield InvalidData, not allocate or panic.
+    #[tokio::test]
+    #[rstest]
+    #[case::symlink_huge(TOK_SYM, 1 << 30)]
+    #[case::symlink_wrap(TOK_SYM, u64::MAX)]
+    #[case::name_huge(&[TOK_DIR, TOK_ENTRY].concat(), 1 << 30)]
+    #[case::name_wrap(&[TOK_DIR, TOK_ENTRY].concat(), u64::MAX)]
+    async fn reject_oversized_length(#[case] prefix: &[u8], #[case] len: u64) {
+        let mut nar = Vec::from(TOK_ROOT);
+        nar.extend_from_slice(prefix);
+        nar.extend_from_slice(&len.to_le_bytes());
+        nar.extend_from_slice(&[0u8; 64]); // enough for one drive() iteration
+
+        let err = read_nar(Cursor::new(nar)).await.unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
     }
 
     #[tokio::test]

--- a/harmonia-nar/src/archive/read_nar.rs
+++ b/harmonia-nar/src/archive/read_nar.rs
@@ -174,6 +174,8 @@ pub const TOK_FILE: &[u8] = token!(b"regular", b"contents");
 pub const TOK_SYM: &[u8] = token!(b"symlink", b"target");
 pub const TOK_DIR: &[u8] = token!(b"directory");
 
+const MAX_NAR_DEPTH: usize = 4096;
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum NodeType {
     File,
@@ -379,6 +381,12 @@ impl<const P: bool> Inner<P> {
                 */
                 InnerState::ReadDir => {
                     trace!(self.level, parsed, "InnerState::ReadDir");
+                    if self.level >= MAX_NAR_DEPTH {
+                        return Err(io::Error::new(
+                            io::ErrorKind::InvalidData,
+                            "NAR directory nesting too deep",
+                        ));
+                    }
                     self.level += 1;
                     if !P {
                         break;


### PR DESCRIPTION

- `harmonia-nar`: bound name/symlink/depth in NAR parser
- `harmonia-cache`: drop unmaintained `rustls-pemfile` (RUSTSEC-2025-0134)
- `harmonia-cache`: harden Range handling in NAR endpoint
