### PR TITLE
Add `UnkeyedValidPathInfo::into_pure()` and use it in tests

### DIFF
--- a/harmonia-store-nar-info/tests/json_upstream/mod.rs
+++ b/harmonia-store-nar-info/tests/json_upstream/mod.rs
@@ -7,7 +7,6 @@ use harmonia_store_path_info::{NarHash, Pure, UnkeyedValidPathInfo};
 use harmonia_utils_test::json_upstream::libstore_test_data_path;
 use harmonia_utils_test::test_upstream_json;
 use hex_literal::hex;
-use std::collections::BTreeSet;
 use std::num::NonZero;
 
 // The NAR hash used in upstream test data
@@ -23,22 +22,7 @@ const TEST_CA_HASH: harmonia_utils_hash::Sha256 = harmonia_utils_hash::Sha256::n
 ));
 
 fn pure_info() -> UnkeyedValidPathInfo {
-    UnkeyedValidPathInfo {
-        deriver: None,
-        nar_hash: TEST_NAR_HASH,
-        references: [
-            "g1w7hy3qg1w7hy3qg1w7hy3qg1w7hy3q-bar".parse().unwrap(),
-            "n5wkd9frr45pa74if5gpz9j7mifg27fh-foo".parse().unwrap(),
-        ]
-        .into_iter()
-        .collect(),
-        registration_time: None,
-        nar_size: 34878,
-        ultimate: false,
-        signatures: BTreeSet::new(),
-        ca: Some(ContentAddress::NixArchive(TEST_CA_HASH.into())),
-        store_dir: StoreDir::default(),
-    }
+    impure_info().info.into_pure()
 }
 
 fn impure_info() -> UnkeyedNarInfo {

--- a/harmonia-store-path-info/src/lib.rs
+++ b/harmonia-store-path-info/src/lib.rs
@@ -44,6 +44,17 @@ pub struct UnkeyedValidPathInfo {
     pub store_dir: StoreDir,
 }
 
+impl UnkeyedValidPathInfo {
+    /// Clear impure-only fields, keeping only the content-addressed metadata.
+    pub fn into_pure(mut self) -> Self {
+        self.deriver = None;
+        self.registration_time = None;
+        self.ultimate = false;
+        self.signatures = BTreeSet::new();
+        self
+    }
+}
+
 /// Pairs a `StorePath` key with some unkeyed payload.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 #[cfg_attr(any(test, feature = "test"), derive(Arbitrary))]

--- a/harmonia-store-path-info/tests/json_upstream/mod.rs
+++ b/harmonia-store-path-info/tests/json_upstream/mod.rs
@@ -37,22 +37,7 @@ fn empty_info() -> UnkeyedValidPathInfo {
 }
 
 fn pure_info() -> UnkeyedValidPathInfo {
-    UnkeyedValidPathInfo {
-        deriver: None,
-        nar_hash: TEST_NAR_HASH,
-        references: [
-            "g1w7hy3qg1w7hy3qg1w7hy3qg1w7hy3q-bar".parse().unwrap(),
-            "n5wkd9frr45pa74if5gpz9j7mifg27fh-foo".parse().unwrap(),
-        ]
-        .into_iter()
-        .collect(),
-        registration_time: None,
-        nar_size: 34878,
-        ultimate: false,
-        signatures: BTreeSet::new(),
-        ca: Some(ContentAddress::NixArchive(TEST_CA_HASH.into())),
-        store_dir: StoreDir::default(),
-    }
+    impure_info().into_pure()
 }
 
 fn impure_info() -> UnkeyedValidPathInfo {


### PR DESCRIPTION
Rather than duplicating the shared fields, compute the pure test value by clearing the impure-only fields from the impure test value via the new `into_pure()` method.