### PR TITLE
Extract `BuildResult` into `harmonia-store-build-result` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1072,6 +1072,7 @@ dependencies = [
  "futures-util",
  "harmonia-nar",
  "harmonia-protocol-derive",
+ "harmonia-store-build-result",
  "harmonia-store-core",
  "harmonia-store-path-info",
  "harmonia-utils-hash",
@@ -1117,6 +1118,20 @@ dependencies = [
  "rstest",
  "serde_json",
  "thiserror",
+]
+
+[[package]]
+name = "harmonia-store-build-result"
+version = "3.1.0"
+dependencies = [
+ "harmonia-store-build-result",
+ "harmonia-store-core",
+ "harmonia-utils-test",
+ "num_enum",
+ "proptest",
+ "proptest-derive",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 members = [
+    "harmonia-store-build-result",
     "harmonia-client",
     "harmonia-utils-io",
     "harmonia-utils-base-encoding",
@@ -95,6 +96,7 @@ harmonia-nar                 = { path = "harmonia-nar" }
 harmonia-protocol            = { path = "harmonia-protocol" }
 harmonia-protocol-derive     = { path = "harmonia-protocol-derive" }
 harmonia-store-aterm         = { path = "harmonia-store-aterm" }
+harmonia-store-build-result  = { path = "harmonia-store-build-result" }
 harmonia-store-core          = { path = "harmonia-store-core" }
 harmonia-store-db            = { path = "harmonia-store-db" }
 harmonia-store-remote        = { path = "harmonia-store-remote" }

--- a/docs/architecture/harmonia-store-structure.md
+++ b/docs/architecture/harmonia-store-structure.md
@@ -87,10 +87,12 @@ graph BT
     store-core --> utils-hash
     store-aterm --> store-core
     store-aterm --> utils-hash
+    store-build-result --> store-core
     store-path-info --> store-core
     store-path-info --> utils-hash
     protocol --> nar
     protocol --> protocol-derive
+    protocol --> store-build-result
     protocol --> store-core
     protocol --> store-path-info
     protocol --> utils-hash
@@ -128,9 +130,11 @@ graph BT
     utils-hash --> utils-base-encoding
     store-core --> utils-hash
     store-aterm --> store-core
+    store-build-result --> store-core
     store-path-info --> store-core
     protocol --> nar
     protocol --> protocol-derive
+    protocol --> store-build-result
     protocol --> store-path-info
     store-db --> store-path-info
     cache --> nar

--- a/harmonia-protocol/Cargo.toml
+++ b/harmonia-protocol/Cargo.toml
@@ -33,26 +33,34 @@ tokio-util       = { workspace = true, features = [ "io" ] }
 tracing          = { workspace = true }
 
 # Internal dependencies
-harmonia-nar             = { version = "3.0.0" }
-harmonia-protocol-derive = { version = "3.1.0" }
-harmonia-store-core      = { version = "0.0.0-alpha.0" }
-harmonia-store-path-info = { path = "../harmonia-store-path-info" }
-harmonia-utils-hash      = { version = "0.0.0-alpha.0" }
-harmonia-utils-io        = { version = "0.0.0-alpha.0" }
-harmonia-utils-test      = { version = "0.0.0-alpha.0", optional = true }
+harmonia-nar                = { version = "3.0.0" }
+harmonia-protocol-derive    = { version = "3.1.0" }
+harmonia-store-build-result = { path = "../harmonia-store-build-result" }
+harmonia-store-core         = { version = "0.0.0-alpha.0" }
+harmonia-store-path-info    = { path = "../harmonia-store-path-info" }
+harmonia-utils-hash         = { version = "0.0.0-alpha.0" }
+harmonia-utils-io           = { version = "0.0.0-alpha.0" }
+harmonia-utils-test         = { version = "0.0.0-alpha.0", optional = true }
 
 [dev-dependencies]
-harmonia-nar        = { version = "3.0.0", features = [ "test" ] }
-harmonia-store-core = { version = "0.0.0-alpha.0", features = [ "test" ] }
-harmonia-utils-test = { version = "0.0.0-alpha.0" }
-hex-literal         = { workspace = true }
-proptest            = { workspace = true }
-proptest-derive     = { workspace = true }
-rstest              = { workspace = true }
-tokio-test          = { workspace = true }
+harmonia-nar                = { version = "3.0.0", features = [ "test" ] }
+harmonia-store-build-result = { path = "../harmonia-store-build-result", features = [ "test" ] }
+harmonia-store-core         = { version = "0.0.0-alpha.0", features = [ "test" ] }
+harmonia-utils-test         = { version = "0.0.0-alpha.0" }
+hex-literal                 = { workspace = true }
+proptest                    = { workspace = true }
+proptest-derive             = { workspace = true }
+rstest                      = { workspace = true }
+tokio-test                  = { workspace = true }
 
 [features]
-test = [ "proptest", "proptest-derive", "harmonia-utils-test", "harmonia-utils-hash/test" ]
+test = [
+    "proptest",
+    "proptest-derive",
+    "harmonia-utils-test",
+    "harmonia-utils-hash/test",
+    "harmonia-store-build-result/test",
+]
 
 [[test]]
 name = "json_upstream"

--- a/harmonia-protocol/src/build_result.rs
+++ b/harmonia-protocol/src/build_result.rs
@@ -1,148 +1,44 @@
-//! BuildResult types with sum type design matching upstream Nix.
+//! `NixDeserialize`/`NixSerialize` impls for `BuildResult` and related types.
 //!
-//! This module provides BuildResult using a `std::variant<Success, Failure>` pattern
-//! that matches the upstream Nix implementation.
+//! The pure types and JSON serialization live in `harmonia-store-build-result`.
 
 use std::collections::BTreeMap;
 
-use num_enum::{IntoPrimitive, TryFromPrimitive};
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
-use serde_json::{Map, Value};
+use bytes::Bytes;
 
-use crate::daemon_wire::types2::Microseconds;
+use harmonia_store_build_result::{
+    BuildResult, BuildResultFailure, BuildResultInner, BuildResultSuccess, FailureStatus,
+    Microseconds, SuccessStatus,
+};
+
 use crate::de::{Error as _, NixDeserialize as NixDeserializeTrait, NixRead};
 use crate::ser::{NixSerialize as NixSerializeTrait, NixWrite};
-use crate::types::{DaemonInt, DaemonString, DaemonTime};
 use harmonia_store_core::derived_path::OutputName;
 use harmonia_store_core::realisation::UnkeyedRealisation;
 
-/// Success status values for BuildResult.
-///
-/// Must be disjoint with `FailureStatus`.
-#[derive(
-    Debug,
-    Clone,
-    Copy,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Hash,
-    TryFromPrimitive,
-    IntoPrimitive,
-    Serialize,
-    Deserialize,
-)]
-#[repr(u16)]
-pub enum SuccessStatus {
-    Built = 0,
-    Substituted = 1,
-    AlreadyValid = 2,
-    ResolvesToAlreadyValid = 13,
-}
-
-/// Failure status values for BuildResult.
-///
-/// Must be disjoint with `SuccessStatus`.
-#[derive(
-    Debug,
-    Clone,
-    Copy,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Hash,
-    TryFromPrimitive,
-    IntoPrimitive,
-    Serialize,
-    Deserialize,
-)]
-#[repr(u16)]
-pub enum FailureStatus {
-    PermanentFailure = 3,
-    InputRejected = 4,
-    OutputRejected = 5,
-    /// possibly transient
-    TransientFailure = 6,
-    /// no longer used
-    CachedFailure = 7,
-    TimedOut = 8,
-    MiscFailure = 9,
-    DependencyFailed = 10,
-    LogLimitExceeded = 11,
-    NotDeterministic = 12,
-    NoSubstituters = 14,
-}
-
-/// Successful build result data.
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct BuildResultSuccess {
-    pub status: SuccessStatus,
-    /// For derivations, a mapping from output names to realisations.
-    #[serde(default)]
-    pub built_outputs: BTreeMap<OutputName, UnkeyedRealisation>,
-}
-
-/// Failed build result data.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct BuildResultFailure {
-    pub status: FailureStatus,
-    /// Information about the error if the build failed.
-    pub error_msg: DaemonString,
-    /// If timesBuilt > 1, whether some builds did not produce the same result.
-    pub is_non_deterministic: bool,
-}
-
-/// The inner result of a build - either success or failure.
-///
-/// Uses the `success` field as a discriminator for JSON serialization.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub enum BuildResultInner {
-    Success(BuildResultSuccess),
-    Failure(BuildResultFailure),
-}
-
-/// Result of a build operation.
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct BuildResult {
-    #[serde(flatten)]
-    pub inner: BuildResultInner,
-    /// How many times this build was performed.
-    pub times_built: DaemonInt,
-    /// The start time of the build.
-    pub start_time: DaemonTime,
-    /// The stop time of the build.
-    pub stop_time: DaemonTime,
-    /// User CPU time the build took.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub cpu_user: Option<Microseconds>,
-    /// System CPU time the build took.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub cpu_system: Option<Microseconds>,
-}
-
-impl BuildResult {
-    /// Returns the success data if this is a successful build.
-    pub fn success(&self) -> Option<&BuildResultSuccess> {
-        match &self.inner {
-            BuildResultInner::Success(s) => Some(s),
-            BuildResultInner::Failure(_) => None,
-        }
-    }
-
-    /// Returns the failure data if this is a failed build.
-    pub fn failure(&self) -> Option<&BuildResultFailure> {
-        match &self.inner {
-            BuildResultInner::Success(_) => None,
-            BuildResultInner::Failure(f) => Some(f),
-        }
-    }
-}
-
 // Wire protocol serialization - maintains compatibility with the flat status enum format
