### PR TITLE
harmonia-cache: stop leaking internal error details in HTTP responses

### DIFF
--- a/harmonia-cache/src/main.rs
+++ b/harmonia-cache/src/main.rs
@@ -109,15 +109,43 @@ impl Display for ServerError {
 impl actix_web::error::ResponseError for ServerError {
     fn status_code(&self) -> actix_web::http::StatusCode {
         use actix_web::http::StatusCode;
+        // Exhaustive on `CacheError` so adding a variant forces an explicit
+        // status decision rather than silently inheriting 500.
         match &self.err {
-            CacheError::Config(_) => StatusCode::INTERNAL_SERVER_ERROR,
             CacheError::Store(StoreError::PathQuery { .. }) => StatusCode::NOT_FOUND,
-            CacheError::Signing(_) => StatusCode::INTERNAL_SERVER_ERROR,
-            CacheError::Serve(_) => StatusCode::INTERNAL_SERVER_ERROR,
-            CacheError::BuildLog(_) => StatusCode::INTERNAL_SERVER_ERROR,
-            CacheError::NarInfo(_) => StatusCode::INTERNAL_SERVER_ERROR,
-            _ => StatusCode::INTERNAL_SERVER_ERROR,
+            // Handlers wrap fs lookups in `io_context`; a missing file under a
+            // resolved store path (GC race, stale client URL) is a lookup miss.
+            CacheError::Io { source, .. } if source.kind() == std::io::ErrorKind::NotFound => {
+                StatusCode::NOT_FOUND
+            }
+            CacheError::Io { .. }
+            | CacheError::Store(StoreError::Db { .. })
+            | CacheError::Config(_)
+            | CacheError::Server(_)
+            | CacheError::Signing(_)
+            | CacheError::Fingerprint(_)
+            | CacheError::NarInfo(_)
+            | CacheError::BuildLog(_)
+            // `ServeError::AccessDenied` is a server-side store anomaly (path
+            // without a file name), not client authz, hence 500 not 403.
+            | CacheError::Serve(_) => StatusCode::INTERNAL_SERVER_ERROR,
         }
+    }
+
+    // The default impl writes `Display` into the body, which would leak
+    // filesystem paths and OS error strings embedded in `CacheError`. Log the
+    // detail server-side and hand the client only the status phrase.
+    fn error_response(&self) -> HttpResponse {
+        let status = self.status_code();
+        if status.is_server_error() {
+            tracing::error!("request failed: {}", self.err);
+        } else {
+            tracing::debug!("request rejected: {}", self.err);
+        }
+        HttpResponse::build(status)
+            .insert_header(cache_control_no_store())
+            .content_type("text/plain; charset=utf-8")
+            .body(status.canonical_reason().unwrap_or("error"))
     }
 }
 

--- a/harmonia-cache/src/serve.rs
+++ b/harmonia-cache/src/serve.rs
@@ -120,10 +120,21 @@ pub(crate) async fn get(
     } else {
         store_path.join(dir)
     };
-    let full_path = full_path.canonicalize().io_context(format!(
-        "cannot resolve nix store path: {}",
-        full_path.display()
-    ))?;
+    let full_path = match full_path.canonicalize() {
+        Ok(p) => p,
+        // A missing sub-path under a valid store path is a client lookup miss,
+        // not a server fault; short-circuit before the generic Io mapping so
+        // the response carries the same no-store 404 as `some_or_404!`.
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            return Ok(HttpResponse::NotFound()
+                .insert_header(crate::cache_control_no_store())
+                .body("missed hash"));
+        }
+        Err(e) => Err(e).io_context(format!(
+            "cannot resolve nix store path: {}",
+            full_path.display()
+        ))?,
+    };
 
     let real_store = settings
         .store

