### PR TITLE
harmonia-protocol: add `SubmitOutput` op

### DIFF
--- a/harmonia-daemon/src/server/mod.rs
+++ b/harmonia-daemon/src/server/mod.rs
@@ -582,6 +582,21 @@ where
         trace!("SubmitOutput Size {}", size_of_val(&ret));
         ret
     }
+
+    fn add_to_store_scanning<'a, 'source, Source>(
+        &'a mut self,
+        name: &'a str,
+        cam: ContentAddressMethodAlgorithm,
+        source: Source,
+    ) -> Pin<Box<dyn ResultLog<Output = DaemonResult<ValidPathInfo>> + Send + 'source>>
+    where
+        Source: AsyncBufRead + Send + Unpin + 'source,
+        'a: 'source,
+    {
+        let ret = Box::pin(self.0.add_to_store_scanning(name, cam, source));
+        trace!("AddToStoreScanning Size {}", size_of_val(ret.deref()));
+        ret
+    }
 }
 
 pub struct DaemonConnection<R, W> {
@@ -1080,6 +1095,18 @@ where
             SubmitOutput(req) => {
                 let logs = store.submit_output(&req.path, &req.output);
                 self.process_logs(logs).await?;
+            }
+            AddToStoreScanning(req) => {
+                // Treated as unknown when not supported in the upstream nix daemon, but returning Unimplemented is
+                // close enough.
+                let buf_reader = AsyncBufReadCompat::new(&mut self.reader);
+                let mut framed = FramedReader::new(buf_reader);
+                let logs = store.add_to_store_scanning(&req.name, req.cam, &mut framed);
+                let res = process_logs(&mut self.writer, logs).await;
+                framed.drain_all().await?;
+                let value = res?;
+                self.writer.write_value(&RawLogMessage::Last).await?;
+                self.writer.write_value(&value).await?;
             }
         }
         Ok(())

--- a/harmonia-daemon/src/server/mod.rs
+++ b/harmonia-daemon/src/server/mod.rs
@@ -572,6 +572,16 @@ where
         trace!("Shutdown Size {}", size_of_val(&ret));
         ret
     }
+
+    fn submit_output<'a>(
+        &'a mut self,
+        path: &'a harmonia_store_core::derived_path::SingleDerivedPath,
+        output: &'a OutputName,
+    ) -> impl ResultLog<Output = DaemonResult<()>> + Send + 'a {
+        let ret = Box::pin(self.0.submit_output(path, output));
+        trace!("SubmitOutput Size {}", size_of_val(&ret));
+        ret
+    }
 }
 
 pub struct DaemonConnection<R, W> {
@@ -1066,6 +1076,10 @@ where
                 let logs = store.add_perm_root(&req.store_path, &req.gc_root);
                 let value = self.process_logs(logs).await?;
                 self.writer.write_value(&value).await?;
+            }
+            SubmitOutput(req) => {
+                let logs = store.submit_output(&req.path, &req.output);
+                self.process_logs(logs).await?;
             }
         }
         Ok(())

--- a/harmonia-daemon/src/server/mod.rs
+++ b/harmonia-daemon/src/server/mod.rs
@@ -39,7 +39,7 @@ use harmonia_protocol::valid_path_info::ValidPathInfo;
 use harmonia_protocol::version::{FEATURE_ADD_TO_STORE_SCANNING, FeatureSet, supported_features};
 use harmonia_store_content_address::ContentAddressMethodAlgorithm;
 use harmonia_store_derivation::derivation::BasicDerivation;
-use harmonia_store_derivation::derived_path::{DerivedPath, OutputName};
+use harmonia_store_derivation::derived_path::{DerivedPath, OutputName, SingleDerivedPath};
 use harmonia_store_derivation::realisation::{DrvOutput, Realisation, UnkeyedRealisation};
 use harmonia_store_path::{StorePath, StorePathHash, StorePathSet};
 use harmonia_utils_io::{AsyncBufReadCompat, BytesReader};
@@ -535,6 +535,16 @@ where
     {
         let ret = self.0.add_build_log(path, source);
         trace!("AddBuildLog Size {}", size_of_val(ret.deref()));
+        ret
+    }
+
+    fn submit_output<'a>(
+        &'a mut self,
+        path: &'a SingleDerivedPath,
+        output: &'a OutputName,
+    ) -> impl ResultLog<Output = DaemonResult<()>> + Send + 'a {
+        let ret = Box::pin(self.0.submit_output(path, output));
+        trace!("SubmitOutput Size {}", size_of_val(ret.deref()));
         ret
     }
 
@@ -1094,6 +1104,11 @@ where
                 let logs = store.add_perm_root(&req.store_path, &req.gc_root);
                 let value = self.process_logs(logs).await?;
                 self.writer.write_value(&value).await?;
+            }
+            SubmitOutput(req) => {
+                let logs = store.submit_output(&req.path, &req.output);
+                self.process_logs(logs).await?;
+                self.writer.write_value(&IgnoredOne).await?;
             }
             AddToStoreScanning(req) => {
                 // Unlike upstream, drain the dump even on rejection so the

--- a/harmonia-daemon/src/tests/add_to_store_scanning.rs
+++ b/harmonia-daemon/src/tests/add_to_store_scanning.rs
@@ -5,61 +5,24 @@
 //! Harmonia's daemon never advertises the `add-to-store-scanning` feature,
 //! so both sides must reject the operation gracefully.
 
-use std::future::ready;
 use std::io::Cursor;
-use std::time::Duration;
 
 use tokio::io::AsyncWriteExt as _;
 use tokio::time::timeout;
 
-use harmonia_protocol::ProtocolVersion;
 use harmonia_protocol::daemon::{
-    DaemonResult, DaemonStore, FutureResultExt as _, HandshakeDaemonStore, ResultLog,
-    wire::{CLIENT_MAGIC, SERVER_MAGIC, logger::RawLogMessage, types::Operation},
+    DaemonStore,
+    wire::{logger::RawLogMessage, types::Operation},
 };
-use harmonia_protocol::de::{NixRead as _, NixReader};
-use harmonia_protocol::ser::{NixWrite as _, NixWriter};
-use harmonia_protocol::types::TrustLevel;
+use harmonia_protocol::de::NixRead as _;
+use harmonia_protocol::ser::NixWrite as _;
 use harmonia_protocol::version::{FEATURE_ADD_TO_STORE_SCANNING, FeatureSet};
 use harmonia_store_content_address::ContentAddressMethodAlgorithm;
 use harmonia_store_path::StorePath;
 use harmonia_store_remote::DaemonClient;
 use harmonia_utils_hash::Algorithm;
 
-use crate::server::Builder;
-
-const TEST_TIMEOUT: Duration = Duration::from_secs(30);
-
-/// Reports every operation as unimplemented.
-#[derive(Debug)]
-struct NullStore;
-
-impl HandshakeDaemonStore for NullStore {
-    type Store = Self;
-
-    fn handshake(self) -> impl ResultLog<Output = DaemonResult<Self::Store>> + Send {
-        ready(Ok(self)).empty_logs()
-    }
-}
-
-impl DaemonStore for NullStore {
-    fn trust_level(&self) -> Option<TrustLevel> {
-        None
-    }
-
-    fn shutdown(&mut self) -> impl std::future::Future<Output = DaemonResult<()>> + Send + '_ {
-        ready(Ok(()))
-    }
-}
-
-fn spawn_server(stream: tokio::io::DuplexStream) -> tokio::task::JoinHandle<DaemonResult<()>> {
-    tokio::spawn(async move {
-        let (read, write) = tokio::io::split(stream);
-        Builder::new()
-            .serve_connection(read, write, NullStore)
-            .await
-    })
-}
+use super::{TEST_TIMEOUT, raw_client_handshake, spawn_server};
 
 /// The client refuses to send the operation without the negotiated feature.
 #[tokio::test]
