### PR TITLE
store-core: gate signature/derivation behind features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1171,7 +1171,6 @@ dependencies = [
  "subtle",
  "tempfile",
  "thiserror",
- "tracing",
  "zerocopy",
  "zeroize",
 ]

--- a/harmonia-store-core/Cargo.toml
+++ b/harmonia-store-core/Cargo.toml
@@ -17,20 +17,19 @@ readme               = "README.md"
 bytes                        = { workspace = true, features = [ "serde" ] }
 data-encoding                = { workspace = true }
 derive_more                  = { workspace = true }
-ed25519-dalek                = { workspace = true }
-getrandom                    = { workspace = true }
+ed25519-dalek                = { workspace = true, optional = true }
+getrandom                    = { workspace = true, optional = true }
 harmonia-utils-base-encoding = { workspace = true }
 harmonia-utils-hash          = { workspace = true }
 harmonia-utils-test          = { workspace = true, optional = true }
 proptest                     = { workspace = true, optional = true }
 proptest-derive              = { workspace = true, optional = true }
 serde                        = { workspace = true }
-serde_json                   = { workspace = true }
-subtle                       = { version = "2", default-features = false }
+serde_json                   = { workspace = true, optional = true }
+subtle                       = { version = "2", default-features = false, optional = true }
 thiserror                    = { workspace = true }
-tracing                      = { workspace = true }
 zerocopy                     = { version = "0.8", features = [ "derive" ] }
-zeroize                      = { version = "1" }
+zeroize                      = { version = "1", optional = true }
 
 [dev-dependencies]
 harmonia-store-core = { path = ".", features = [ "test" ] }
@@ -39,7 +38,12 @@ rstest              = { workspace = true }
 tempfile            = { workspace = true }
 
 [features]
-test = [ "proptest", "proptest-derive", "harmonia-utils-test", "harmonia-utils-hash/test" ]
+default = [ "signature", "derivation" ]
+# Cryptographic signing of store paths (NAR signatures).
+signature = [ "ed25519-dalek", "getrandom", "subtle", "zeroize" ]
+# Derivations, derived paths, placeholders, realisations.
+derivation = [ "serde_json", "signature" ]
+test       = [ "proptest", "proptest-derive", "harmonia-utils-test", "harmonia-utils-hash/test" ]
 
 [[test]]
 name = "json_upstream"

--- a/harmonia-store-core/src/lib.rs
+++ b/harmonia-store-core/src/lib.rs
@@ -53,10 +53,15 @@ macro_rules! impl_serde_via_string {
     };
 }
 
+#[cfg(feature = "derivation")]
 pub mod derivation;
+#[cfg(feature = "derivation")]
 pub mod derived_path;
+#[cfg(feature = "derivation")]
 pub mod placeholder;
+#[cfg(feature = "derivation")]
 pub mod realisation;
+#[cfg(feature = "signature")]
 pub mod signature;
 pub mod store_path;
 

--- a/harmonia-store-core/src/store_path/mod.rs
+++ b/harmonia-store-core/src/store_path/mod.rs
@@ -8,6 +8,7 @@ mod store_dir;
 pub use content_address::{
     ContentAddress, ContentAddressMethod, ContentAddressMethodAlgorithm, ParseContentAddressError,
 };
+#[cfg(feature = "derivation")]
 pub(crate) use path::into_name;
 pub use path::{
     ParseStorePathError, StorePath, StorePathError, StorePathHash, StorePathName,

--- a/harmonia-store-core/src/test/mod.rs
+++ b/harmonia-store-core/src/test/mod.rs
@@ -1,4 +1,5 @@
 pub use harmonia_utils_test as arbitrary;
+#[cfg(feature = "derivation")]
 pub mod derived_path;
 
 #[macro_export]


### PR DESCRIPTION
Consumers that only need StorePath/StoreDir parsing currently pull in ed25519-dalek, getrandom, subtle, zeroize and serde_json transitively. Split those behind `signature` and `derivation` features, both on by default. Also drop the unused tracing dependency.