+
+impl NixDeserializeTrait for Microseconds {
+    async fn try_deserialize<R>(reader: &mut R) -> Result<Option<Self>, R::Error>
+    where
+        R: ?Sized + NixRead + Send,
+    {
+        Ok(reader
+            .try_read_value::<i64>()
+            .await?
+            .map(Microseconds::from))
+    }
+}
+
+impl NixSerializeTrait for Microseconds {
+    async fn serialize<W>(&self, writer: &mut W) -> Result<(), W::Error>
+    where
+        W: NixWrite,
+    {
+        let v: i64 = (*self).into();
+        writer.write_value(&v).await
+    }
+}
 
 impl NixDeserializeTrait for BuildResult {
     async fn try_deserialize<R>(reader: &mut R) -> Result<Option<Self>, R::Error>
@@ -152,11 +48,11 @@ impl NixDeserializeTrait for BuildResult {
         let Some(status_raw) = reader.try_read_value::<u16>().await? else {
             return Ok(None);
         };
-        let error_msg: DaemonString = reader.read_value().await?;
-        let times_built: DaemonInt = reader.read_value().await?;
+        let error_msg: Vec<u8> = reader.read_value::<Bytes>().await?.to_vec();
+        let times_built: u32 = reader.read_value().await?;
         let is_non_deterministic: bool = reader.read_value().await?;
-        let start_time: DaemonTime = reader.read_value().await?;
-        let stop_time: DaemonTime = reader.read_value().await?;
+        let start_time: i64 = reader.read_value().await?;
+        let stop_time: i64 = reader.read_value().await?;
         let cpu_user: Option<Microseconds> = reader.read_value().await?;
         let cpu_system: Option<Microseconds> = reader.read_value().await?;
         let built_outputs: BTreeMap<OutputName, UnkeyedRealisation> =
@@ -206,19 +102,16 @@ impl NixSerializeTrait for BuildResult {
     {
         let (status_raw, error_msg, is_non_deterministic, built_outputs): (
             u16,
-            &DaemonString,
+            &[u8],
             bool,
             &BTreeMap<OutputName, UnkeyedRealisation>,
         ) = match &self.inner {
-            BuildResultInner::Success(s) => {
-                static EMPTY_STRING: DaemonString = DaemonString::new();
-                (s.status.into(), &EMPTY_STRING, false, &s.built_outputs)
-            }
+            BuildResultInner::Success(s) => (s.status.into(), &[], false, &s.built_outputs),
             BuildResultInner::Failure(f) => {
                 static EMPTY_MAP: BTreeMap<OutputName, UnkeyedRealisation> = BTreeMap::new();
                 (
                     f.status.into(),
-                    &f.error_msg,
+                    f.error_msg.as_slice(),
                     f.is_non_deterministic,
                     &EMPTY_MAP,
                 )
@@ -226,7 +119,7 @@ impl NixSerializeTrait for BuildResult {
         };
 
         writer.write_value(&status_raw).await?;
-        writer.write_value(error_msg).await?;
+        writer.write_slice(error_msg).await?;
         writer.write_value(&self.times_built).await?;
         writer.write_value(&is_non_deterministic).await?;
         writer.write_value(&self.start_time).await?;
@@ -252,193 +145,6 @@ impl NixSerializeTrait for BuildResult {
         }
 
         Ok(())
-    }
-}
-
-#[cfg(test)]
-mod arbitrary {
-    use super::*;
-    use proptest::prelude::*;
-
-    impl Arbitrary for SuccessStatus {
-        type Parameters = ();
-        type Strategy = BoxedStrategy<Self>;
-        fn arbitrary_with(_: ()) -> Self::Strategy {
-            use SuccessStatus::*;
-            prop_oneof![
-                Just(Built),
-                Just(Substituted),
-                Just(AlreadyValid),
-                Just(ResolvesToAlreadyValid),
-            ]
-            .boxed()
-        }
-    }
-
-    impl Arbitrary for FailureStatus {
-        type Parameters = ();
-        type Strategy = BoxedStrategy<Self>;
-        fn arbitrary_with(_: ()) -> Self::Strategy {
-            use FailureStatus::*;
-            prop_oneof![
-                Just(PermanentFailure),
-                Just(InputRejected),
-                Just(OutputRejected),
-                Just(TransientFailure),
-                Just(CachedFailure),
-                Just(TimedOut),
-                Just(MiscFailure),
-                Just(DependencyFailed),
-                Just(LogLimitExceeded),
-                Just(NotDeterministic),
-                Just(NoSubstituters),
-            ]
-            .boxed()
-        }
-    }
-
-    impl Arbitrary for BuildResult {
-        type Parameters = ();
-        type Strategy = BoxedStrategy<Self>;
-        fn arbitrary_with(_: ()) -> Self::Strategy {
-            let success = (
-                any::<SuccessStatus>(),
-                proptest::collection::btree_map(
-                    any::<OutputName>(),
-                    any::<UnkeyedRealisation>(),
-                    0..4,
-                ),
-            )
-                .prop_map(|(status, built_outputs)| {
-                    BuildResultInner::Success(BuildResultSuccess {
-                        status,
-                        built_outputs,
-                    })
-                });
-            let failure = (any::<FailureStatus>(), any::<Vec<u8>>(), any::<bool>()).prop_map(
-                |(status, error_msg, is_non_deterministic)| {
-                    BuildResultInner::Failure(BuildResultFailure {
-                        status,
-                        error_msg: error_msg.into(),
-                        is_non_deterministic,
-                    })
-                },
-            );
-            (
-                prop_oneof![success, failure],
-                any::<DaemonInt>(),
-                any::<DaemonTime>(),
-                any::<DaemonTime>(),
-                any::<Option<Microseconds>>(),
-                any::<Option<Microseconds>>(),
-            )
-                .prop_map(
-                    |(inner, times_built, start_time, stop_time, cpu_user, cpu_system)| {
-                        BuildResult {
-                            inner,
-                            times_built,
-                            start_time,
-                            stop_time,
-                            cpu_user,
-                            cpu_system,
-                        }
-                    },
-                )
-                .boxed()
-        }
-    }
-}
-
-// JSON serialization for upstream Nix compatibility
-
-/// JSON helper for BuildResultFailure (handles DaemonString <-> String conversion)
-#[derive(Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-struct BuildResultFailureJson {
-    status: FailureStatus,
-    #[serde(default)]
-    error_msg: String,
-    #[serde(default)]
-    is_non_deterministic: bool,
-}
-
-impl Serialize for BuildResultFailure {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        BuildResultFailureJson {
-            status: self.status,
-            error_msg: String::from_utf8_lossy(&self.error_msg).into_owned(),
-            is_non_deterministic: self.is_non_deterministic,
-        }
-        .serialize(serializer)
-    }
-}
-
-impl<'de> Deserialize<'de> for BuildResultFailure {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        let json = BuildResultFailureJson::deserialize(deserializer)?;
-        Ok(BuildResultFailure {
-            status: json.status,
-            error_msg: json.error_msg.into(),
-            is_non_deterministic: json.is_non_deterministic,
-        })
-    }
-}
-
-impl Serialize for BuildResultInner {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        use serde::ser::Error;
-
-        let (success, value) = match self {
-            BuildResultInner::Success(s) => {
-                (true, serde_json::to_value(s).map_err(S::Error::custom)?)
-            }
-            BuildResultInner::Failure(f) => {
-                (false, serde_json::to_value(f).map_err(S::Error::custom)?)
-            }
-        };
-
-        let Value::Object(mut map) = value else {
-            return Err(S::Error::custom("expected object"));
-        };
-        map.insert("success".into(), Value::Bool(success));
-        map.serialize(serializer)
-    }
-}
-
-impl<'de> Deserialize<'de> for BuildResultInner {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        use serde::de::Error;
-
-        let mut map = Map::<String, Value>::deserialize(deserializer)?;
-
-        let success = map
-            .remove("success")
-            .and_then(|v| v.as_bool())
-            .ok_or_else(|| D::Error::missing_field("success"))?;
-
-        let value = Value::Object(map);
-
-        if success {
-            serde_json::from_value(value)
-                .map(BuildResultInner::Success)
-                .map_err(D::Error::custom)
-        } else {
-            serde_json::from_value(value)
-                .map(BuildResultInner::Failure)
-                .map_err(D::Error::custom)
-        }
     }
 }
 