@@ -100,42 +63,13 @@ async fn server_rejects_unnegotiated_scanning_op() {
         let (client_side, server_side) = tokio::io::duplex(64 * 1024);
         let server = spawn_server(server_side);
 
-        let (read, write) = tokio::io::split(client_side);
-        let mut reader = NixReader::builder().build_buffered(read);
-        let mut writer = NixWriter::builder().build(write);
-
-        // Handshake, advertising the scanning feature ourselves.
-        writer.write_number(CLIENT_MAGIC).await.unwrap();
-        writer.flush().await.unwrap();
-        assert_eq!(reader.read_number().await.unwrap(), SERVER_MAGIC);
-        let version: ProtocolVersion = reader.read_value().await.unwrap();
-        writer.write_value(&version).await.unwrap();
-        reader.set_version(version);
-        writer.set_version(version);
-
         let local: FeatureSet = [FEATURE_ADD_TO_STORE_SCANNING.to_owned()].into();
-        writer.write_value(&local).await.unwrap();
-        writer.flush().await.unwrap();
-        let daemon_features: FeatureSet = reader.read_value().await.unwrap();
+        let (mut reader, mut writer, daemon_features) =
+            raw_client_handshake(client_side, local).await;
         assert!(
             !daemon_features.contains(FEATURE_ADD_TO_STORE_SCANNING),
             "daemon must not advertise the scanning feature"
         );
-
-        writer.write_value(&false).await.unwrap(); // obsolete CPU affinity
-        writer.write_value(&false).await.unwrap(); // obsolete reserve space
-        writer.flush().await.unwrap();
-        let _nix_version: String = reader.read_value().await.unwrap();
-        let _trust: Option<TrustLevel> = reader.read_value().await.unwrap();
-
-        // Drain the store handshake's stderr stream.
-        loop {
-            match reader.read_value::<RawLogMessage>().await.unwrap() {
-                RawLogMessage::Last => break,
-                RawLogMessage::Error(err) => panic!("handshake error: {:?}", err.msg),
-                _ => {}
-            }
-        }
 
         // Send the operation despite the failed negotiation.
         let cam = ContentAddressMethodAlgorithm::NixArchive(Algorithm::SHA256);

--- a/harmonia-daemon/src/tests/mod.rs
+++ b/harmonia-daemon/src/tests/mod.rs
@@ -1,2 +1,99 @@
 mod add_to_store_scanning;
 mod sqlite_nix_store;
+mod submit_output;
+
+use std::future::ready;
+use std::time::Duration;
+
+use tokio::io::AsyncWriteExt as _;
+
+use harmonia_protocol::ProtocolVersion;
+use harmonia_protocol::daemon::{
+    DaemonResult, DaemonStore, FutureResultExt as _, HandshakeDaemonStore, ResultLog,
+    wire::{CLIENT_MAGIC, SERVER_MAGIC, logger::RawLogMessage},
+};
+use harmonia_protocol::de::{NixRead as _, NixReader};
+use harmonia_protocol::ser::{NixWrite as _, NixWriter};
+use harmonia_protocol::types::TrustLevel;
+use harmonia_protocol::version::FeatureSet;
+use harmonia_utils_io::BytesReader;
+
+use crate::server::Builder;
+
+pub(crate) const TEST_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Reports every operation as unimplemented.
+#[derive(Debug)]
+pub(crate) struct NullStore;
+
+impl HandshakeDaemonStore for NullStore {
+    type Store = Self;
+
+    fn handshake(self) -> impl ResultLog<Output = DaemonResult<Self::Store>> + Send {
+        ready(Ok(self)).empty_logs()
+    }
+}
+
+impl DaemonStore for NullStore {
+    fn trust_level(&self) -> Option<TrustLevel> {
+        None
+    }
+
+    fn shutdown(&mut self) -> impl std::future::Future<Output = DaemonResult<()>> + Send + '_ {
+        ready(Ok(()))
+    }
+}
+
+pub(crate) fn spawn_server(
+    stream: tokio::io::DuplexStream,
+) -> tokio::task::JoinHandle<DaemonResult<()>> {
+    tokio::spawn(async move {
+        let (read, write) = tokio::io::split(stream);
+        Builder::new()
+            .serve_connection(read, write, NullStore)
+            .await
+    })
+}
+
+pub(crate) type RawReader = NixReader<BytesReader<tokio::io::ReadHalf<tokio::io::DuplexStream>>>;
+pub(crate) type RawWriter = NixWriter<tokio::io::WriteHalf<tokio::io::DuplexStream>>;
+
+/// Hand-rolled client handshake advertising `local`, returning the daemon's
+/// advertised features.
+pub(crate) async fn raw_client_handshake(
+    stream: tokio::io::DuplexStream,
+    local: FeatureSet,
+) -> (RawReader, RawWriter, FeatureSet) {
+    let (read, write) = tokio::io::split(stream);
+    let mut reader = NixReader::builder().build_buffered(read);
+    let mut writer = NixWriter::builder().build(write);
+
+    writer.write_number(CLIENT_MAGIC).await.unwrap();
+    writer.flush().await.unwrap();
+    assert_eq!(reader.read_number().await.unwrap(), SERVER_MAGIC);
+    let version: ProtocolVersion = reader.read_value().await.unwrap();
+    writer.write_value(&version).await.unwrap();
+    reader.set_version(version);
+    writer.set_version(version);
+
+    writer.write_value(&local).await.unwrap();
+    writer.flush().await.unwrap();
+    let daemon_features: FeatureSet = reader.read_value().await.unwrap();
+
+    writer.write_value(&false).await.unwrap(); // obsolete CPU affinity
+    writer.write_value(&false).await.unwrap(); // obsolete reserve space
+    writer.flush().await.unwrap();
+    let _nix_version: String = reader.read_value().await.unwrap();
+    let _trust: Option<TrustLevel> = reader.read_value().await.unwrap();
+
+    // Drain the store handshake's stderr stream.
+    loop {
+        match reader.read_value::<RawLogMessage>().await.unwrap() {
+            RawLogMessage::Last => break,
+            RawLogMessage::Error(err) => panic!("handshake error: {:?}", err.msg),
+            _ => {}
+        }
+    }
+
+    (reader, writer, daemon_features)
+}

