### PR TITLE
harmonia-cache: systemd socket activation, sd_notify, tighter sandbox

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1570,6 +1570,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1607,6 +1616,7 @@ dependencies = [
  "cfg-if",
  "cfg_aliases",
  "libc",
+ "memoffset",
 ]
 
 [[package]]

--- a/harmonia-cache/Cargo.toml
+++ b/harmonia-cache/Cargo.toml
@@ -46,6 +46,7 @@ harmonia-nar        = { version = "3.0.0" }
 harmonia-store-core = { version = "0.0.0-alpha.0" }
 harmonia-store-db   = { version = "3.0.0" }
 harmonia-utils-hash = { version = "0.0.0-alpha.0" }
+nix                 = { workspace = true, features = [ "socket", "fs" ] }
 prometheus          = { workspace = true }
 
 [dev-dependencies]

--- a/harmonia-cache/src/main.rs
+++ b/harmonia-cache/src/main.rs
@@ -313,7 +313,10 @@ async fn inner_main() -> Result<()> {
         }
     }
 
-    server.run().await.io_context("Failed to start server")
+    let server = server.run();
+    systemd::notify_ready();
+    systemd::spawn_watchdog();
+    server.await.io_context("Failed to start server")
 }
 
 #[actix_web::main]

--- a/harmonia-cache/src/main.rs
+++ b/harmonia-cache/src/main.rs
@@ -39,6 +39,7 @@ mod realisations;
 mod root;
 mod serve;
 mod store;
+mod systemd;
 mod template;
 mod tls;
 mod version;