--- a/harmonia-protocol/src/daemon_wire/types2.rs
+++ b/harmonia-protocol/src/daemon_wire/types2.rs
@@ -1,13 +1,12 @@
-pub use crate::build_result::{
+pub use harmonia_store_build_result::{
     BuildResult, BuildResultFailure, BuildResultInner, BuildResultSuccess, FailureStatus,
-    SuccessStatus,
+    Microseconds, SuccessStatus,
 };
 
 use std::fmt;
 use std::num::NonZero;
 use std::str::FromStr;
 use std::str::from_utf8;
-use std::time::Duration;
 
 use num_enum::{IntoPrimitive, TryFromPrimitive};
 #[cfg(test)]
@@ -29,47 +28,6 @@ use harmonia_store_core::store_path::{
 
 use super::IgnoredZero;
 use super::types::Operation;
-
-#[derive(
-    Debug,
-    Clone,
-    Copy,
-    PartialEq,
-    Eq,
-    Hash,
-    NixDeserialize,
-    NixSerialize,
-    serde::Serialize,
-    serde::Deserialize,
-)]
-#[nix(from = "i64", into = "i64")]
-#[serde(transparent)]
-pub struct Microseconds(pub i64);
-
-impl From<i64> for Microseconds {
-    fn from(value: i64) -> Self {
-        Microseconds(value)
-    }
-}
-
-impl From<Microseconds> for Duration {
-    fn from(value: Microseconds) -> Self {
-        Duration::from_micros(value.0.unsigned_abs())
-    }
-}
-
-impl TryFrom<Duration> for Microseconds {
-    type Error = std::num::TryFromIntError;
-    fn try_from(value: Duration) -> Result<Self, Self::Error> {
-        Ok(Microseconds(value.as_micros().try_into()?))
-    }
-}
-
-impl From<Microseconds> for i64 {
-    fn from(value: Microseconds) -> Self {
-        value.0
-    }
-}
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, NixDeserialize, NixSerialize)]
 #[nix(from_str, display)]