--- a/harmonia-daemon/src/tests/submit_output.rs
+++ b/harmonia-daemon/src/tests/submit_output.rs
@@ -1,0 +1,194 @@
+// SPDX-License-Identifier: MIT
+
+//! Client/server tests for the `SubmitOutput` operation.
+//!
+//! Harmonia's daemon never advertises the `submit-output` feature, so both
+//! sides must reject the operation gracefully.
+
+use std::future::ready;
+use std::sync::Arc;
+
+use tokio::io::AsyncWriteExt as _;
+use tokio::time::timeout;
+
+use harmonia_protocol::daemon::{
+    DaemonResult, DaemonStore, FutureResultExt as _, HandshakeDaemonStore, ResultLog,
+    wire::{logger::RawLogMessage, types::Operation},
+};
+use harmonia_protocol::de::NixRead as _;
+use harmonia_protocol::ser::NixWrite as _;
+use harmonia_protocol::types::TrustLevel;
+use harmonia_protocol::version::{FEATURE_SUBMIT_OUTPUT, FeatureSet};
+use harmonia_store_derivation::derived_path::{OutputName, SingleDerivedPath};
+use harmonia_store_path::StorePath;
+use harmonia_store_remote::DaemonClient;
+
+use crate::server::Builder;
+
+use super::{TEST_TIMEOUT, raw_client_handshake, spawn_server};
+
+fn out() -> OutputName {
+    "out".parse().unwrap()
+}
+
+/// Accepts `SubmitOutput` and reports everything else as unimplemented.
+#[derive(Debug)]
+struct AcceptingStore;
+
+impl HandshakeDaemonStore for AcceptingStore {
+    type Store = Self;
+
+    fn handshake(self) -> impl ResultLog<Output = DaemonResult<Self::Store>> + Send {
+        ready(Ok(self)).empty_logs()
+    }
+}
+
+impl DaemonStore for AcceptingStore {
+    fn trust_level(&self) -> Option<TrustLevel> {
+        None
+    }
+
+    fn submit_output<'a>(
+        &'a mut self,
+        _path: &'a SingleDerivedPath,
+        _output: &'a OutputName,
+    ) -> impl ResultLog<Output = DaemonResult<()>> + Send + 'a {
+        ready(Ok(())).empty_logs()
+    }
+
+    fn shutdown(&mut self) -> impl std::future::Future<Output = DaemonResult<()>> + Send + '_ {
+        ready(Ok(()))
+    }
+}
+
+/// The client refuses to send the operation without the negotiated feature.
+#[tokio::test]
+async fn client_requires_negotiated_feature() {
+    timeout(TEST_TIMEOUT, async {
+        let (client_side, server_side) = tokio::io::duplex(64 * 1024);
+        let server = spawn_server(server_side);
+
+        let (read, write) = tokio::io::split(client_side);
+        let mut client = DaemonClient::builder()
+            .connect(read, write)
+            .await
+            .expect("client handshake");
+        assert!(!client.has_feature(FEATURE_SUBMIT_OUTPUT));
+
+        let path = SingleDerivedPath::Opaque(
+            StorePath::from_bytes(b"00000000000000000000000000000000-x").unwrap(),
+        );
+        let err = client
+            .submit_output(&path, &out())
+            .await
+            .expect_err("must fail without the negotiated feature");
+        assert!(
+            err.to_string().contains(FEATURE_SUBMIT_OUTPUT),
+            "unexpected error: {err}"
+        );
+
+        drop(client);
+        server.await.expect("join").expect("server");
+    })
+    .await
+    .expect("test timed out");
+}
+
+/// A store that implements the operation answers with the log terminator and
+/// the trailing `1`, leaving the connection in sync.
+#[tokio::test]
+async fn server_accepts_submit_output() {
+    timeout(TEST_TIMEOUT, async {
+        let (client_side, server_side) = tokio::io::duplex(64 * 1024);
+        let server = tokio::spawn(async move {
+            let (read, write) = tokio::io::split(server_side);
+            Builder::new()
+                .serve_connection(read, write, AcceptingStore)
+                .await
+        });
+
+        let local: FeatureSet = [FEATURE_SUBMIT_OUTPUT.to_owned()].into();
+        let (mut reader, mut writer, _daemon_features) =
+            raw_client_handshake(client_side, local).await;
+
+        let path = SingleDerivedPath::Opaque(
+            StorePath::from_bytes(b"00000000000000000000000000000000-x").unwrap(),
+        );
+        writer.write_value(&Operation::SubmitOutput).await.unwrap();
+        writer.write_value(&path).await.unwrap();
+        writer.write_value(&out()).await.unwrap();
+        writer.flush().await.unwrap();
+
+        loop {
+            match reader.read_value::<RawLogMessage>().await.unwrap() {
+                RawLogMessage::Last => break,
+                RawLogMessage::Error(err) => panic!("unexpected error: {:?}", err.msg),
+                _ => {}
+            }
+        }
+        assert_eq!(reader.read_value::<u64>().await.unwrap(), 1);
+
+        // Both halves must drop or the server never sees EOF.
+        drop(reader);
+        drop(writer);
+        server.await.expect("join").expect("server");
+    })
+    .await
+    .expect("test timed out");
+}
+
+/// A client that sends the operation anyway gets a recoverable error and
+/// the connection stays usable.
+#[tokio::test]
+async fn server_rejects_unnegotiated_submit_output() {
+    timeout(TEST_TIMEOUT, async {
+        let (client_side, server_side) = tokio::io::duplex(64 * 1024);
+        let server = spawn_server(server_side);
+
+        let local: FeatureSet = [FEATURE_SUBMIT_OUTPUT.to_owned()].into();
+        let (mut reader, mut writer, daemon_features) =
+            raw_client_handshake(client_side, local).await;
+        assert!(
+            !daemon_features.contains(FEATURE_SUBMIT_OUTPUT),
+            "daemon must not advertise the submit-output feature"
+        );
+
+        // Send the operation despite the failed negotiation, with a nested
+        // built path to exercise the tagged encoding.
+        let path = SingleDerivedPath::Built {
+            drv_path: Arc::new(SingleDerivedPath::Opaque(
+                StorePath::from_bytes(b"00000000000000000000000000000000-x.drv").unwrap(),
+            )),
+            output: out(),
+        };
+        writer.write_value(&Operation::SubmitOutput).await.unwrap();
+        writer.write_value(&path).await.unwrap();
+        writer.write_value(&out()).await.unwrap();
+        writer.flush().await.unwrap();
+
+        let RawLogMessage::Error(err) = reader.read_value::<RawLogMessage>().await.unwrap() else {
+            panic!("expected an error for the unnegotiated operation");
+        };
+        let msg = String::from_utf8_lossy(&err.msg).into_owned();
+        assert!(msg.contains("SubmitOutput"), "unexpected error: {msg}");
+
+        // The connection must still be in sync for the next request.
+        let store_path = StorePath::from_bytes(b"00000000000000000000000000000000-x").unwrap();
+        writer.write_value(&Operation::IsValidPath).await.unwrap();
+        writer.write_value(&store_path).await.unwrap();
+        writer.flush().await.unwrap();
+
+        let RawLogMessage::Error(err) = reader.read_value::<RawLogMessage>().await.unwrap() else {
+            panic!("expected NullStore to report IsValidPath as unimplemented");
+        };
+        let msg = String::from_utf8_lossy(&err.msg).into_owned();
+        assert!(msg.contains("IsValidPath"), "unexpected error: {msg}");
+
+        // Both halves must drop or the server never sees EOF.
+        drop(reader);
+        drop(writer);
+        server.await.expect("join").expect("server");
+    })
+    .await
+    .expect("test timed out");
+}

