### PR TITLE
Add `ConnectionPool::store_dir()` accessor

### DIFF
--- a/harmonia-store-remote/src/pool.rs
+++ b/harmonia-store-remote/src/pool.rs
@@ -170,6 +170,11 @@ impl ConnectionPool {
         pool
     }
 
+    /// Get the store directory for this pool.
+    pub fn store_dir(&self) -> &StoreDir {
+        &self.store_dir
+    }
+
     /// Acquire a connection from the pool.
     ///
     /// Returns an RAII guard that automatically returns the connection


### PR DESCRIPTION
Expose the pool's store directory so callers can format store paths without acquiring a connection.