@@ -172,7 +173,6 @@ async fn inner_main() -> Result<()> {
     let config_data = c.clone();
     let metrics_data = web::Data::new(metrics.clone());
 
-    tracing::info!("listening on {}", c.bind);
     let nar_route = format!("/nar/{{narhash:[{NIXBASE32_ALPHABET}]{{52}}}}.nar");
     // narinfos served by nix-serve have the narhash embedded in the nar URL.
     // While we don't do that, if nix-serve is replaced with harmonia, the old nar URLs
@@ -221,28 +221,8 @@ async fn inner_main() -> Result<()> {
         server = server.max_connections(c.max_connections);
     }
 
-    let try_url = Url::parse(&c.bind);
-    let (bind, uds) = if let Ok(url) = try_url.as_ref() {
-        if url.scheme() != "unix" {
-            (c.bind.as_str(), false)
-        } else if url.host().is_none() {
-            (url.path(), true)
-        } else {
-            return Err(error::ServerError::Startup {
-                reason: "Can only bind to file URLs without host portion.".to_string(),
-            }
-            .into());
-        }
-    } else {
-        (c.bind.as_str(), false)
-    };
-
-    if c.tls_cert_path.is_some() || c.tls_key_path.is_some() {
-        if uds {
-            tracing::error!("TLS is not supported with Unix domain sockets.");
-            std::process::exit(1);
-        }
-        let config = tls::load_tls_config(
+    let tls_config = if c.tls_cert_path.is_some() || c.tls_key_path.is_some() {
+        Some(tls::load_tls_config(
             Path::new(
                 &c.tls_cert_path
                     .clone()
@@ -253,27 +233,84 @@ async fn inner_main() -> Result<()> {
                     .clone()
                     .expect("tls key path must be set when tls is enabled"),
             ),
-        )?;
-
-        server = server
-            .bind_rustls_0_23(c.bind.clone(), config)
-            .io_context("Failed to bind with TLS")?;
-    } else if uds {
-        if !cfg!(unix) {
-            tracing::error!("Binding to Unix domain sockets is only supported on Unix.");
-            std::process::exit(1);
-        } else {
-            let socket_path = Path::new(bind);
-            server = server
-                .bind_uds(socket_path)
-                .io_context("Failed to bind to Unix domain socket")?;
-            fs::set_permissions(socket_path, fs::Permissions::from_mode(0o777))
-                .io_context("Failed to set socket permissions")?;
-        }
+        )?)
     } else {
-        server = server
-            .bind(c.bind.clone())
-            .io_context("Failed to bind server")?;
+        None
+    };
+
+    // systemd socket activation takes precedence over `bind`.
+    let mut activated = false;
+    for fd in systemd::inherited_fds() {
+        match systemd::classify(fd)? {
+            systemd::Listener::Tcp(tcp) => {
+                tracing::info!("listening on inherited fd {} ({:?})", fd, tcp.local_addr());
+                server = match tls_config.clone() {
+                    Some(cfg) => server
+                        .listen_rustls_0_23(tcp, cfg)
+                        .io_context("Failed to listen on inherited TCP listener with TLS")?,
+                    None => server
+                        .listen(tcp)
+                        .io_context("Failed to listen on inherited TCP listener")?,
+                };
+            }
+            systemd::Listener::Unix(uds) => {
+                if tls_config.is_some() {
+                    tracing::warn!(
+                        "TLS configured but inherited socket is a Unix domain socket; serving plaintext on it"
+                    );
+                }
+                tracing::info!("listening on inherited fd {} ({:?})", fd, uds.local_addr());
+                server = server
+                    .listen_uds(uds)
+                    .io_context("Failed to listen on inherited Unix listener")?;
+            }
+        }
+        activated = true;
+    }
+
+    if !activated {
+        tracing::info!("listening on {}", c.bind);
+        let try_url = Url::parse(&c.bind);
+        let (bind, uds) = if let Ok(url) = try_url.as_ref() {
+            if url.scheme() != "unix" {
+                (c.bind.as_str(), false)
+            } else if url.host().is_none() {
+                (url.path(), true)
+            } else {
+                return Err(error::ServerError::Startup {
+                    reason: "Can only bind to file URLs without host portion.".to_string(),
+                }
+                .into());
+            }
+        } else {
+            (c.bind.as_str(), false)
+        };
+
+        if let Some(cfg) = tls_config {
+            if uds {
+                tracing::error!("TLS is not supported with Unix domain sockets.");
+                std::process::exit(1);
+            }
+            server = server
+                .bind_rustls_0_23(c.bind.clone(), cfg)
+                .io_context("Failed to bind with TLS")?;
+        } else if uds {
+            if !cfg!(unix) {
+                tracing::error!("Binding to Unix domain sockets is only supported on Unix.");
+                std::process::exit(1);
+            } else {
+                let socket_path = Path::new(bind);
+                server = server
+                    .bind_uds(socket_path)
+                    .io_context("Failed to bind to Unix domain socket")?;
+                fs::set_permissions(socket_path, fs::Permissions::from_mode(0o777))
+                    .io_context("Failed to set socket permissions")?;
+            }
+        } else {
+            server = server
+                .bind(c.bind.clone())
+                .io_context("Failed to bind server")?;
+        }
     }
 
     server.run().await.io_context("Failed to start server")

--- a/harmonia-cache/src/systemd.rs
+++ b/harmonia-cache/src/systemd.rs
@@ -1,5 +1,5 @@
-//! Minimal systemd socket activation (`sd_listen_fds`): inherit pre-bound
-//! listeners from fds `3..3+$LISTEN_FDS`.
+//! Minimal systemd integration: socket activation (`sd_listen_fds`) and
+//! readiness notification (`sd_notify`).
 
 use std::os::fd::{AsRawFd, FromRawFd, OwnedFd, RawFd};
 
@@ -79,4 +79,57 @@ pub fn classify(fd: RawFd) -> Result<Listener> {
         }
     };
     Ok(listener)
+}
+
+fn notify_send(path: &str, state: &[u8]) -> std::io::Result<()> {
+    let sock = std::os::unix::net::UnixDatagram::unbound()?;
+    #[cfg(target_os = "linux")]
+    if let Some(abs) = path.strip_prefix('@') {
+        use nix::sys::socket::{MsgFlags, UnixAddr, sendto};
+        let addr = UnixAddr::new_abstract(abs.as_bytes())?;
+        sendto(sock.as_raw_fd(), state, &addr, MsgFlags::empty())?;
+        return Ok(());
+    }
+    sock.send_to(state, path)?;
+    Ok(())
+}
+
+/// Best-effort `sd_notify`; never fatal so standalone use is unaffected.
+fn notify(state: &[u8]) {
+    let Ok(path) = std::env::var("NOTIFY_SOCKET") else {
+        return;
+    };
+    if let Err(e) = notify_send(&path, state) {
+        tracing::warn!("sd_notify to {path} failed: {e}");
+    }
+}
+
+pub fn notify_ready() {
+    notify(b"READY=1");
+}
+
+/// Ping at half the systemd watchdog deadline. Only proves the async runtime
+/// still schedules work; will not detect a single wedged worker.
+pub fn spawn_watchdog() {
+    if !pid_var_matches("WATCHDOG_PID") {
+        return;
+    }
+    let Some(usec) = std::env::var("WATCHDOG_USEC")
+        .ok()
+        .and_then(|v| v.parse::<u64>().ok())
+        .filter(|&v| v > 0)
+    else {
+        return;
+    };
+    let interval =
+        std::time::Duration::from_micros(usec / 2).max(std::time::Duration::from_secs(1));
+    tracing::info!("systemd watchdog enabled, pinging every {interval:?}");
+    tokio::spawn(async move {
+        let mut tick = tokio::time::interval(interval);
+        tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+        loop {
+            tick.tick().await;
+            notify(b"WATCHDOG=1");
+        }
+    });
 }

--- a/harmonia-cache/src/systemd.rs
+++ b/harmonia-cache/src/systemd.rs
@@ -1,0 +1,82 @@
+//! Minimal systemd socket activation (`sd_listen_fds`): inherit pre-bound
+//! listeners from fds `3..3+$LISTEN_FDS`.
+
+use std::os::fd::{AsRawFd, FromRawFd, OwnedFd, RawFd};
+
+use nix::fcntl::{FcntlArg, FdFlag, fcntl};
+use nix::sys::socket::{AddressFamily, SockaddrLike, SockaddrStorage, getsockname};
+
+use crate::error::{Result, ServerError};
+
+const SD_LISTEN_FDS_START: RawFd = 3;
+
+pub enum Listener {
+    Tcp(std::net::TcpListener),
+    Unix(std::os::unix::net::UnixListener),
+}
+
+/// `$VAR` is unset, or set and equal to our PID. An unset value is tolerated
+/// so non-systemd launchers (`systemfd`, test harnesses) that cannot know the
+/// child PID up front still work.
+fn pid_var_matches(var: &str) -> bool {
+    match std::env::var(var) {
+        Err(_) => true,
+        Ok(v) => v.parse::<u32>().ok() == Some(std::process::id()),
+    }
+}
+
+/// Returns the inherited listener fds, empty when not activated.
+pub fn inherited_fds() -> std::ops::Range<RawFd> {
+    if !pid_var_matches("LISTEN_PID") {
+        return SD_LISTEN_FDS_START..SD_LISTEN_FDS_START;
+    }
+    let count: RawFd = std::env::var("LISTEN_FDS")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(0);
+
+    // LISTEN_* are left set: `remove_var` is unsound once tokio worker threads
+    // exist; the LISTEN_PID check plus CLOEXEC on the fds protect grandchildren.
+    SD_LISTEN_FDS_START..SD_LISTEN_FDS_START + count
+}
+
+/// Take ownership of an inherited socket fd. Must be called at most once per
+/// fd value: it constructs an `OwnedFd`, so a second call would double-close.
+pub fn classify(fd: RawFd) -> Result<Listener> {
+    // SAFETY: systemd guarantees fds [3, 3+LISTEN_FDS) are open and owned by
+    // us; we take ownership exactly once per fd.
+    #[allow(unsafe_code)]
+    let fd = unsafe { OwnedFd::from_raw_fd(fd) };
+
+    fcntl(&fd, FcntlArg::F_SETFD(FdFlag::FD_CLOEXEC)).map_err(|e| ServerError::Startup {
+        reason: format!("F_SETFD on inherited fd: {e}"),
+    })?;
+
+    let addr: SockaddrStorage = getsockname(fd.as_raw_fd()).map_err(|e| ServerError::Startup {
+        reason: format!("inherited fd is not a socket: {e}"),
+    })?;
+
+    let listener = match addr.family() {
+        Some(AddressFamily::Inet) | Some(AddressFamily::Inet6) => {
+            let l = std::net::TcpListener::from(fd);
+            l.set_nonblocking(true).map_err(|e| ServerError::Startup {
+                reason: format!("set_nonblocking on inherited fd: {e}"),
+            })?;
+            Listener::Tcp(l)
+        }
+        Some(AddressFamily::Unix) => {
+            let l = std::os::unix::net::UnixListener::from(fd);
+            l.set_nonblocking(true).map_err(|e| ServerError::Startup {
+                reason: format!("set_nonblocking on inherited fd: {e}"),
+            })?;
+            Listener::Unix(l)
+        }
+        other => {
+            return Err(ServerError::Startup {
+                reason: format!("inherited fd has unsupported address family {other:?}"),
+            }
+            .into());
+        }
+    };
+    Ok(listener)
+}

--- a/harmonia-cache/tests/common.rs
+++ b/harmonia-cache/tests/common.rs
@@ -170,7 +170,7 @@ async fn wait_for_service(
     })?
 }
 