--- a/harmonia-protocol/src/daemon_wire/types.rs
+++ b/harmonia-protocol/src/daemon_wire/types.rs
@@ -56,6 +56,7 @@ pub enum Operation {
     BuildPathsWithResults = 46,
     AddPermRoot = 47,
     SubmitOutput = 1000,
+    AddToStoreScanning = 1001,
 }
 
 impl Operation {

--- a/harmonia-protocol/src/daemon_wire/types.rs
+++ b/harmonia-protocol/src/daemon_wire/types.rs
@@ -55,6 +55,7 @@ pub enum Operation {
     AddBuildLog = 45,
     BuildPathsWithResults = 46,
     AddPermRoot = 47,
+    SubmitOutput = 1000,
 }
 
 impl Operation {

--- a/harmonia-protocol/src/daemon_wire/types.rs
+++ b/harmonia-protocol/src/daemon_wire/types.rs
@@ -55,6 +55,7 @@ pub enum Operation {
     AddBuildLog = 45,
     BuildPathsWithResults = 46,
     AddPermRoot = 47,
+    SubmitOutput = 1000,
     AddToStoreScanning = 1001,
 }
 

--- a/harmonia-protocol/src/daemon_wire/types2.rs
+++ b/harmonia-protocol/src/daemon_wire/types2.rs
@@ -189,6 +189,7 @@ pub enum Request {
     BuildPathsWithResults(BuildPathsRequest),
     AddPermRoot(AddPermRootRequest),
     SubmitOutput(SubmitOutputRequest),
+    AddToStoreScanning(AddToStoreScanningRequest),
 }
 
 impl Request {
@@ -225,6 +226,7 @@ impl Request {
             Request::BuildPathsWithResults(_) => Operation::BuildPathsWithResults,
             Request::AddPermRoot(_) => Operation::AddPermRoot,
             Request::SubmitOutput(_) => Operation::SubmitOutput,
+            Request::AddToStoreScanning(_) => Operation::AddToStoreScanning,
         }
     }
 
@@ -323,6 +325,9 @@ impl Request {
             }
             Request::SubmitOutput(req) => {
                 debug_span!("SubmitOutput", path=?req.path, output=?req.output)
+            }
+            Request::AddToStoreScanning(req) => {
+                debug_span!("AddToStoreScanning", name=?req.name, cam=?req.cam)
             }
         }
     }
@@ -439,6 +444,12 @@ pub struct AddPermRootRequest {
 pub struct SubmitOutputRequest {
     pub path: SingleDerivedPath,
     pub output: OutputName,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, NixDeserialize, NixSerialize)]