--- a/harmonia-cache/tests/error_responses.rs
+++ b/harmonia-cache/tests/error_responses.rs
@@ -1,0 +1,145 @@
+//! Regression tests for HTTP error-response hygiene: handlers must not leak
+//! server filesystem paths, OS error strings or internal error-type names to
+//! clients, and lookup misses must map to 4xx rather than 5xx.
+
+use std::fs;
+use std::process::Command;
+
+mod common;
+
+use common::{CanonicalTempDir, LocalStore, TestCache, pick_unused_port, start_harmonia_cache};
+
+type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
+
+/// Spin up a cache with one directory store path and return (port, guard,
+/// store_dir, dir_hash).
+async fn cache_with_dir() -> Result<(u16, Box<dyn Send>, std::path::PathBuf, String)> {
+    let temp_dir = CanonicalTempDir::new()?;
+    let store_dir = temp_dir.path().join("store");
+    let state_dir = temp_dir.path().join("var/nix");
+
+    let test_dir = temp_dir.path().join("my-dir");
+    fs::create_dir_all(&test_dir)?;
+    fs::write(test_dir.join("my-file"), "test contents")?;
+
+    let out = Command::new("nix")
+        .args([
+            "--extra-experimental-features",
+            "nix-command",
+            "store",
+            "add-path",
+            "--store",
+            &format!(
+                "local?store={}&state={}",
+                store_dir.display(),
+                state_dir.display()
+            ),
+            test_dir.to_str().unwrap(),
+        ])
+        .env_remove("NIX_REMOTE")
+        .output()?;
+    if !out.status.success() {
+        return Err(format!(
+            "nix store add-path failed: {}",
+            String::from_utf8_lossy(&out.stderr)
+        )
+        .into());
+    }
+    let dir_path = String::from_utf8(out.stdout)?.trim().to_string();
+    let dir_hash = dir_path
+        .rsplit('/')
+        .next()
+        .and_then(|n| n.split('-').next())
+        .ok_or("bad store path")?
+        .to_string();
+
+    let store = LocalStore::init_at(store_dir.clone(), state_dir)?;
+    let port = pick_unused_port().ok_or("no free port")?;
+    let cfg = format!(
+        r#"
+bind = "127.0.0.1:{port}"
+nix_db_path = "{}"
+virtual_nix_store = "{}"
+real_nix_store = "{}"
+"#,
+        store.db_path().display(),
+        store_dir.display(),
+        store_dir.display(),
+    );
+    let guard = start_harmonia_cache(&cfg, port).await?;
+    // Keep temp_dir alive by leaking it into the guard tuple via Box.
+    let guard: Box<dyn Send> = Box::new((guard, temp_dir));
+    Ok((port, guard, store_dir, dir_hash))
+}
+
+/// Requesting a non-existent file under a valid store path used to bubble the
+/// `canonicalize()` ENOENT up as a 500 whose body contained the on-disk store
+/// path and libc error string. It must be a plain 404 with no internal detail.
+#[tokio::test]
+async fn serve_missing_file_does_not_leak_fs_path() -> Result<()> {
+    let (port, _guard, store_dir, dir_hash) = cache_with_dir().await?;
+
+    let out = Command::new("curl")
+        .args([
+            "--silent",
+            "--max-time",
+            "5",
+            "--write-out",
+            "\n%{http_code}",
+            &format!("http://127.0.0.1:{port}/serve/{dir_hash}/does-not-exist"),
+        ])
+        .output()?;
+    assert!(out.status.success(), "curl invocation failed");
+    let resp = String::from_utf8(out.stdout)?;
+    let (body, status) = resp.rsplit_once('\n').ok_or("no status line")?;
+
+    // A missing sub-path is a client lookup miss, not a server fault.
+    assert_eq!(
+        status, "404",
+        "expected 404 for missing sub-path, got {status} (body: {body:?})"
+    );
+
+    // The on-disk store directory must never appear in a response body.
+    let store_dir = store_dir.display().to_string();
+    assert!(
+        !body.contains(&store_dir),
+        "response body leaks server filesystem path {store_dir:?}: {body:?}"
+    );
+    // Generic guard against any io::Error detail leaking through.
+    assert!(
+        !body.to_ascii_lowercase().contains("no such file"),
+        "response body leaks io error detail: {body:?}"
+    );
+
+    Ok(())
+}
+
+/// Malformed hash input must not be reflected back with internal error-type
+/// wording (`Store error: ... Invalid hash format: ...`).
+#[tokio::test]
+async fn invalid_hash_response_is_generic() -> Result<()> {
+    let cache = TestCache::start().await?;
+
+    // 32 chars but 'e' is not in the nixbase32 alphabet.
+    let bad_hash = "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee";
+    let out = Command::new("curl")
+        .args([
+            "--silent",
+            "--max-time",
+            "5",
+            "--write-out",
+            "\n%{http_code}",
+            &cache.url(&format!("/{bad_hash}.narinfo")),
+        ])
+        .output()?;
+    let resp = String::from_utf8(out.stdout)?;
+    let (body, status) = resp.rsplit_once('\n').unwrap();
+
+    assert_eq!(status, "404");
+    assert!(
+        !body.contains("Store error") && !body.contains("Invalid hash format"),
+        "response body exposes internal error taxonomy: {body:?}"
+    );
+
+    Ok(())
+}


### PR DESCRIPTION

ServerError relied on actix default ResponseError::error_response(),
which writes Display into the body. CacheError Display embeds io_context
strings that contain on-disk store paths plus the libc error string, so
e.g. GET /serve/<hash>/missing returned 500 with the full real_nix_store
path and "No such file or directory". Malformed-hash requests likewise
echoed the internal error taxonomy.