@@ -571,20 +529,6 @@ pub mod arbitrary {
                 5 => Just(Check),
             ]
             .boxed()
-        }
-    }
-
-    impl Arbitrary for Microseconds {
-        type Parameters = ();
-        type Strategy = BoxedStrategy<Microseconds>;
-
-        fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {
-            arb_microseconds().boxed()
-        }
-    }
-    prop_compose! {
-        fn arb_microseconds()(ms in 0i64..i64::MAX) -> Microseconds {
-            Microseconds(ms)
         }
     }
 }

--- a/harmonia-protocol/src/lib.rs
+++ b/harmonia-protocol/src/lib.rs
@@ -27,7 +27,7 @@
 //! 3. **Well-specified**: Document wire format
 //! 4. **Type-safe**: Use strong types for protocol messages
 
-pub mod build_result;
+mod build_result;
 pub mod daemon_wire;
 pub mod de;
 pub mod log;

--- a/harmonia-protocol/src/wire_roundtrip.rs
+++ b/harmonia-protocol/src/wire_roundtrip.rs
@@ -57,8 +57,8 @@ macro_rules! wire_roundtrip {
     };
 }
 
-use crate::build_result::BuildResult;
 use crate::daemon_wire::types2::QueryMissingResult;
+use harmonia_store_build_result::BuildResult;
 use harmonia_store_core::derived_path::DerivedPath;
 use harmonia_store_core::realisation::{DrvOutput, Realisation, UnkeyedRealisation};
 