+pub struct AddToStoreScanningRequest {
+    pub name: String,
+    pub cam: ContentAddressMethodAlgorithm,
 }
 
 macro_rules! optional_info {

--- a/harmonia-protocol/src/daemon_wire/types2.rs
+++ b/harmonia-protocol/src/daemon_wire/types2.rs
@@ -20,7 +20,7 @@ use crate::types::{ClientOptions, DaemonPath, DaemonString};
 use crate::valid_path_info::{UnkeyedValidPathInfo, ValidPathInfo};
 use harmonia_protocol_derive::{NixDeserialize, NixSerialize};
 use harmonia_store_core::derivation::BasicDerivation;
-use harmonia_store_core::derived_path::DerivedPath;
+use harmonia_store_core::derived_path::{DerivedPath, OutputName, SingleDerivedPath};
 use harmonia_store_core::realisation::{DrvOutput, Realisation};
 use harmonia_store_core::signature::Signature;
 use harmonia_store_core::store_path::{
@@ -188,6 +188,7 @@ pub enum Request {
     AddBuildLog(BaseStorePath),
     BuildPathsWithResults(BuildPathsRequest),
     AddPermRoot(AddPermRootRequest),
+    SubmitOutput(SubmitOutputRequest),
 }
 
 impl Request {
@@ -223,6 +224,7 @@ impl Request {
             Request::AddBuildLog(_) => Operation::AddBuildLog,
             Request::BuildPathsWithResults(_) => Operation::BuildPathsWithResults,
             Request::AddPermRoot(_) => Operation::AddPermRoot,
+            Request::SubmitOutput(_) => Operation::SubmitOutput,
         }
     }
 
@@ -318,6 +320,9 @@ impl Request {
             Request::AddPermRoot(req) => {
                 let gc_root = String::from_utf8_lossy(&req.gc_root);
                 debug_span!("AddPermRoot", path=?req.store_path, ?gc_root)
+            }
+            Request::SubmitOutput(req) => {
+                debug_span!("SubmitOutput", path=?req.path, output=?req.output)
             }
         }
     }
@@ -428,6 +433,12 @@ pub struct AddMultipleToStoreRequest {
 pub struct AddPermRootRequest {
     pub store_path: StorePath,
     pub gc_root: DaemonPath,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, NixDeserialize, NixSerialize)]
+pub struct SubmitOutputRequest {
+    pub path: SingleDerivedPath,
+    pub output: OutputName,
 }
 
 macro_rules! optional_info {

--- a/harmonia-protocol/src/daemon_wire/types2.rs
+++ b/harmonia-protocol/src/daemon_wire/types2.rs
@@ -20,7 +20,7 @@ use crate::valid_path_info::{UnkeyedValidPathInfo, ValidPathInfo};
 use harmonia_protocol_derive::{NixDeserialize, NixSerialize};
 use harmonia_store_content_address::{ContentAddress, ContentAddressMethodAlgorithm};
 use harmonia_store_derivation::derivation::BasicDerivation;
-use harmonia_store_derivation::derived_path::DerivedPath;
+use harmonia_store_derivation::derived_path::{DerivedPath, OutputName, SingleDerivedPath};
 use harmonia_store_derivation::realisation::{DrvOutput, Realisation};
 use harmonia_store_path::{StorePath, StorePathHash, StorePathSet};
 use harmonia_utils_signature::Signature;
@@ -148,6 +148,7 @@ pub enum Request {
     AddBuildLog(BaseStorePath),
     BuildPathsWithResults(BuildPathsRequest),
     AddPermRoot(AddPermRootRequest),
+    SubmitOutput(SubmitOutputRequest),
     AddToStoreScanning(AddToStoreScanningRequest),
 }
 
@@ -184,6 +185,7 @@ impl Request {
             Request::AddBuildLog(_) => Operation::AddBuildLog,
             Request::BuildPathsWithResults(_) => Operation::BuildPathsWithResults,
             Request::AddPermRoot(_) => Operation::AddPermRoot,
+            Request::SubmitOutput(_) => Operation::SubmitOutput,
             Request::AddToStoreScanning(_) => Operation::AddToStoreScanning,
         }
     }
@@ -280,6 +282,9 @@ impl Request {
             Request::AddPermRoot(req) => {
                 let gc_root = String::from_utf8_lossy(&req.gc_root);
                 debug_span!("AddPermRoot", path=?req.store_path, ?gc_root)
+            }
+            Request::SubmitOutput(req) => {
+                debug_span!("SubmitOutput", path=?req.path, output=?req.output)
             }
             Request::AddToStoreScanning(req) => {
                 debug_span!("AddToStoreScanning", name=?req.name, cam=?req.cam)
@@ -393,6 +398,12 @@ pub struct AddMultipleToStoreRequest {
 pub struct AddPermRootRequest {
     pub store_path: StorePath,
     pub gc_root: DaemonPath,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, NixDeserialize, NixSerialize)]
+pub struct SubmitOutputRequest {
+    pub path: SingleDerivedPath,
+    pub output: OutputName,
 }
 
 /// Like [`AddToStoreRequest`] but without `refs`, which are instead discovered

--- a/harmonia-protocol/src/lib.rs
+++ b/harmonia-protocol/src/lib.rs
@@ -41,8 +41,9 @@ pub mod version;
 pub use harmonia_store_path_info::NarHash;
 
 pub use version::{
-    FEATURE_ADD_TO_STORE_SCANNING, FEATURE_REALISATION_WITH_PATH, Feature, FeatureSet,
-    ProtocolVersion, supported_features,
+    BUILDER_RPC_V0_VERSION, FEATURE_ADD_TO_STORE_SCANNING, FEATURE_DISABLE_SET_OPTIONS,
+    FEATURE_REALISATION_WITH_PATH, FEATURE_SUBMIT_OUTPUT, Feature, FeatureSet, ProtocolVersion,
+    builder_rpc_v0_features, supported_features,
 };
 
 // Re-exports required by derive macros (harmonia_protocol_derive generates code using crate::store_path, etc.)

--- a/harmonia-protocol/src/store_impls.rs
+++ b/harmonia-protocol/src/store_impls.rs
@@ -11,6 +11,9 @@
 //! but protocol can impl traits for external store-core types.
 
 use std::collections::BTreeMap;
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
 
 use bytes::Bytes;
 
@@ -21,7 +24,9 @@ use crate::ser::{NixSerialize, NixWrite};
 use harmonia_protocol_derive::{nix_deserialize_remote, nix_serialize_remote};
 use harmonia_store_aterm::raw_output::{AtermOutput as _, BorrowedRawOutput};
 use harmonia_store_derivation::derivation::{BasicDerivation, DerivationOutput, StructuredAttrs};
-use harmonia_store_derivation::derived_path::{DerivedPath, LegacyDerivedPath, OutputName};
+use harmonia_store_derivation::derived_path::{
+    DerivedPath, LegacyDerivedPath, OutputName, SingleDerivedPath,
+};
 use harmonia_store_derivation::realisation::{DrvOutput, Realisation, UnkeyedRealisation};
 use harmonia_store_path::{StorePath, StorePathName};
 
@@ -190,6 +195,79 @@ impl NixDeserialize for DerivedPath {
                 .parse::<LegacyDerivedPath>(&s)
                 .map_err(R::Error::invalid_data)?;
             Ok(Some(legacy.0))
+        } else {
+            Ok(None)
+        }
+    }
+}
+
+// ========== SingleDerivedPath ==========
+// The worker protocol uses a tagged binary format rather than the "drv!output"
+// string form. A tag word of 0 means an opaque store path and 1 means a built
+// path followed by its output name.
+
+fn write_single_derived_path<'a, W>(
+    value: &'a SingleDerivedPath,
+    writer: &'a mut W,
+) -> Pin<Box<dyn Future<Output = Result<(), W::Error>> + Send + 'a>>
+where
+    W: NixWrite,
+{
+    Box::pin(async move {
+        match value {
+            SingleDerivedPath::Opaque(path) => {
+                writer.write_number(0).await?;
+                writer.write_value(path).await
+            }
+            SingleDerivedPath::Built { drv_path, output } => {
+                writer.write_number(1).await?;
+                write_single_derived_path(drv_path, writer).await?;
+                writer.write_value(output).await
+            }
+        }
+    })
+}
+
+fn read_single_derived_path_tail<'a, R>(
+    reader: &'a mut R,
+    tag: u64,
+) -> Pin<Box<dyn Future<Output = Result<SingleDerivedPath, R::Error>> + Send + 'a>>
+where
+    R: ?Sized + NixRead + Send,
+{
+    Box::pin(async move {
+        use crate::de::Error;
+        match tag {
+            0 => Ok(SingleDerivedPath::Opaque(reader.read_value().await?)),
+            1 => {
+                let inner_tag = reader.read_value::<u64>().await?;
+                let drv_path = Arc::new(read_single_derived_path_tail(reader, inner_tag).await?);
+                let output = reader.read_value().await?;
+                Ok(SingleDerivedPath::Built { drv_path, output })
+            }
+            _ => Err(R::Error::invalid_data(std::format_args!(
+                "invalid tag {tag} for single derived path"
+            ))),
+        }
+    })
+}
+
+impl NixSerialize for SingleDerivedPath {
+    async fn serialize<W>(&self, writer: &mut W) -> Result<(), W::Error>
+    where
+        W: NixWrite,
+    {
+        write_single_derived_path(self, writer).await
+    }
+}
+
+impl NixDeserialize for SingleDerivedPath {
+    async fn try_deserialize<R>(reader: &mut R) -> Result<Option<Self>, R::Error>
+    where
+        R: ?Sized + NixRead + Send,
+    {
+        if let Some(tag) = reader.try_read_value::<u64>().await? {
+            read_single_derived_path_tail(reader, tag).await.map(Some)
         } else {
             Ok(None)
         }

--- a/harmonia-protocol/src/store_impls.rs
+++ b/harmonia-protocol/src/store_impls.rs
@@ -522,6 +522,16 @@ nix_serialize_remote!(
     harmonia_store_core::store_path::StorePath
 );
 
+// SingleDerivedPath
+nix_deserialize_remote!(
+    #[nix(from_store_dir_str)]
+    harmonia_store_core::derived_path::SingleDerivedPath
+);
+nix_serialize_remote!(
+    #[nix(store_dir_display)]
+    harmonia_store_core::derived_path::SingleDerivedPath
+);
+
 // Verbosity
 nix_deserialize_remote!(
     #[nix(from = "u16")]

--- a/harmonia-protocol/src/types.rs
+++ b/harmonia-protocol/src/types.rs
@@ -573,6 +573,23 @@ pub trait DaemonStore: Send {
         ready(Err(DaemonError::unimplemented(Operation::SubmitOutput))).empty_logs()
     }
 
+    fn add_to_store_scanning<'a, 'source, Source>(
+        &'a mut self,
+        name: &'a str,
+        cam: ContentAddressMethodAlgorithm,
+        source: Source,
+    ) -> Pin<Box<dyn ResultLog<Output = DaemonResult<ValidPathInfo>> + Send + 'source>>
+    where
+        Source: AsyncBufRead + Send + Unpin + 'source,
+        'a: 'source,
+    {
+        ready(Err(DaemonError::unimplemented(
+            Operation::AddToStoreScanning,
+        )))
+        .empty_logs()
+        .boxed_result()
+    }
+
     fn add_ca_to_store<'a, 'r, R>(
         &'a mut self,
         name: &'a str,
@@ -859,6 +876,19 @@ where
 
     fn shutdown(&mut self) -> impl Future<Output = DaemonResult<()>> + Send + '_ {
         (**self).shutdown()
+    }
+
+    fn add_to_store_scanning<'a, 'source, Source>(
+        &'a mut self,
+        name: &'a str,
+        cam: ContentAddressMethodAlgorithm,
+        source: Source,
+    ) -> Pin<Box<dyn ResultLog<Output = DaemonResult<ValidPathInfo>> + Send + 'source>>
+    where
+        Source: AsyncBufRead + Send + Unpin + 'source,
+        'a: 'source,
+    {
+        (**self).add_to_store_scanning(name, cam, source)
     }
 }
 

--- a/harmonia-protocol/src/types.rs
+++ b/harmonia-protocol/src/types.rs
@@ -21,7 +21,7 @@ use crate::log::Verbosity;
 use crate::valid_path_info::{UnkeyedValidPathInfo, ValidPathInfo};
 use harmonia_protocol_derive::{NixDeserialize, NixSerialize};
 use harmonia_store_core::derivation::BasicDerivation;
-use harmonia_store_core::derived_path::{DerivedPath, OutputName};
+use harmonia_store_core::derived_path::{DerivedPath, OutputName, SingleDerivedPath};
 use harmonia_store_core::realisation::{DrvOutput, Realisation, UnkeyedRealisation};
 use harmonia_store_core::signature::Signature;
 use harmonia_store_core::store_path::{
@@ -565,6 +565,14 @@ pub trait DaemonStore: Send {
         ready(Err(DaemonError::unimplemented(Operation::AddPermRoot))).empty_logs()
     }
 
+    fn submit_output<'a>(
+        &'a mut self,
+        path: &'a SingleDerivedPath,
+        output: &'a OutputName,
+    ) -> impl ResultLog<Output = DaemonResult<()>> + Send + 'a {
+        ready(Err(DaemonError::unimplemented(Operation::SubmitOutput))).empty_logs()
+    }
+
     fn add_ca_to_store<'a, 'r, R>(
         &'a mut self,
         name: &'a str,
@@ -824,6 +832,14 @@ where
         gc_root: &'a DaemonPath,
     ) -> impl ResultLog<Output = DaemonResult<DaemonPath>> + Send + 'a {
         (**self).add_perm_root(path, gc_root)
+    }
+
+    fn submit_output<'a>(
+        &'a mut self,
+        path: &'a SingleDerivedPath,
+        output: &'a OutputName,
+    ) -> impl ResultLog<Output = DaemonResult<()>> + Send + 'a {
+        (**self).submit_output(path, output)
     }
 
     fn add_ca_to_store<'a, 'r, R>(

--- a/harmonia-protocol/src/types.rs
+++ b/harmonia-protocol/src/types.rs
@@ -23,7 +23,7 @@ use crate::valid_path_info::{UnkeyedValidPathInfo, ValidPathInfo};
 use harmonia_protocol_derive::{NixDeserialize, NixSerialize};
 use harmonia_store_content_address::ContentAddressMethodAlgorithm;
 use harmonia_store_derivation::derivation::BasicDerivation;
-use harmonia_store_derivation::derived_path::{DerivedPath, OutputName};
+use harmonia_store_derivation::derived_path::{DerivedPath, OutputName, SingleDerivedPath};
 use harmonia_store_derivation::realisation::{DrvOutput, Realisation, UnkeyedRealisation};
 use harmonia_store_path::{StorePath, StorePathHash, StorePathSet};
 use harmonia_utils_signature::Signature;
@@ -587,6 +587,17 @@ pub trait DaemonStore: Send {
         ready(Err(DaemonError::unimplemented(Operation::QueryRealisation))).empty_logs()
     }
 
+    /// Submit a store object as an output of the currently building derivation.
+    ///
+    /// Only daemons serving a `builder-rpc-v0` derivation builder support this.
+    fn submit_output<'a>(
+        &'a mut self,
+        path: &'a SingleDerivedPath,
+        output: &'a OutputName,
+    ) -> impl ResultLog<Output = DaemonResult<()>> + Send + 'a {
+        ready(Err(DaemonError::unimplemented(Operation::SubmitOutput))).empty_logs()
+    }
+
     fn add_build_log<'s, 'r, 'p, R>(
         &'s mut self,
         path: &'p StorePath,
