### PR TITLE
Remove `public = true` from workspace dependency declarations

### DIFF
--- a/harmonia-store-aterm/Cargo.toml
+++ b/harmonia-store-aterm/Cargo.toml
@@ -14,10 +14,10 @@ readme               = "README.md"
 
 [dependencies]
 bytes                          = { workspace = true }
-harmonia-store-content-address = { workspace = true, public = true }
-harmonia-store-derivation      = { workspace = true, public = true }
-harmonia-store-path            = { workspace = true, public = true }
-harmonia-utils-hash            = { workspace = true, public = true }
+harmonia-store-content-address = { workspace = true }
+harmonia-store-derivation      = { workspace = true }
+harmonia-store-path            = { workspace = true }
+harmonia-utils-hash            = { workspace = true }
 memchr.workspace               = true
 proptest                       = { workspace = true, optional = true }
 serde_json.workspace           = true

--- a/harmonia-store-content-address/Cargo.toml
+++ b/harmonia-store-content-address/Cargo.toml
@@ -14,8 +14,8 @@ description          = "Content addressing for the Nix store"
 
 [dependencies]
 derive_more         = { workspace = true }
-harmonia-store-path = { workspace = true, public = true }
-harmonia-utils-hash = { workspace = true, public = true }
+harmonia-store-path = { workspace = true }
+harmonia-utils-hash = { workspace = true }
 proptest            = { workspace = true, optional = true }
 proptest-derive     = { workspace = true, optional = true }
 serde               = { workspace = true }

--- a/harmonia-store-derivation/Cargo.toml
+++ b/harmonia-store-derivation/Cargo.toml
@@ -14,19 +14,19 @@ description          = "Core Nix store semantics - pure types and validation log
 readme               = "README.md"
 
 [dependencies]
-bytes                          = { workspace = true, features = [ "serde" ], public = true }
+bytes                          = { workspace = true, features = [ "serde" ] }
 data-encoding                  = { workspace = true }
 derive_more                    = { workspace = true }
-harmonia-store-content-address = { workspace = true, public = true }
-harmonia-store-path            = { workspace = true, public = true }
+harmonia-store-content-address = { workspace = true }
+harmonia-store-path            = { workspace = true }
 harmonia-utils-base-encoding   = { workspace = true }
 harmonia-utils-hash            = { workspace = true }
-harmonia-utils-signature       = { workspace = true, public = true }
+harmonia-utils-signature       = { workspace = true }
 harmonia-utils-test            = { workspace = true, optional = true }
 proptest                       = { workspace = true, optional = true }
 proptest-derive                = { workspace = true, optional = true }
 serde                          = { workspace = true }
-serde_json                     = { workspace = true, public = true }
+serde_json                     = { workspace = true }
 thiserror                      = { workspace = true }
 zerocopy                       = { version = "0.8", features = [ "derive" ] }
 

--- a/harmonia-store-nar-info/Cargo.toml
+++ b/harmonia-store-nar-info/Cargo.toml
@@ -10,10 +10,10 @@ description          = "NarInfo formatting and construction for Nix binary cache
 
 [dependencies]
 harmonia-store-content-address = { workspace = true }
-harmonia-store-path            = { workspace = true, public = true }
-harmonia-store-path-info       = { workspace = true, public = true }
-harmonia-utils-hash            = { workspace = true, public = true }
-harmonia-utils-signature       = { workspace = true, public = true }
+harmonia-store-path            = { workspace = true }
+harmonia-store-path-info       = { workspace = true }
+harmonia-utils-hash            = { workspace = true }
+harmonia-utils-signature       = { workspace = true }
 serde                          = { workspace = true }
 
 [dev-dependencies]

--- a/harmonia-store-path-info/Cargo.toml
+++ b/harmonia-store-path-info/Cargo.toml
@@ -13,10 +13,10 @@ description          = "ValidPathInfo, NarHash, and JSON serialization for Nix s
 readme               = "README.md"
 
 [dependencies]
-harmonia-store-content-address = { workspace = true, public = true }
-harmonia-store-path            = { workspace = true, public = true }
-harmonia-utils-hash            = { workspace = true, public = true }
-harmonia-utils-signature       = { workspace = true, public = true }
+harmonia-store-content-address = { workspace = true }
+harmonia-store-path            = { workspace = true }
+harmonia-utils-hash            = { workspace = true }
+harmonia-utils-signature       = { workspace = true }
 proptest                       = { workspace = true, optional = true }
 proptest-derive                = { workspace = true, optional = true }
 serde                          = { workspace = true }

--- a/harmonia-store-path/Cargo.toml
+++ b/harmonia-store-path/Cargo.toml
@@ -15,7 +15,7 @@ description          = "Nix store path types, parsing, validation, and content a
 [dependencies]
 derive_more                  = { workspace = true }
 harmonia-utils-base-encoding = { workspace = true }
-harmonia-utils-hash          = { workspace = true, public = true }
+harmonia-utils-hash          = { workspace = true }
 harmonia-utils-test          = { workspace = true, optional = true }
 proptest                     = { workspace = true, optional = true }
 proptest-derive              = { workspace = true, optional = true }


### PR DESCRIPTION
Nixpkgs' `replace-workspace-values` script doesn't handle the `public` key yet, causing builds of downstream consumers (like Hydra) to fail. Remove it for now until nixpkgs gains support.