--- a/harmonia-store-build-result/Cargo.toml
+++ b/harmonia-store-build-result/Cargo.toml
@@ -1,0 +1,36 @@
+# SPDX-FileCopyrightText: 2025 Obsidian Systems
+# SPDX-License-Identifier: MIT
+
+[package]
+name                 = "harmonia-store-build-result"
+version.workspace    = true
+authors.workspace    = true
+edition.workspace    = true
+license.workspace    = true
+homepage.workspace   = true
+repository.workspace = true
+description          = "BuildResult types and JSON serialization for Nix build results"
+readme               = "README.md"
+
+[dependencies]
+harmonia-store-core = { path = "../harmonia-store-core" }
+num_enum            = { workspace = true }
+proptest            = { workspace = true, optional = true }
+proptest-derive     = { workspace = true, optional = true }
+serde               = { workspace = true }
+serde_json          = { workspace = true }
+
+[dev-dependencies]
+harmonia-store-build-result = { path = ".", features = [ "test" ] }
+harmonia-utils-test         = { version = "0.0.0-alpha.0" }
+serde_json                  = { workspace = true }
+
+[features]
+test = [ "proptest", "proptest-derive", "harmonia-store-core/test" ]
+
+[[test]]
+name = "json_upstream"
+path = "tests/json_upstream/mod.rs"
+
+[lints]
+workspace = true