@@ -868,6 +879,14 @@ where
         output_id: &'a DrvOutput,
     ) -> impl ResultLog<Output = DaemonResult<Option<UnkeyedRealisation>>> + Send + 'a {
         (**self).query_realisation(output_id)
+    }
+
+    fn submit_output<'a>(
+        &'a mut self,
+        path: &'a SingleDerivedPath,
+        output: &'a OutputName,
+    ) -> impl ResultLog<Output = DaemonResult<()>> + Send + 'a {
+        (**self).submit_output(path, output)
     }
 
     fn add_build_log<'s, 'r, 'p, R>(

--- a/harmonia-protocol/src/version.rs
+++ b/harmonia-protocol/src/version.rs
@@ -36,9 +36,34 @@ pub const FEATURE_REALISATION_WITH_PATH: &str = "realisation-with-path-not-hash"
 /// not in [`supported_features`] and the client adds it at handshake instead.
 pub const FEATURE_ADD_TO_STORE_SCANNING: &str = "add-to-store-scanning";
 
+/// Enables the `SubmitOutput` operation.
+///
+/// Upstream daemons only advertise this on `builder-rpc-v0` connections, so it
+/// is not in [`supported_features`] and the client adds it at handshake instead.
+pub const FEATURE_SUBMIT_OUTPUT: &str = "submit-output";
+
+/// Tells the client not to send [`SetOptions`](crate::daemon_wire::types::Operation::SetOptions).
+///
+/// Upstream daemons only advertise this on recursive connections.
+pub const FEATURE_DISABLE_SET_OPTIONS: &str = "disable-set-options";
+
 /// Features harmonia advertises during handshake.
 pub fn supported_features() -> FeatureSet {
     [FEATURE_REALISATION_WITH_PATH.to_owned()].into()
+}
+
+/// The protocol version of the pinned `builder-rpc-v0` derivation feature.
+pub const BUILDER_RPC_V0_VERSION: ProtocolVersion = ProtocolVersion::from_parts(1, 38);
+
+/// The feature set of the `builder-rpc-v0` derivation feature.
+pub fn builder_rpc_v0_features() -> FeatureSet {
+    [
+        FEATURE_REALISATION_WITH_PATH.to_owned(),
+        FEATURE_DISABLE_SET_OPTIONS.to_owned(),
+        FEATURE_ADD_TO_STORE_SCANNING.to_owned(),
+        FEATURE_SUBMIT_OUTPUT.to_owned(),
+    ]
+    .into()
 }
 
 #[derive(