-fn write_toml_config(content: &str) -> Result<NamedTempFile> {
+pub fn write_toml_config(content: &str) -> Result<NamedTempFile> {
     use std::io::Write;
     let mut file = NamedTempFile::new()?;
     write!(file, "{content}")?;
@@ -180,12 +180,12 @@ fn write_toml_config(content: &str) -> Result<NamedTempFile> {
 
 // Process guard implementations
 
-struct ProcessGuard {
+pub struct ProcessGuard {
     child: Option<Child>,
 }
 
 impl ProcessGuard {
-    fn new(child: Child) -> Self {
+    pub fn new(child: Child) -> Self {
         Self { child: Some(child) }
     }
 }

--- a/harmonia-cache/tests/socket_activation.rs
+++ b/harmonia-cache/tests/socket_activation.rs
@@ -2,6 +2,7 @@
 
 use std::net::TcpListener;
 use std::os::fd::{AsRawFd, BorrowedFd, OwnedFd};
+use std::os::unix::net::UnixDatagram;
 use std::os::unix::process::CommandExt;
 use std::process::Command;
 use std::time::Duration;
@@ -13,9 +14,10 @@ mod common;
 
 type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
 
-/// Emulate systemd: pass a pre-bound listener as fd 3 with `LISTEN_FDS=1`.
-/// Config `bind` is unroutable so the test fails unless the inherited socket
-/// is used. `LISTEN_PID` stays unset because `Command` fixes envp before fork.
+/// Emulate systemd: pass a pre-bound listener as fd 3 plus NOTIFY_SOCKET and
+/// WATCHDOG_USEC. Config `bind` is unroutable so the test fails unless the
+/// inherited socket is used. `LISTEN_PID` stays unset because `Command` fixes
+/// envp before fork.
 #[tokio::test]
 async fn test_socket_activation_tcp() -> Result<()> {
     let temp_dir = CanonicalTempDir::new()?;
@@ -28,6 +30,10 @@ async fn test_socket_activation_tcp() -> Result<()> {
     fcntl(&listener, FcntlArg::F_SETFD(FdFlag::empty()))?;
     let raw = listener.as_raw_fd();
 
+    let notify_path = temp_dir.path().join("notify.sock");
+    let notify = UnixDatagram::bind(&notify_path)?;
+    notify.set_read_timeout(Some(Duration::from_secs(30)))?;
+
     let config_file = common::write_toml_config(&format!(
         "bind = \"255.255.255.255:1\"\nnix_db_path = \"{}\"\npriority = 30\n",
         store.db_path().display(),
@@ -38,7 +44,9 @@ async fn test_socket_activation_tcp() -> Result<()> {
     let mut cmd = Command::new(&bin_path);
     cmd.env("CONFIG_FILE", config_file.path())
         .env("RUST_LOG", "debug")
-        .env("LISTEN_FDS", "1");
+        .env("LISTEN_FDS", "1")
+        .env("NOTIFY_SOCKET", &notify_path)
+        .env("WATCHDOG_USEC", "2000000");
     // SAFETY: only async-signal-safe syscalls (dup2/close) between fork and exec.
     unsafe {
         cmd.pre_exec(move || {
@@ -53,20 +61,25 @@ async fn test_socket_activation_tcp() -> Result<()> {
     let _guard = common::ProcessGuard::new(cmd.spawn()?);
     drop(listener);
 
-    let url = format!("http://127.0.0.1:{port}/nix-cache-info");
-    let start = std::time::Instant::now();
-    let body = loop {
-        let output = Command::new("curl")
-            .args(["--fail", "--silent", "--max-time", "2", &url])
-            .output()?;
-        if output.status.success() {
-            break String::from_utf8(output.stdout)?;
-        }
-        if start.elapsed() > Duration::from_secs(30) {
-            return Err(format!("timeout waiting for {url}").into());
-        }
-        tokio::time::sleep(Duration::from_millis(100)).await;
+    let recv = || -> Result<Vec<u8>> {
+        let mut buf = [0u8; 64];
+        let n = notify.recv(&mut buf)?;
+        Ok(buf[..n].to_vec())
     };
+    assert_eq!(recv()?, b"READY=1");
+    assert_eq!(recv()?, b"WATCHDOG=1");
+
+    let output = Command::new("curl")
+        .args([
+            "--fail",
+            "--silent",
+            "--max-time",
+            "5",
+            &format!("http://127.0.0.1:{port}/nix-cache-info"),
+        ])
+        .output()?;
+    assert!(output.status.success(), "curl failed: {output:?}");
+    let body = String::from_utf8(output.stdout)?;
     assert!(body.contains("StoreDir:"), "got: {body}");
 
     Ok(())

--- a/harmonia-cache/tests/socket_activation.rs
+++ b/harmonia-cache/tests/socket_activation.rs
@@ -1,0 +1,73 @@
+#![allow(unsafe_code)]
+
+use std::net::TcpListener;
+use std::os::fd::{AsRawFd, BorrowedFd, OwnedFd};
+use std::os::unix::process::CommandExt;
+use std::process::Command;
+use std::time::Duration;
+
+use common::{CanonicalTempDir, LocalStore};
+use nix::fcntl::{FcntlArg, FdFlag, fcntl};
+
+mod common;
+
+type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
+
+/// Emulate systemd: pass a pre-bound listener as fd 3 with `LISTEN_FDS=1`.
+/// Config `bind` is unroutable so the test fails unless the inherited socket
+/// is used. `LISTEN_PID` stays unset because `Command` fixes envp before fork.
+#[tokio::test]
+async fn test_socket_activation_tcp() -> Result<()> {
+    let temp_dir = CanonicalTempDir::new()?;
+    let store = LocalStore::init(temp_dir.path())?;
+
+    let listener = TcpListener::bind("127.0.0.1:0")?;
+    let port = listener.local_addr()?.port();
+    let listener = OwnedFd::from(listener);
+    // std sockets are CLOEXEC; clear it so the fd survives exec.
+    fcntl(&listener, FcntlArg::F_SETFD(FdFlag::empty()))?;
+    let raw = listener.as_raw_fd();
+
+    let config_file = common::write_toml_config(&format!(
+        "bind = \"255.255.255.255:1\"\nnix_db_path = \"{}\"\npriority = 30\n",
+        store.db_path().display(),
+    ))?;
+
+    let bin_path = std::env::var("HARMONIA_CACHE_BIN")
+        .unwrap_or_else(|_| env!("CARGO_BIN_EXE_harmonia-cache").to_string());
+    let mut cmd = Command::new(&bin_path);
+    cmd.env("CONFIG_FILE", config_file.path())
+        .env("RUST_LOG", "debug")
+        .env("LISTEN_FDS", "1");
+    // SAFETY: only async-signal-safe syscalls (dup2/close) between fork and exec.
+    unsafe {
+        cmd.pre_exec(move || {
+            let old = BorrowedFd::borrow_raw(raw);
+            std::mem::forget(nix::unistd::dup2_raw(old, 3)?);
+            if raw != 3 {
+                nix::unistd::close(raw)?;
+            }
+            Ok(())
+        });
+    }
+    let _guard = common::ProcessGuard::new(cmd.spawn()?);
+    drop(listener);
+
+    let url = format!("http://127.0.0.1:{port}/nix-cache-info");
+    let start = std::time::Instant::now();
+    let body = loop {
+        let output = Command::new("curl")
+            .args(["--fail", "--silent", "--max-time", "2", &url])
+            .output()?;
+        if output.status.success() {
+            break String::from_utf8(output.stdout)?;
+        }
+        if start.elapsed() > Duration::from_secs(30) {
+            return Err(format!("timeout waiting for {url}").into());
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    };
+    assert!(body.contains("StoreDir:"), "got: {body}");
+
+    Ok(())
+}

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -149,6 +149,9 @@ in
         };
 
         serviceConfig = {
+          Type = "notify";
+          WatchdogSec = 15;
+          Restart = "on-failure";
           ExecStart = "${cfg.package}/bin/harmonia-cache";
 
           User = "harmonia";

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -16,7 +16,7 @@ let
   signKeyPaths =
     cacheCfg.signKeyPaths ++ (if cacheCfg.signKeyPath != null then [ cacheCfg.signKeyPath ] else [ ]);
   credentials = lib.imap0 (i: signKeyPath: {
-    id = "sign-key-${builtins.toString i}";
+    id = "sign-key-${toString i}";
     path = signKeyPath;
   }) signKeyPaths;
 in
@@ -52,7 +52,7 @@ in
       };
 
       cache = {
-        enable = lib.mkEnableOption ("Harmonia: Nix binary cache written in Rust");
+        enable = lib.mkEnableOption "Harmonia: Nix binary cache written in Rust";
 
         signKeyPath = lib.mkOption {
           type = lib.types.nullOr lib.types.path;
@@ -74,7 +74,7 @@ in
       };
 
       daemon = {
-        enable = lib.mkEnableOption ("Harmonia daemon: Nix daemon protocol implementation");
+        enable = lib.mkEnableOption "Harmonia daemon: Nix daemon protocol implementation";
 
         socketPath = lib.mkOption {
           type = lib.types.str;
@@ -120,16 +120,25 @@ in
         priority = 50;
       };
 
+      # Socket activation lets the service run with PrivateNetwork; the
+      # inherited fd keeps referring to the host netns.
+      systemd.sockets.harmonia-dev = {
+        description = "harmonia binary cache socket";
+        wantedBy = [ "sockets.target" ];
+        socketConfig.ListenStream =
+          let
+            b = cacheCfg.settings.bind;
+          in
+          if lib.hasPrefix "unix:" b then lib.removePrefix "//" (lib.removePrefix "unix:" b) else b;
+      };
+
       systemd.services.harmonia-dev = {
         description = "harmonia binary cache service";
 
-        # The cache reads /nix/store and /nix/var/nix/db/db.sqlite directly;
-        # it does not talk to any nix daemon.
-        after = [ "network.target" ];
-        wantedBy = [ "multi-user.target" ];
+        requires = [ "harmonia-dev.socket" ];
+        after = [ "harmonia-dev.socket" ];
 
         environment = {
-          LIBEV_FLAGS = "4"; # go ahead and mandate epoll(2)
           CONFIG_FILE = lib.mkIf (configFile != null) configFile;
           SIGN_KEY_PATHS = lib.strings.concatMapStringsSep " " (
             credential: "%d/${credential.id}"
@@ -138,11 +147,6 @@ in
           RUST_LOG = "info,actix_web=debug";
           RUST_BACKTRACE = "1";
         };
-
-        # Note: it's important to set this for nix-store, because it wants to use
-        # $HOME in order to use a temporary cache dir. bizarre failures will occur
-        # otherwise
-        environment.HOME = "/run/harmonia";
 
         serviceConfig = {
           ExecStart = "${cfg.package}/bin/harmonia-cache";
@@ -176,7 +180,11 @@ in
           RestrictNamespaces = true;
           SystemCallArchitectures = "native";
 
-          PrivateNetwork = false;
+          # accept(2) on the inherited fd is exempt from both restrictions.
+          PrivateNetwork = true;
+          RestrictAddressFamilies = [ "AF_UNIX" ];
+          IPAddressDeny = "any";
+
           PrivateTmp = true;
           PrivateDevices = true;
           PrivateMounts = true;
@@ -184,7 +192,6 @@ in
           ProtectSystem = "strict";
           ProtectHome = true;
           LockPersonality = true;
-          RestrictAddressFamilies = "AF_UNIX AF_INET AF_INET6";
 
           LimitNOFILE = 65536;
         };
@@ -230,7 +237,7 @@ in
             ProtectHome = true;
             # SQLite needs write access for WAL mode
             ReadWritePaths = [
-              (builtins.dirOf daemonCfg.dbPath) # Need write access for WAL and SHM files
+              (dirOf daemonCfg.dbPath) # Need write access for WAL and SHM files
             ];
             ReadOnlyPaths = [
               daemonCfg.storeDir

--- a/nix/tests/ca-derivations.nix
+++ b/nix/tests/ca-derivations.nix
@@ -56,7 +56,7 @@ pkgs.testers.nixosTest {
     import json
 
     start_all()
-    harmonia.wait_for_unit("harmonia-dev.service")
+    harmonia.wait_for_unit("harmonia-dev.socket")
     harmonia.wait_for_open_port(5000)
     client01.wait_until_succeeds("timeout 1 curl -f http://harmonia:5000/nix-cache-info")
 

--- a/nix/tests/chroot-store.nix
+++ b/nix/tests/chroot-store.nix
@@ -54,7 +54,7 @@ pkgs.testers.nixosTest {
     harmonia.succeed(f"cp -a {d} /guest{d}")
 
     # Wait for harmonia
-    harmonia.wait_for_unit("harmonia-dev.service")
+    harmonia.wait_for_unit("harmonia-dev.socket")
     harmonia.wait_for_open_port(5000)
 
     # Client checks


### PR DESCRIPTION
Teach harmonia-cache to inherit listeners from LISTEN_FDS and speak sd_notify (READY=1 plus a watchdog ping), so the NixOS module can let systemd own the socket and run the service inside an empty network namespace with RestrictAddressFamilies narrowed to AF_UNIX. This gives on-demand start, privileged ports without extra capabilities, restarts without dropping the listen socket, and auto-recovery if the async runtime ever wedges. Implemented in a few dozen lines on the already-present nix crate, no-ops outside Linux/systemd.