--- a/harmonia-store-build-result/src/lib.rs
+++ b/harmonia-store-build-result/src/lib.rs
@@ -1,0 +1,370 @@
+// SPDX-FileCopyrightText: 2025 Obsidian Systems
+// SPDX-License-Identifier: MIT
+
+//! Pure `BuildResult` types and JSON serialization for Nix build results.
+//!
+//! Quarantined from `harmonia-protocol` so the types can be used without
+//! pulling in the full wire protocol stack.  Protocol-specific wire format
+//! impls are added in the protocol layer.
+
+use std::collections::BTreeMap;
+use std::time::Duration;
+
+use num_enum::{IntoPrimitive, TryFromPrimitive};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use serde_json::{Map, Value};
+
+use harmonia_store_core::derived_path::OutputName;
+use harmonia_store_core::realisation::UnkeyedRealisation;
+
+/// A duration measured in microseconds.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct Microseconds(pub i64);
+
+impl From<i64> for Microseconds {
+    fn from(value: i64) -> Self {
+        Microseconds(value)
+    }
+}
+
+impl From<Microseconds> for i64 {
+    fn from(value: Microseconds) -> Self {
+        value.0
+    }
+}
+
+impl From<Microseconds> for Duration {
+    fn from(value: Microseconds) -> Self {
+        Duration::from_micros(value.0.unsigned_abs())
+    }
+}
+
+impl TryFrom<Duration> for Microseconds {
+    type Error = std::num::TryFromIntError;
+    fn try_from(value: Duration) -> Result<Self, Self::Error> {
+        Ok(Microseconds(value.as_micros().try_into()?))
+    }
+}
+
+/// Success status values for BuildResult.
+///
+/// Must be disjoint with `FailureStatus`.
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    TryFromPrimitive,
+    IntoPrimitive,
+    Serialize,
+    Deserialize,
+)]
+#[repr(u16)]
+pub enum SuccessStatus {
+    Built = 0,
+    Substituted = 1,
+    AlreadyValid = 2,
+    ResolvesToAlreadyValid = 13,
+}
+
+/// Failure status values for BuildResult.
+///
+/// Must be disjoint with `SuccessStatus`.
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    TryFromPrimitive,
+    IntoPrimitive,
+    Serialize,
+    Deserialize,
+)]
+#[repr(u16)]
+pub enum FailureStatus {
+    PermanentFailure = 3,
+    InputRejected = 4,
+    OutputRejected = 5,
+    /// possibly transient
+    TransientFailure = 6,
+    /// no longer used
+    CachedFailure = 7,
+    TimedOut = 8,
+    MiscFailure = 9,
+    DependencyFailed = 10,
+    LogLimitExceeded = 11,
+    NotDeterministic = 12,
+    NoSubstituters = 14,
+}
+
+/// Successful build result data.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BuildResultSuccess {
+    pub status: SuccessStatus,
+    /// For derivations, a mapping from output names to realisations.
+    #[serde(default)]
+    pub built_outputs: BTreeMap<OutputName, UnkeyedRealisation>,
+}
+
+/// Failed build result data.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct BuildResultFailure {
+    pub status: FailureStatus,
+    /// Information about the error if the build failed.
+    pub error_msg: Vec<u8>,
+    /// If timesBuilt > 1, whether some builds did not produce the same result.
+    pub is_non_deterministic: bool,
+}
+
+/// The inner result of a build - either success or failure.
+///
+/// Uses the `success` field as a discriminator for JSON serialization.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum BuildResultInner {
+    Success(BuildResultSuccess),
+    Failure(BuildResultFailure),
+}
+
+/// Result of a build operation.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BuildResult {
+    #[serde(flatten)]
+    pub inner: BuildResultInner,
+    /// How many times this build was performed.
+    pub times_built: u32,
+    /// The start time of the build.
+    pub start_time: i64,
+    /// The stop time of the build.
+    pub stop_time: i64,
+    /// User CPU time the build took.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cpu_user: Option<Microseconds>,
+    /// System CPU time the build took.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cpu_system: Option<Microseconds>,
+}
+
+impl BuildResult {
+    /// Returns the success data if this is a successful build.
+    pub fn success(&self) -> Option<&BuildResultSuccess> {
+        match &self.inner {
+            BuildResultInner::Success(s) => Some(s),
+            BuildResultInner::Failure(_) => None,
+        }
+    }
+
+    /// Returns the failure data if this is a failed build.
+    pub fn failure(&self) -> Option<&BuildResultFailure> {
+        match &self.inner {
+            BuildResultInner::Success(_) => None,
+            BuildResultInner::Failure(f) => Some(f),
+        }
+    }
+}
+
+// JSON serialization for upstream Nix compatibility
+
+/// JSON helper for BuildResultFailure (handles Vec<u8> <-> String conversion)
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct BuildResultFailureJson {
+    status: FailureStatus,
+    #[serde(default)]
+    error_msg: String,
+    #[serde(default)]
+    is_non_deterministic: bool,
+}
+
+impl Serialize for BuildResultFailure {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        BuildResultFailureJson {
+            status: self.status,
+            error_msg: String::from_utf8_lossy(&self.error_msg).into_owned(),
+            is_non_deterministic: self.is_non_deterministic,
+        }
+        .serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for BuildResultFailure {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let json = BuildResultFailureJson::deserialize(deserializer)?;
+        Ok(BuildResultFailure {
+            status: json.status,
+            error_msg: json.error_msg.into_bytes(),
+            is_non_deterministic: json.is_non_deterministic,
+        })
+    }
+}
+
+impl Serialize for BuildResultInner {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        use serde::ser::Error;
+
+        let (success, value) = match self {
+            BuildResultInner::Success(s) => {
+                (true, serde_json::to_value(s).map_err(S::Error::custom)?)
+            }
+            BuildResultInner::Failure(f) => {
+                (false, serde_json::to_value(f).map_err(S::Error::custom)?)
+            }
+        };
+
+        let Value::Object(mut map) = value else {
+            return Err(S::Error::custom("expected object"));
+        };
+        map.insert("success".into(), Value::Bool(success));
+        map.serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for BuildResultInner {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        use serde::de::Error;
+
+        let mut map = Map::<String, Value>::deserialize(deserializer)?;
+
+        let success = map
+            .remove("success")
+            .and_then(|v| v.as_bool())
+            .ok_or_else(|| D::Error::missing_field("success"))?;
+
+        let value = Value::Object(map);
+
+        if success {
+            serde_json::from_value(value)
+                .map(BuildResultInner::Success)
+                .map_err(D::Error::custom)
+        } else {
+            serde_json::from_value(value)
+                .map(BuildResultInner::Failure)
+                .map_err(D::Error::custom)
+        }
+    }
+}
+
+#[cfg(any(test, feature = "test"))]
+mod arbitrary {
+    use super::*;
+    use proptest::prelude::*;
+
+    impl Arbitrary for Microseconds {
+        type Parameters = ();
+        type Strategy = BoxedStrategy<Microseconds>;
+
+        fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {
+            (0i64..i64::MAX).prop_map(Microseconds).boxed()
+        }
+    }
+
+    impl Arbitrary for SuccessStatus {
+        type Parameters = ();
+        type Strategy = BoxedStrategy<Self>;
+        fn arbitrary_with(_: ()) -> Self::Strategy {
+            use SuccessStatus::*;
+            prop_oneof![
+                Just(Built),
+                Just(Substituted),
+                Just(AlreadyValid),
+                Just(ResolvesToAlreadyValid),
+            ]
+            .boxed()
+        }
+    }
+
+    impl Arbitrary for FailureStatus {
+        type Parameters = ();
+        type Strategy = BoxedStrategy<Self>;
+        fn arbitrary_with(_: ()) -> Self::Strategy {
+            use FailureStatus::*;
+            prop_oneof![
+                Just(PermanentFailure),
+                Just(InputRejected),
+                Just(OutputRejected),
+                Just(TransientFailure),
+                Just(CachedFailure),
+                Just(TimedOut),
+                Just(MiscFailure),
+                Just(DependencyFailed),
+                Just(LogLimitExceeded),
+                Just(NotDeterministic),
+                Just(NoSubstituters),
+            ]
+            .boxed()
+        }
+    }
+
+    impl Arbitrary for BuildResult {
+        type Parameters = ();
+        type Strategy = BoxedStrategy<Self>;
+        fn arbitrary_with(_: ()) -> Self::Strategy {
+            let success = (
+                any::<SuccessStatus>(),
+                proptest::collection::btree_map(
+                    any::<OutputName>(),
+                    any::<UnkeyedRealisation>(),
+                    0..4,
+                ),
+            )
+                .prop_map(|(status, built_outputs)| {
+                    BuildResultInner::Success(BuildResultSuccess {
+                        status,
+                        built_outputs,
+                    })
+                });
+            let failure = (any::<FailureStatus>(), any::<Vec<u8>>(), any::<bool>()).prop_map(
+                |(status, error_msg, is_non_deterministic)| {
+                    BuildResultInner::Failure(BuildResultFailure {
+                        status,
+                        error_msg,
+                        is_non_deterministic,
+                    })
+                },
+            );
+            (
+                prop_oneof![success, failure],
+                any::<u32>(),
+                any::<i64>(),
+                any::<i64>(),
+                any::<Option<Microseconds>>(),
+                any::<Option<Microseconds>>(),
+            )
+                .prop_map(
+                    |(inner, times_built, start_time, stop_time, cpu_user, cpu_system)| {
+                        BuildResult {
+                            inner,
+                            times_built,
+                            start_time,
+                            stop_time,
+                            cpu_user,
+                            cpu_system,
+                        }
+                    },
+                )
+                .boxed()
+        }
+    }
+}