--- a/harmonia-protocol/src/wire_roundtrip.rs
+++ b/harmonia-protocol/src/wire_roundtrip.rs
@@ -74,6 +74,68 @@ wire_roundtrip!(roundtrip_query_missing_result, QueryMissingResult);
 wire_roundtrip!(roundtrip_derived_path, DerivedPath);
 
 #[test]
+fn single_derived_path_rejects_invalid_tag() {
+    use harmonia_store_derivation::derived_path::SingleDerivedPath;
+
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .build()
+        .unwrap();
+
+    rt.block_on(async {
+        let mut buf = Vec::new();
+        let mut w = NixWriter::builder().build(&mut buf);
+        w.write_value(&2u64).await.expect("write");
+        w.flush().await.expect("flush");
+
+        let mut r = NixReader::builder().build_buffered(Cursor::new(buf));
+        r.read_value::<SingleDerivedPath>().await.unwrap_err();
+    });
+}
+
+/// Pins opcode 1000 and the tagged `SingleDerivedPath` encoding.
+#[test]
+fn roundtrip_submit_output_request() {
+    use std::sync::Arc;
+
+    use crate::daemon_wire::types2::{Request, SubmitOutputRequest};
+    use harmonia_store_derivation::derived_path::SingleDerivedPath;
+    use harmonia_store_path::StorePath;
+
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .build()
+        .unwrap();
+
+    let path = SingleDerivedPath::Built {
+        drv_path: Arc::new(SingleDerivedPath::Opaque(
+            StorePath::from_bytes(b"00000000000000000000000000000000-x.drv").unwrap(),
+        )),
+        output: "lib".parse().unwrap(),
+    };
+    let req = Request::SubmitOutput(SubmitOutputRequest {
+        path,
+        output: "out".parse().unwrap(),
+    });
+
+    let buf = rt.block_on(async {
+        let mut buf = Vec::new();
+        let mut w = NixWriter::builder().build(&mut buf);
+        w.write_value(&req).await.expect("write");
+        w.flush().await.expect("flush");
+        buf
+    });
+    let word = |i: usize| u64::from_le_bytes(buf[i * 8..(i + 1) * 8].try_into().unwrap());
+    assert_eq!(word(0), 1000);
+    assert_eq!(word(1), 1); // Built tag
+    assert_eq!(word(2), 0); // inner Opaque tag
+
+    let back: Request = rt.block_on(async {
+        let mut r = NixReader::builder().build_buffered(Cursor::new(buf));
+        r.read_value().await.expect("read")
+    });
+    assert_eq!(back, req);
+}
+
+#[test]
 fn roundtrip_add_to_store_scanning_request() {
     use crate::daemon_wire::types2::{AddToStoreScanningRequest, Request};
     use harmonia_store_content_address::ContentAddressMethodAlgorithm;

--- a/harmonia-store-remote/src/client.rs
+++ b/harmonia-store-remote/src/client.rs
@@ -981,6 +981,39 @@ where
         .fill_operation(Operation::SubmitOutput)
     }
 
