### PR TITLE
Rename `Recursive` to `NixArchive` in content address types

### DIFF
--- a/harmonia-store-core/CHANGELOG.md
+++ b/harmonia-store-core/CHANGELOG.md
@@ -8,6 +8,7 @@ Various changes, and supporting the latest Nix `master` branch.
 
 #### Types
 
+- Renamed `ContentAddress::Recursive` to `ContentAddress::NixArchive`, `ContentAddressMethod::Recursive` to `ContentAddressMethod::NixArchive`, and `ContentAddressMethodAlgorithm::Recursive` to `ContentAddressMethodAlgorithm::NixArchive`, aligning with upstream Nix's terminology.
 - `Realisation` restructured to `{ key: DrvOutput, value: UnkeyedRealisation }`, matching upstream Nix's key-value composition.
   The old flat fields and `dependent_realisations` are removed.
 - `DrvOutput` now uses `StorePath` (not `Hash`) for `drv_path`, and uses `^` as the separator in its string format.

--- a/harmonia-store-core/src/derivation/derivation_output.rs
+++ b/harmonia-store-core/src/derivation/derivation_output.rs
@@ -131,7 +131,7 @@ impl<'de> Deserialize<'de> for DerivationOutput {
             let ca_method_algo = match method {
                 ContentAddressMethod::Text => ContentAddressMethodAlgorithm::Text,
                 ContentAddressMethod::Flat => ContentAddressMethodAlgorithm::Flat(algo),
-                ContentAddressMethod::Recursive => ContentAddressMethodAlgorithm::Recursive(algo),
+                ContentAddressMethod::NixArchive => ContentAddressMethodAlgorithm::NixArchive(algo),
             };
             if raw.impure {
                 Ok(DerivationOutput::Impure(ca_method_algo))
@@ -247,7 +247,7 @@ pub mod arbitrary {
         prop_oneof![
             any::<hash::Hash>().prop_map(|h| DerivationOutput::CAFixed(ContentAddress::Flat(h))),
             any::<hash::Hash>()
-                .prop_map(|h| DerivationOutput::CAFixed(ContentAddress::Recursive(h)))
+                .prop_map(|h| DerivationOutput::CAFixed(ContentAddress::NixArchive(h)))
         ]
     }
 
@@ -265,7 +265,7 @@ pub mod arbitrary {
         prop_oneof![
             1 => Just(ContentAddressMethodAlgorithm::Text),
             2 => hash_type.clone().prop_map(ContentAddressMethodAlgorithm::Flat),
-            2 => hash_type.prop_map(ContentAddressMethodAlgorithm::Recursive),
+            2 => hash_type.prop_map(ContentAddressMethodAlgorithm::NixArchive),
         ]
         .prop_map(DerivationOutput::CAFloating)
     }

--- a/harmonia-store-core/src/store_path/content_address.rs
+++ b/harmonia-store-core/src/store_path/content_address.rs
@@ -22,7 +22,7 @@ pub enum ContentAddressMethod {
     Flat,
     #[display("fixed:r")]
     #[serde(rename = "nar")]
-    Recursive,
+    NixArchive,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Display)]
@@ -33,7 +33,7 @@ pub enum ContentAddressMethodAlgorithm {
     #[display("{_0}")]
     Flat(Algorithm),
     #[display("r:{_0}")]
-    Recursive(Algorithm),
+    NixArchive(Algorithm),
 }
 
 /// Raw representation for JSON serialization/deserialization
@@ -66,8 +66,8 @@ impl<'de> Deserialize<'de> for ContentAddressMethodAlgorithm {
         Ok(match raw.method {
             ContentAddressMethod::Text => ContentAddressMethodAlgorithm::Text,
             ContentAddressMethod::Flat => ContentAddressMethodAlgorithm::Flat(raw.hash_algo),
-            ContentAddressMethod::Recursive => {
-                ContentAddressMethodAlgorithm::Recursive(raw.hash_algo)
+            ContentAddressMethod::NixArchive => {
+                ContentAddressMethodAlgorithm::NixArchive(raw.hash_algo)
             }
         })
     }
@@ -78,7 +78,7 @@ impl ContentAddressMethodAlgorithm {
         match self {
             ContentAddressMethodAlgorithm::Text => Algorithm::SHA256,
             ContentAddressMethodAlgorithm::Flat(algorithm) => *algorithm,
-            ContentAddressMethodAlgorithm::Recursive(algorithm) => *algorithm,
+            ContentAddressMethodAlgorithm::NixArchive(algorithm) => *algorithm,
         }
     }
 
@@ -86,7 +86,7 @@ impl ContentAddressMethodAlgorithm {
         match self {
             ContentAddressMethodAlgorithm::Text => ContentAddressMethod::Text,
             ContentAddressMethodAlgorithm::Flat(_) => ContentAddressMethod::Flat,
-            ContentAddressMethodAlgorithm::Recursive(_) => ContentAddressMethod::Recursive,
+            ContentAddressMethodAlgorithm::NixArchive(_) => ContentAddressMethod::NixArchive,
         }
     }
 }
@@ -98,7 +98,7 @@ impl FromStr for ContentAddressMethodAlgorithm {
         if s == "text:sha256" {
             Ok(Self::Text)
         } else if let Some(algo) = s.strip_prefix("r:") {
-            Ok(Self::Recursive(algo.parse()?))
+            Ok(Self::NixArchive(algo.parse()?))
         } else {
             Ok(Self::Flat(s.parse()?))
         }
@@ -113,7 +113,7 @@ pub enum ContentAddress {
     #[display("fixed:{}", _0.as_base32())]
     Flat(Hash),
     #[display("fixed:r:{}", _0.as_base32())]
-    Recursive(Hash),
+    NixArchive(Hash),
 }
 
 impl ContentAddress {
@@ -124,7 +124,7 @@ impl ContentAddress {
         Ok(match method {
             ContentAddressMethod::Text => ContentAddress::Text(hash.try_into()?),
             ContentAddressMethod::Flat => ContentAddress::Flat(hash),
-            ContentAddressMethod::Recursive => ContentAddress::Recursive(hash),
+            ContentAddressMethod::NixArchive => ContentAddress::NixArchive(hash),
         })
     }
     pub fn algorithm(&self) -> Algorithm {
@@ -134,7 +134,7 @@ impl ContentAddress {
         match self {
             ContentAddress::Text(_) => ContentAddressMethod::Text,
             ContentAddress::Flat(_) => ContentAddressMethod::Flat,
-            ContentAddress::Recursive(_) => ContentAddressMethod::Recursive,
+            ContentAddress::NixArchive(_) => ContentAddressMethod::NixArchive,
         }
     }
 
@@ -142,8 +142,8 @@ impl ContentAddress {
         match self {
             ContentAddress::Text(_) => ContentAddressMethodAlgorithm::Text,
             ContentAddress::Flat(hash) => ContentAddressMethodAlgorithm::Flat(hash.algorithm()),
-            ContentAddress::Recursive(hash) => {
-                ContentAddressMethodAlgorithm::Recursive(hash.algorithm())
+            ContentAddress::NixArchive(hash) => {
+                ContentAddressMethodAlgorithm::NixArchive(hash.algorithm())
             }
         }
     }
@@ -152,7 +152,7 @@ impl ContentAddress {
         match *self {
             ContentAddress::Text(sha256) => sha256.into(),
             ContentAddress::Flat(hash) => hash,
-            ContentAddress::Recursive(hash) => hash,
+            ContentAddress::NixArchive(hash) => hash,
         }
     }
 }
@@ -207,10 +207,10 @@ impl FromStr for ContentAddress {
             let hash = hash_s
                 .parse::<NonSRI<Hash>>()
                 .map_err(|err| {
-                    ParseContentAddressError::InvalidHash(ContentAddressMethod::Recursive, err)
+                    ParseContentAddressError::InvalidHash(ContentAddressMethod::NixArchive, err)
                 })?
                 .into_hash();
-            Ok(Self::Recursive(hash))
+            Ok(Self::NixArchive(hash))
         } else if let Some(hash_s) = s.strip_prefix("fixed:") {
             let hash = hash_s
                 .parse::<NonSRI<Hash>>()
@@ -259,7 +259,7 @@ mod unittests {
     )]
     #[case::recursive(
         "fixed:r:sha256:1b8m03r63zqhnjf7l5wnldhh7c134ap5vpj0850ymkq1iyzicy5s",
-        ContentAddressMethod::Recursive,
+        ContentAddressMethod::NixArchive,
         Algorithm::SHA256
     )]
     fn content_address_parse(
@@ -297,7 +297,7 @@ mod unittests {
     #[rstest]
     #[case(ContentAddressMethod::Text, "text:")]
     #[case(ContentAddressMethod::Flat, "")]
-    #[case(ContentAddressMethod::Recursive, "r:")]
+    #[case(ContentAddressMethod::NixArchive, "r:")]
     fn content_address_method_parse(#[case] method: ContentAddressMethod, #[case] value: &str) {
         assert_eq!(method.to_string(), value);
         let actual = value.parse::<ContentAddressMethod>().unwrap();
@@ -311,14 +311,14 @@ mod unittests {
     #[case(ContentAddressMethodAlgorithm::Flat(Algorithm::SHA1), "sha1")]
     #[case(ContentAddressMethodAlgorithm::Flat(Algorithm::SHA256), "sha256")]
     #[case(ContentAddressMethodAlgorithm::Flat(Algorithm::SHA512), "sha512")]
-    #[case(ContentAddressMethodAlgorithm::Recursive(Algorithm::MD5), "r:md5")]
-    #[case(ContentAddressMethodAlgorithm::Recursive(Algorithm::SHA1), "r:sha1")]
+    #[case(ContentAddressMethodAlgorithm::NixArchive(Algorithm::MD5), "r:md5")]
+    #[case(ContentAddressMethodAlgorithm::NixArchive(Algorithm::SHA1), "r:sha1")]
     #[case(
-        ContentAddressMethodAlgorithm::Recursive(Algorithm::SHA256),
+        ContentAddressMethodAlgorithm::NixArchive(Algorithm::SHA256),
         "r:sha256"
     )]
     #[case(
-        ContentAddressMethodAlgorithm::Recursive(Algorithm::SHA512),
+        ContentAddressMethodAlgorithm::NixArchive(Algorithm::SHA512),
         "r:sha512"
     )]
     fn content_address_method_algo_parse(

--- a/harmonia-store-core/src/store_path/create.rs
+++ b/harmonia-store-core/src/store_path/create.rs
@@ -71,7 +71,7 @@ impl From<ContentAddress> for PathType {
                 references: StorePathSet::new(),
                 digest,
             },
-            ContentAddress::Recursive(hash) if hash.algorithm() == Algorithm::SHA256 => {
+            ContentAddress::NixArchive(hash) if hash.algorithm() == Algorithm::SHA256 => {
                 let digest = hash.try_into().unwrap();
                 PathType::Source {
                     references: StorePathSet::new(),
@@ -79,7 +79,7 @@ impl From<ContentAddress> for PathType {
                     digest,
                 }
             }
-            ContentAddress::Recursive(hash) => PathType::Output { hash },
+            ContentAddress::NixArchive(hash) => PathType::Output { hash },
             ContentAddress::Flat(hash) => PathType::FlatOutput { hash },
         }
     }

--- a/harmonia-store-core/src/store_path/store_dir.rs
+++ b/harmonia-store-core/src/store_path/store_dir.rs
@@ -249,14 +249,14 @@ mod unittests {
         "aidi01pgcl6i79fkw737qzx06kjl930m-konsole-18.12.3"
     )]
     #[case::source(
-        ContentAddress::Recursive("sha256:248d6a61d20638b8e5c026930c3e6039a33ce45964ff2167f6ecedd419db06c1".parse::<Any<Hash>>().unwrap().into()),
+        ContentAddress::NixArchive("sha256:248d6a61d20638b8e5c026930c3e6039a33ce45964ff2167f6ecedd419db06c1".parse::<Any<Hash>>().unwrap().into()),
         "konsole-18.12.3",
         None,
         "source:sha256:248d6a61d20638b8e5c026930c3e6039a33ce45964ff2167f6ecedd419db06c1:/nix/store:konsole-18.12.3",
         "1w01xxn8f7s9s4n65ry6rwd7x9awf04s-konsole-18.12.3"
     )]
     #[case::output(
