### PR TITLE
harmonia-cache: return 4xx for malformed hash on .ls and /log/

### DIFF
--- a/harmonia-cache/src/buildlog.rs
+++ b/harmonia-cache/src/buildlog.rs
@@ -1,4 +1,4 @@
-use crate::error::{BuildLogError, CacheError, IoErrorContext, Result};
+use crate::error::{IoErrorContext, Result};
 use actix_files::NamedFile;
 use actix_web::Responder;
 use actix_web::http::header::HeaderValue;
@@ -48,11 +48,7 @@ pub(crate) async fn get(
     req: HttpRequest,
     settings: web::Data<Config>,
 ) -> crate::ServerResult {
-    let drv_path = some_or_404!(query_drv_path(&settings, drv.as_bytes()).map_err(|e| {
-        CacheError::from(BuildLogError::QueryFailed {
-            reason: format!("Could not query nar hash in database for {drv}: {e}"),
-        })
-    })?);
+    let drv_path = some_or_404!(query_drv_path(&settings, drv.as_bytes())?);
     if !settings.store.is_valid_path(&drv_path)? {
         return Ok(HttpResponse::NotFound()
             .insert_header(cache_control_no_store())

--- a/harmonia-cache/src/error.rs
+++ b/harmonia-cache/src/error.rs
@@ -27,9 +27,6 @@ pub enum CacheError {
     #[error("NARInfo error: {0}")]
     NarInfo(#[from] NarInfoError),
 
-    #[error("Build log error: {0}")]
-    BuildLog(#[from] BuildLogError),
-
     #[error("File serving error: {0}")]
     Serve(#[from] ServeError),
 }
@@ -74,12 +71,6 @@ pub enum StoreError {
 #[derive(Error, Debug)]
 pub enum NarInfoError {
     #[error("Failed to query path info: {reason}")]
-    QueryFailed { reason: String },
-}
-
-#[derive(Error, Debug)]
-pub enum BuildLogError {
-    #[error("Failed to query derivation path: {reason}")]
     QueryFailed { reason: String },
 }
 

--- a/harmonia-cache/src/main.rs
+++ b/harmonia-cache/src/main.rs
@@ -125,7 +125,6 @@ impl actix_web::error::ResponseError for ServerError {
             | CacheError::Signing(_)
             | CacheError::Fingerprint(_)
             | CacheError::NarInfo(_)
-            | CacheError::BuildLog(_)
             // `ServeError::AccessDenied` is a server-side store anomaly (path
             // without a file name), not client authz, hence 500 not 403.
             | CacheError::Serve(_) => StatusCode::INTERNAL_SERVER_ERROR,

--- a/harmonia-cache/src/narlist.rs
+++ b/harmonia-cache/src/narlist.rs
@@ -1,5 +1,5 @@
 use crate::ServerResult;
-use crate::error::{CacheError, IoErrorContext, NarInfoError, Result, ServeError};
+use crate::error::{CacheError, IoErrorContext, Result, ServeError};
 use actix_web::{HttpResponse, http, web};
 use serde::{Deserialize, Serialize};
 use std::fs::Metadata;
@@ -164,11 +164,7 @@ async fn get_nar_list(path: PathBuf) -> Result<NarList> {
 }
 
 pub(crate) async fn get(hash: web::Path<String>, settings: web::Data<Config>) -> ServerResult {
-    let store_path = some_or_404!(nixhash(&settings, hash.as_bytes()).map_err(|e| {
-        CacheError::from(NarInfoError::QueryFailed {
-            reason: format!("Could not query nar hash in database: {e}"),
-        })
-    })?);
+    let store_path = some_or_404!(nixhash(&settings, hash.as_bytes())?);
 
     let nar_list = get_nar_list(settings.store.get_real_path(&store_path)).await?;
     Ok(HttpResponse::Ok()

--- a/harmonia-cache/tests/common.rs
+++ b/harmonia-cache/tests/common.rs
@@ -414,6 +414,30 @@ impl TestCache {
         Ok(String::from_utf8(output.stdout)?)
     }
 
+    /// Return the HTTP status code for `path` without failing on non-2xx.
+    /// Uses `--path-as-is` so traversal-shaped inputs reach the server unchanged.
+    pub fn curl_status(&self, path: &str) -> Result<u16> {
+        let url = self.url(path);
+        let mut args = vec![
+            "--max-time",
+            "5",
+            "--silent",
+            "--output",
+            "/dev/null",
+            "--write-out",
+            "%{http_code}",
+            "--path-as-is",
+        ];
+        if self.tls {
+            args.push("--insecure");
+        }
+        let output = Command::new("curl").args(args).arg(&url).output()?;
+        if !output.status.success() {
+            return Err(format!("curl invocation failed for {url}").into());
+        }
+        Ok(std::str::from_utf8(&output.stdout)?.trim().parse()?)
+    }
+
     /// Get the TLS certificate path (for curl --cacert)
     pub fn tls_cert_path(&self) -> Option<&PathBuf> {
         self.tls_cert_path.as_ref()

--- a/harmonia-cache/tests/realisations.rs
+++ b/harmonia-cache/tests/realisations.rs
@@ -1,46 +1,21 @@
 mod common;
 
 use common::{Result, TestCacheBuilder};
-use std::process::Command;
-
-fn curl_status(url: &str) -> Result<String> {
-    let output = Command::new("curl")
-        .args([
-            "--silent",
-            "--output",
-            "/dev/null",
-            "--write-out",
-            "%{http_code}",
-        ])
-        .arg(url)
-        .output()?;
-    if !output.status.success() {
-        return Err(format!(
-            "curl {url} exited {}: {}",
-            output.status,
-            String::from_utf8_lossy(&output.stderr)
-        )
-        .into());
-    }
-    Ok(String::from_utf8(output.stdout)?.trim().to_string())
-}
 
 #[tokio::test]
 async fn test_build_trace_endpoint() -> Result<()> {
     let cache = TestCacheBuilder::new().build().await?;
 
-    let status = curl_status(&cache.url("/build-trace-v2/not-a-store-path/out.doi"))?;
-    assert_eq!(status, "400", "Expected 400 for invalid drv path");
+    let status = cache.curl_status("/build-trace-v2/not-a-store-path/out.doi")?;
+    assert_eq!(status, 400, "Expected 400 for invalid drv path");
 
-    let status = curl_status(
-        &cache.url("/build-trace-v2/g1w7hy3qg1w7hy3qg1w7hy3qg1w7hy3q-bar.drv/out%7Bput.doi"),
-    )?;
-    assert_eq!(status, "400", "Expected 400 for invalid output name");
+    let status = cache
+        .curl_status("/build-trace-v2/g1w7hy3qg1w7hy3qg1w7hy3qg1w7hy3q-bar.drv/out%7Bput.doi")?;
+    assert_eq!(status, 400, "Expected 400 for invalid output name");
 
-    let status = curl_status(
-        &cache.url("/build-trace-v2/g1w7hy3qg1w7hy3qg1w7hy3qg1w7hy3q-bar.drv/out.doi"),
-    )?;
-    assert_eq!(status, "404", "Expected 404 for non-existent realisation");
+    let status =
+        cache.curl_status("/build-trace-v2/g1w7hy3qg1w7hy3qg1w7hy3qg1w7hy3q-bar.drv/out.doi")?;
+    assert_eq!(status, 404, "Expected 404 for non-existent realisation");
 
     Ok(())
 }

--- a/harmonia-cache/tests/security_paths.rs
+++ b/harmonia-cache/tests/security_paths.rs
@@ -1,0 +1,29 @@
+//! Malformed store-path hashes must yield 4xx, never 5xx.
+
+mod common;
+
+use common::{Result, TestCache};
+
+#[tokio::test]
+async fn malformed_hash_is_4xx_not_5xx() -> Result<()> {
+    let cache = TestCache::start().await?;
+
+    let cases = [
+        // These two returned 500 before the fix.
+        "/%2e%2e%2f%2e%2e%2fetc%2fpasswd.ls",
+        "/log/..%2f..%2f..%2f..%2f..%2f..%2f..%2fetc%2fpasswd",
+        // Pin that the other hash entry points keep validating.
+        "/%2e%2e%2fetc%2fpasswd.narinfo",
+        "/nar/0000000000000000000000000000000000000000000000000000.nar?hash=../../etc/passwd",
+    ];
+
+    for path in cases {
+        let status = cache.curl_status(path)?;
+        assert!(
+            (400..500).contains(&status),
+            "{path} must be rejected with 4xx, got {status}",
+        );
+    }
+
+    Ok(())
+}


### PR DESCRIPTION

nixhash() already validates the 32-char base32 store-path hash and
returns StoreError::PathQuery, which ServerError::status_code maps to
404. The narlist and buildlog handlers re-wrapped that error into
NarInfoError/BuildLogError, both of which map to 500, so a request like

    GET /%2e%2e%2fetc%2fpasswd.ls

produced an Internal Server Error and an error-level log line even
though the input was rejected before any filesystem or DB access.

Let the original error propagate so malformed client input is a 4xx on
every hash entry point. BuildLogError becomes dead and is removed.

A new integration test pins this for .ls, /log/, .narinfo and
/nar/?hash=.