+    fn add_to_store_scanning<'a, 'source, Source>(
+        &'a mut self,
+        name: &'a str,
+        cam: ContentAddressMethodAlgorithm,
+        source: Source,
+    ) -> Pin<Box<dyn ResultLog<Output = DaemonResult<ValidPathInfo>> + Send + 'source>>
+    where
+        Source: AsyncBufRead + Send + Unpin + 'source,
+        'a: 'source,
+    {
+        async move {
+            self.writer
+                .write_value(&Operation::AddToStoreScanning)
+                .await?;
+            self.writer.write_value(name).await?;
+            self.writer.write_value(&cam).await?;
+            self.writer.flush().await?;
+            Ok(ProcessStderr::new(&mut self.reader)
+                .stream()
+                .drive_result(async {
+                    let mut source = source;
+                    let mut framed = FramedWriter::new(&mut self.writer);
+                    copy_buf(&mut source, &mut framed).await?;
+                    framed.shutdown().await?;
+                    self.writer.flush().await?;
+                    Ok(()) as DaemonResult<()>
+                }))
+        }
+        .future_result()
+        .fill_operation(Operation::AddToStoreScanning)
+        .boxed_result()
+    }
+
     fn add_ca_to_store<'a, 'r, S>(
         &'a mut self,
         name: &'a str,

--- a/harmonia-store-remote/src/client.rs
+++ b/harmonia-store-remote/src/client.rs
@@ -42,14 +42,15 @@ use harmonia_protocol::types::{
 use harmonia_protocol::valid_path_info::{UnkeyedValidPathInfo, ValidPathInfo};
 use harmonia_protocol::version::{FeatureSet, supported_features};
 use harmonia_protocol::{
-    FEATURE_ADD_TO_STORE_SCANNING, FEATURE_REALISATION_WITH_PATH, ProtocolVersion,
+    FEATURE_ADD_TO_STORE_SCANNING, FEATURE_DISABLE_SET_OPTIONS, FEATURE_REALISATION_WITH_PATH,
+    FEATURE_SUBMIT_OUTPUT, ProtocolVersion,
 };
 
 // From harmonia-store-derivation
 use harmonia_protocol::log::{LogMessage, Message, Verbosity};
 use harmonia_store_content_address::ContentAddressMethodAlgorithm;
 use harmonia_store_derivation::derivation::BasicDerivation;
-use harmonia_store_derivation::derived_path::{DerivedPath, OutputName};
+use harmonia_store_derivation::derived_path::{DerivedPath, OutputName, SingleDerivedPath};
 use harmonia_store_derivation::realisation::{DrvOutput, Realisation, UnkeyedRealisation};
 use harmonia_store_path::{StoreDir, StorePath, StorePathHash, StorePathSet};
 use harmonia_utils_io::{AsyncBufReadCompat, BytesReader, Lending};
@@ -246,8 +247,12 @@ where
             // Exchange features (protocol >= 1.38).
             let mut features = FeatureSet::new();
             if version.minor() >= 38 {
+                // These are not in `supported_features()` because the daemon
+                // only advertises them on recursive connections.
                 let mut local = supported_features();
+                local.insert(FEATURE_DISABLE_SET_OPTIONS.to_owned());
                 local.insert(FEATURE_ADD_TO_STORE_SCANNING.to_owned());
+                local.insert(FEATURE_SUBMIT_OUTPUT.to_owned());
                 writer.write_value(&local).await.with_field("features")?;
                 writer.flush().await.with_field("features")?;
                 let daemon_features: FeatureSet =
@@ -1000,6 +1005,28 @@ where
         .future_result()
         .fill_operation(Operation::AddToStore)
         .boxed_result()
+    }
+
+    fn submit_output<'a>(
+        &'a mut self,
+        path: &'a SingleDerivedPath,
+        output: &'a OutputName,
+    ) -> impl ResultLog<Output = DaemonResult<()>> + Send + 'a {
+        async move {
+            if !self.has_feature(FEATURE_SUBMIT_OUTPUT) {
+                return Err(DaemonErrorKind::Custom(format!(
+                    "the daemon does not support the '{FEATURE_SUBMIT_OUTPUT}' protocol feature, \
+                   perhaps this is not in a derivation with the `builder-rpc-v0` feature?"
+                ))
+                .into());
+            }
+            self.writer.write_value(&Operation::SubmitOutput).await?;
+            self.writer.write_value(path).await?;
+            self.writer.write_value(output).await?;
+            Ok(self.process_stderr().map_ok(|_: IgnoredOne| ()))
+        }
+        .future_result()
+        .fill_operation(Operation::SubmitOutput)
     }
 
     fn add_to_store_scanning<'a, 'r, S>(

--- a/harmonia-store-remote/src/client.rs
+++ b/harmonia-store-remote/src/client.rs
@@ -47,7 +47,7 @@ use harmonia_protocol::{FEATURE_REALISATION_WITH_PATH, ProtocolVersion};
 // From harmonia-store-core
 use harmonia_protocol::log::{LogMessage, Message, Verbosity};
 use harmonia_store_core::derivation::BasicDerivation;
-use harmonia_store_core::derived_path::{DerivedPath, OutputName};
+use harmonia_store_core::derived_path::{DerivedPath, OutputName, SingleDerivedPath};
 use harmonia_store_core::realisation::{DrvOutput, Realisation, UnkeyedRealisation};
 use harmonia_store_core::signature::Signature;
 use harmonia_store_core::store_path::{
@@ -964,6 +964,21 @@ where
         }
         .future_result()
         .fill_operation(Operation::AddPermRoot)
+    }
+
+    fn submit_output<'a>(
+        &'a mut self,
+        path: &'a SingleDerivedPath,
+        output: &'a OutputName,
+    ) -> impl ResultLog<Output = DaemonResult<()>> + Send + 'a {
+        async move {
+            self.writer.write_value(&Operation::SubmitOutput).await?;
+            self.writer.write_value(path).await?;
+            self.writer.write_value(output).await?;
+            Ok(self.process_stderr().map_ok(|_: IgnoredOne| ()))
+        }
+        .future_result()
+        .fill_operation(Operation::SubmitOutput)
     }
 
     fn add_ca_to_store<'a, 'r, S>(


### PR DESCRIPTION
This PR adds the `SubmitOutput` op, the `submit-output` protocol feature, and the pinned `builder-rpc-v0` feature set from upstream Nix. As with `add-to-store-scanning`, only the client advertises the feature.

`SingleDerivedPath` is sent in the tagged binary format, with a word tag of 0 for an opaque path and 1 for a built path followed by its output name. The decoder has no depth limit to match upstream's serializer, and the feature set is pinned by a test since it's derivation-visible.

This depends on NixOS/nix#15793.