--- a/harmonia-store-build-result/tests/json_upstream/build_result.rs
+++ b/harmonia-store-build-result/tests/json_upstream/build_result.rs
@@ -1,7 +1,7 @@
 //! BuildResult JSON tests
 
 use super::{libstore_test_data_path, test_upstream_json};
-use harmonia_protocol::daemon_wire::types2::{
+use harmonia_store_build_result::{
     BuildResult, BuildResultFailure, BuildResultInner, BuildResultSuccess, FailureStatus,
     Microseconds, SuccessStatus,
 };
@@ -50,7 +50,7 @@ test_upstream_json!(
         BuildResult {
             inner: BuildResultInner::Failure(BuildResultFailure {
                 status: FailureStatus::OutputRejected,
-                error_msg: "no idea why".into(),
+                error_msg: b"no idea why".to_vec(),
                 is_non_deterministic: false,
             }),
             times_built: 3,
@@ -69,7 +69,7 @@ test_upstream_json!(
         BuildResult {
             inner: BuildResultInner::Failure(BuildResultFailure {
                 status: FailureStatus::NotDeterministic,
-                error_msg: "no idea why".into(),
+                error_msg: b"no idea why".to_vec(),
                 is_non_deterministic: false,
             }),
             times_built: 1,

--- a/harmonia-store-build-result/tests/json_upstream/mod.rs
+++ b/harmonia-store-build-result/tests/json_upstream/mod.rs
@@ -1,6 +1,6 @@
 //! Tests that verify JSON serialization matches upstream Nix format
-//!
-//! These tests use JSON test data from the upstream Nix repository.
 
 pub use harmonia_utils_test::json_upstream::libstore_test_data_path;
 pub use harmonia_utils_test::test_upstream_json;
+
+mod build_result;


### PR DESCRIPTION
Same pattern as `ValidPathInfo` / `harmonia-store-path-info`: pure types and JSON serialization live in the new crate, wire protocol `NixDeserialize`/`NixSerialize` impls remain in `harmonia-protocol`. The motivation is the same too --- both `BuildResult` and `ValidPathInfo` are a bit more implementation-opinated / not the only way of doing things, so I don't want them to live in `harmonia-store-core`.

Type changes for protocol independence:
- `error_msg`: `DaemonString` (`Bytes`) → `Vec<u8>`
- `times_built`: `DaemonInt` (`c_uint`) → `u32`
- `start_time`/`stop_time`: `DaemonTime` (`time_t`) → `i64`
- `Microseconds` moved from `types2.rs` to the new crate