### PR TITLE
Always serialize `executable` field, matching latest Nix

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -18,11 +18,11 @@
     "nix": {
       "flake": false,
       "locked": {
-        "lastModified": 1778422772,
-        "narHash": "sha256-z0jqtz6N92vUnY11paSExIbjm0IrzetxAcTdiLEwlvo=",
+        "lastModified": 1778522440,
+        "narHash": "sha256-cdkL4bfi56zvylh3wmxDruQ2n4ZJidYAduvXep7KJDg=",
         "owner": "nixos",
         "repo": "nix",
-        "rev": "6d4308e4e32a6735fcc118d684c9a546de57c9a4",
+        "rev": "008fbd4f5d9c08962360b93b6dcf274028078f41",
         "type": "github"
       },
       "original": {

--- a/harmonia-cache/src/narlist.rs
+++ b/harmonia-cache/src/narlist.rs
@@ -212,23 +212,30 @@ mod test {
         let reference: serde_json::Value = serde_json::from_slice(&res2.stdout).unwrap();
         let ours: serde_json::Value = serde_json::to_value(&json.root).unwrap();
 
-        // nix's output may include narOffset; strip for comparison
-        fn strip_nar_offset(v: &mut serde_json::Value) {
+        // Strip fields that may differ between nix versions:
+        // - narOffset: present in NAR listings but not filesystem listings
+        // - executable: false may be absent in older nix (pre-NixOS/nix#15834)
+        fn normalize(v: &mut serde_json::Value) {
             if let Some(obj) = v.as_object_mut() {
                 obj.remove("narOffset");
+                if obj.get("executable") == Some(&serde_json::Value::Bool(false)) {
+                    obj.remove("executable");
+                }
                 if let Some(entries) = obj.get_mut("entries")
                     && let Some(map) = entries.as_object_mut()
                 {
                     for (_, child) in map.iter_mut() {
-                        strip_nar_offset(child);
+                        normalize(child);
                     }
                 }
             }
         }
-        let mut reference_stripped = reference;
-        strip_nar_offset(&mut reference_stripped);
+        let mut ours_normalized = ours;
+        normalize(&mut ours_normalized);
+        let mut reference_normalized = reference;
+        normalize(&mut reference_normalized);
 
-        assert_eq!(ours, reference_stripped);
+        assert_eq!(ours_normalized, reference_normalized);
 
         Ok(())
     }

--- a/harmonia-file-core/src/lib.rs
+++ b/harmonia-file-core/src/lib.rs
@@ -17,16 +17,10 @@ use std::collections::BTreeMap;
 // File-system object types
 // ---------------------------------------------------------------------------
 
-fn is_false(b: &bool) -> bool {
-    !b
-}
-
 /// A regular file.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Regular<C> {
-    // TODO: remove `skip_serializing_if` once NixOS/nix#15834 lands —
-    // then always serialize `executable` to match upstream.
-    #[serde(default, skip_serializing_if = "is_false")]
+    #[serde(default)]
     pub executable: bool,
     #[serde(flatten)]
     pub contents: C,

--- a/harmonia-file-core/tests/json_upstream/mod.rs
+++ b/harmonia-file-core/tests/json_upstream/mod.rs
@@ -140,29 +140,14 @@ fn complex_tree() -> FileTree<StringContents> {
     }))
 }
 
-// memory-source-accessor JSON includes `"executable": false` for
-// non-executable files. Our serde currently skips false values
-// (matching `nix nar ls` behavior pre-NixOS/nix#15834).
-// Once that PR lands, remove `skip_serializing_if` and use
-// `test_upstream_json!` for full round-trip here too.
-mod memory_source_accessor_simple {
-    use super::*;
-    #[test]
-    fn from_json() {
-        harmonia_utils_test::json_upstream::test_upstream_json_from_json(
-            &libutil_test_data_path("memory-source-accessor/simple.json"),
-            &simple_tree(),
-        );
-    }
-}
+test_upstream_json!(
+    memory_source_accessor_simple,
+    libutil_test_data_path("memory-source-accessor/simple.json"),
+    simple_tree()
+);
 
-mod memory_source_accessor_complex {
-    use super::*;
-    #[test]
-    fn from_json() {
-        harmonia_utils_test::json_upstream::test_upstream_json_from_json(
-            &libutil_test_data_path("memory-source-accessor/complex.json"),
-            &complex_tree(),
-        );
-    }
-}
+test_upstream_json!(
+    memory_source_accessor_complex,
+    libutil_test_data_path("memory-source-accessor/complex.json"),
+    complex_tree()
+);


### PR DESCRIPTION
Bump nix flake input to pick up the merged
https://github.com/NixOS/nix/pull/15834 which makes `executable` serialization consistent (always present, even when `false`).

- Remove `skip_serializing_if = "is_false"` from `Regular::executable`

- Upstream JSON tests now use full round-trip (`test_upstream_json!`) for all fixtures including `memory-source-accessor`