-        ContentAddress::Recursive("sha1:84983e441c3bd26ebaae4aa1f95129e5e54670f1".parse::<Any<Hash>>().unwrap().into()),
+        ContentAddress::NixArchive("sha1:84983e441c3bd26ebaae4aa1f95129e5e54670f1".parse::<Any<Hash>>().unwrap().into()),
         "konsole-18.12.3",
         Some("fixed:out:r:sha1:84983e441c3bd26ebaae4aa1f95129e5e54670f1:"),
         "output:out:sha256:5341f5afdd0fb724c8f7eae0e346de5bb151a00422d47ae683aed85cd78f7120:/nix/store:konsole-18.12.3",

--- a/harmonia-store-core/tests/json_upstream/content_address.rs
+++ b/harmonia-store-core/tests/json_upstream/content_address.rs
@@ -22,7 +22,7 @@ test_upstream_json!(
 test_upstream_json!(
     test_content_address_nar,
     libstore_test_data_path("content-address/nar.json"),
-    ContentAddress::Recursive(Hash::new(
+    ContentAddress::NixArchive(Hash::new(
         Algorithm::SHA256,
         &hex!("f6f2ea8f45d8a057c9566a33f99474da2e5c6a6604d736121650e2730c6fb0a3"),
     ))

--- a/harmonia-store-core/tests/json_upstream/derivation.rs
+++ b/harmonia-store-core/tests/json_upstream/derivation.rs
@@ -14,7 +14,7 @@ use harmonia_utils_hash::Algorithm;
 use std::collections::{BTreeMap, BTreeSet};
 
 fn ca_floating_output() -> DerivationOutput {
-    DerivationOutput::CAFloating(ContentAddressMethodAlgorithm::Recursive(Algorithm::SHA256))
+    DerivationOutput::CAFloating(ContentAddressMethodAlgorithm::NixArchive(Algorithm::SHA256))
 }
 
 test_upstream_json!(

--- a/harmonia-store-core/tests/json_upstream/derivation_output.rs
+++ b/harmonia-store-core/tests/json_upstream/derivation_output.rs
@@ -34,7 +34,7 @@ test_upstream_json!(
     test_derivation_output_ca_fixed_nar,
     libstore_test_data_path("derivation/output-caFixedNAR.json"),
     {
-        DerivationOutput::CAFixed(ContentAddress::Recursive(Hash::new(
+        DerivationOutput::CAFixed(ContentAddress::NixArchive(Hash::new(
             Algorithm::SHA256,
             &hex!("894517c9163c896ec31a2adbd33c0681fd5f45b2c0ef08a64c92a03fb97f390f"),
         )))
@@ -59,7 +59,7 @@ test_upstream_json!(
 test_upstream_json!(
     test_derivation_output_ca_floating,
     libstore_test_data_path("derivation/output-caFloating.json"),
-    { DerivationOutput::CAFloating(ContentAddressMethodAlgorithm::Recursive(Algorithm::SHA256)) }
+    { DerivationOutput::CAFloating(ContentAddressMethodAlgorithm::NixArchive(Algorithm::SHA256)) }
 );
 
 test_upstream_json!(
@@ -71,5 +71,5 @@ test_upstream_json!(
 test_upstream_json!(
     test_derivation_output_impure,
     libstore_test_data_path("derivation/output-impure.json"),
-    { DerivationOutput::Impure(ContentAddressMethodAlgorithm::Recursive(Algorithm::SHA256)) }
+    { DerivationOutput::Impure(ContentAddressMethodAlgorithm::NixArchive(Algorithm::SHA256)) }
 );

--- a/harmonia-store-path-info/tests/json_upstream/valid_path_info.rs
+++ b/harmonia-store-path-info/tests/json_upstream/valid_path_info.rs
@@ -50,7 +50,7 @@ fn pure_info() -> UnkeyedValidPathInfo {
         nar_size: 34878,
         ultimate: false,
         signatures: BTreeSet::new(),
-        ca: Some(ContentAddress::Recursive(TEST_CA_HASH.into())),
+        ca: Some(ContentAddress::NixArchive(TEST_CA_HASH.into())),
         store_dir: StoreDir::default(),
     }
 }
@@ -74,7 +74,7 @@ fn impure_info() -> UnkeyedValidPathInfo {
         ]
         .into_iter()
         .collect(),
-        ca: Some(ContentAddress::Recursive(TEST_CA_HASH.into())),
+        ca: Some(ContentAddress::NixArchive(TEST_CA_HASH.into())),
         store_dir: StoreDir::default(),
     }
 }


### PR DESCRIPTION
Aligns with upstream Nix's terminology change for
`ContentAddress`, `ContentAddressMethod`, and
`ContentAddressMethodAlgorithm`.