### PR TITLE
harmonia-utils-io: bind/connect AF_UNIX sockets past sun_path on Linux, FreeBSD, and macOS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1275,9 +1275,12 @@ dependencies = [
  "bytes",
  "futures-util",
  "hex-literal",
+ "libc",
+ "nix",
  "pin-project-lite",
  "proptest",
  "rstest",
+ "tempfile",
  "tokio",
  "tokio-test",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ futures-core = "0.3"
 futures-sink = "0.3"
 futures-util = { version = "0.3", features = [ "sink" ] }
 getrandom = "0.4"
+libc = "0.2"
 md5 = "0.8"
 memchr = "2"
 nix = { version = "0.31", features = [ "signal", "mman" ] }

--- a/harmonia-daemon/src/server/mod.rs
+++ b/harmonia-daemon/src/server/mod.rs
@@ -18,7 +18,6 @@ use std::pin::{Pin, pin};
 use futures_core::Stream;
 use futures_util::{FutureExt, StreamExt as _, TryFutureExt};
 use tokio::io::{AsyncBufRead, AsyncRead, AsyncWrite, AsyncWriteExt, copy_buf};
-use tokio::net::UnixListener;
 use tracing::{Instrument, debug, error, info, instrument, trace};
 
 use harmonia_protocol::ProtocolVersion;
@@ -1106,7 +1105,7 @@ where
             std::fs::create_dir_all(parent)?;
         }
 
-        let listener = UnixListener::bind(&self.socket_path)?;
+        let listener = harmonia_utils_io::unix_socket::bind_unix_long(&self.socket_path)?;
 
         // Make socket world-accessible so other users can connect
         #[cfg(unix)]

--- a/harmonia-protocol/Cargo.toml
+++ b/harmonia-protocol/Cargo.toml
@@ -20,7 +20,7 @@ bytes            = { workspace = true }
 derive_more      = { workspace = true }
 futures-core     = { workspace = true }
 futures-util     = { workspace = true }
-libc             = "0.2"
+libc             = { workspace = true }
 num_enum         = { workspace = true }
 pin-project-lite = { workspace = true }
 proptest         = { workspace = true, optional = true }

--- a/harmonia-store-remote/src/client.rs
+++ b/harmonia-store-remote/src/client.rs
@@ -17,7 +17,6 @@ use std::io::Cursor;
 use futures_core::Stream;
 use futures_util::future::Either;
 use tokio::io::{AsyncBufRead, AsyncRead, AsyncWrite, AsyncWriteExt as _, copy_buf};
-use tokio::net::UnixStream;
 use tokio::net::unix::{OwnedReadHalf, OwnedWriteHalf};
 use tokio::sync::oneshot;
 use tracing::{debug, info, trace};
@@ -154,7 +153,7 @@ impl DaemonClientBuilder {
     where
         P: AsRef<Path>,
     {
-        let stream = UnixStream::connect(path).await?;
+        let stream = harmonia_utils_io::unix_socket::connect_unix_long(path).await?;
         let (reader, writer) = stream.into_split();
         Ok(self.build(reader, writer))
     }

--- a/harmonia-utils-io/Cargo.toml
+++ b/harmonia-utils-io/Cargo.toml
@@ -17,12 +17,23 @@ readme               = "README.md"
 bytes            = { workspace = true }
 futures-util     = { workspace = true }
 pin-project-lite = { workspace = true }
-tokio            = { workspace = true, features = [ "io-util", "sync" ] }
+tokio            = { workspace = true, features = [ "io-util", "net", "sync" ] }
+
+# Linux opens the dir with O_PATH
+[target.'cfg(target_os = "linux")'.dependencies]
+nix = { workspace = true, features = [ "fs" ] }
+
+# FreeBSD uses bindat/connectat
+[target.'cfg(target_os = "freebsd")'.dependencies]
+libc = { workspace = true }
+nix  = { workspace = true, features = [ "fs", "socket" ] }
 
 [dev-dependencies]
 hex-literal = { workspace = true }
 proptest    = { workspace = true }
 rstest      = { workspace = true }
+tempfile    = { workspace = true }
+tokio       = { workspace = true, features = [ "macros", "rt-multi-thread" ] }
 tokio-test  = { workspace = true }
 
 [lints]

--- a/harmonia-utils-io/Cargo.toml
+++ b/harmonia-utils-io/Cargo.toml
@@ -28,6 +28,11 @@ nix = { workspace = true, features = [ "fs" ] }
 libc = { workspace = true }
 nix  = { workspace = true, features = [ "fs", "socket" ] }
 
+# macOS uses per-thread chdir (__pthread_fchdir)
+[target.'cfg(target_os = "macos")'.dependencies]
+libc = { workspace = true }
+nix  = { workspace = true, features = [ "fs" ] }
+
 [dev-dependencies]
 hex-literal = { workspace = true }
 proptest    = { workspace = true }

--- a/harmonia-utils-io/src/lib.rs
+++ b/harmonia-utils-io/src/lib.rs
@@ -14,6 +14,8 @@ mod lending;
 mod read_u64;
 mod tee;
 mod try_read_bytes_limited;
+#[cfg(unix)]
+pub mod unix_socket;
 
 pub use async_bytes_read::AsyncBytesRead;
 pub use bytes_reader::{BytesReader, DEFAULT_MAX_BUF_SIZE, DEFAULT_RESERVED_BUF_SIZE};

--- a/harmonia-utils-io/src/unix_socket.rs
+++ b/harmonia-utils-io/src/unix_socket.rs
@@ -3,7 +3,8 @@
 //! Bind and connect AF_UNIX sockets at paths longer than `sockaddr_un.sun_path`.
 //! FreeBSD reaches them through bindat and connectat. Linux routes plain bind
 //! and connect through `/proc/self/fd/<N>/<base>`, as it's just a  magic symlink
-//! the kernel resolves via an open dirfd.
+//! the kernel resolves via an open dirfd. macOS uses the per-thread cwd
+//! (`__pthread_fchdir`) plus a relative basename.
 
 use std::io;
 use std::path::Path;
@@ -34,6 +35,18 @@ pub async fn connect_unix_long(path: impl AsRef<Path>) -> io::Result<UnixStream>
         return UnixStream::connect(path).await;
     }
     long_path::connect(path).await
+}
+
+/// Split a socket path into its parent directory and basename.
+#[cfg(any(target_os = "freebsd", target_os = "macos"))]
+fn split_path(path: &Path) -> io::Result<(&Path, &std::ffi::OsStr)> {
+    let dir = path
+        .parent()
+        .ok_or_else(|| io::Error::other("socket path has no parent directory"))?;
+    let base = path
+        .file_name()
+        .ok_or_else(|| io::Error::other("socket path has no file name"))?;
+    Ok((dir, base))
 }
 
 #[cfg(target_os = "linux")]
@@ -94,9 +107,8 @@ mod long_path {
 #[cfg(target_os = "freebsd")]
 #[allow(unsafe_code)]
 mod long_path {
-    use super::{Path, UnixListener, UnixStream, io};
+    use super::{Path, UnixListener, UnixStream, io, split_path};
 
-    use std::ffi::OsStr;
     use std::os::fd::{AsRawFd, OwnedFd};
     use std::os::unix::net::{UnixListener as StdUnixListener, UnixStream as StdUnixStream};
 
@@ -128,16 +140,6 @@ mod long_path {
         // `O_SEARCH` matches chdir's search-bit semantics.
         let flags = OFlag::O_SEARCH | OFlag::O_DIRECTORY | OFlag::O_CLOEXEC;
         open(dir, flags, Mode::empty()).map_err(io::Error::from)
-    }
-
-    fn split_path(path: &Path) -> io::Result<(&Path, &OsStr)> {
-        let dir = path
-            .parent()
-            .ok_or_else(|| io::Error::other("socket path has no parent directory"))?;
-        let base = path
-            .file_name()
-            .ok_or_else(|| io::Error::other("socket path has no file name"))?;
-        Ok((dir, base))
     }
 
     pub fn bind(path: &Path) -> io::Result<UnixListener> {
@@ -212,7 +214,79 @@ mod long_path {
     }
 }
 
-#[cfg(not(any(target_os = "linux", target_os = "freebsd")))]
+#[cfg(target_os = "macos")]
+#[allow(unsafe_code)]
+mod long_path {
+    use super::{Path, UnixListener, UnixStream, io, split_path};
+
+    use std::os::fd::{AsRawFd, OwnedFd, RawFd};
+    use std::os::unix::net::UnixStream as StdUnixStream;
+
+    use nix::fcntl::{OFlag, open};
+    use nix::sys::stat::Mode;
+
+    /// Darwin's `__pthread_fchdir` syscall: per-thread cwd override. Private SPI,
+    /// but long-stable and relied on by Go's runtime for `*at()` emulation.
+    /// `fd == -1` clears the override and falls back to the process cwd.
+    const SYS___PTHREAD_FCHDIR: libc::c_int = 349;
+
+    fn pthread_fchdir(fd: RawFd) -> io::Result<()> {
+        // SAFETY: __pthread_fchdir takes a single int fd and returns 0/-1.
+        let rc = unsafe { libc::syscall(SYS___PTHREAD_FCHDIR, fd) };
+        if rc < 0 {
+            return Err(io::Error::last_os_error());
+        }
+        Ok(())
+    }
+
+    /// Pins the calling thread's cwd to a dirfd; clears it on drop so tokio's
+    /// reusable pool threads don't leak a stale override.
+    struct ThreadCwd;
+
+    impl ThreadCwd {
+        fn enter(dirfd: &OwnedFd) -> io::Result<Self> {
+            pthread_fchdir(dirfd.as_raw_fd())?;
+            Ok(Self)
+        }
+    }
+
+    impl Drop for ThreadCwd {
+        fn drop(&mut self) {
+            let _ = pthread_fchdir(-1);
+        }
+    }
+
+    fn open_dir(dir: &Path) -> io::Result<OwnedFd> {
+        let flags = OFlag::O_RDONLY | OFlag::O_DIRECTORY | OFlag::O_CLOEXEC;
+        open(dir, flags, Mode::empty()).map_err(io::Error::from)
+    }
+
+    pub fn bind(path: &Path) -> io::Result<UnixListener> {
+        let (dir, base) = split_path(path)?;
+        let dirfd = open_dir(dir)?;
+        let _cwd = ThreadCwd::enter(&dirfd)?;
+        UnixListener::bind(base)
+    }
+
+    pub async fn connect(path: &Path) -> io::Result<UnixStream> {
+        // The per-thread cwd must stay pinned to one OS thread and connect()
+        // can block, so do the whole thing on the blocking pool.
+        let path = path.to_owned();
+        let std_stream = tokio::task::spawn_blocking(move || -> io::Result<StdUnixStream> {
+            let (dir, base) = split_path(&path)?;
+            let dirfd = open_dir(dir)?;
+            let _cwd = ThreadCwd::enter(&dirfd)?;
+            let stream = StdUnixStream::connect(base)?;
+            stream.set_nonblocking(true)?;
+            Ok(stream)
+        })
+        .await
+        .map_err(|e| io::Error::other(format!("connect task panicked: {e}")))??;
+        UnixStream::from_std(std_stream)
+    }
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "freebsd", target_os = "macos")))]
 mod long_path {
     use super::{Path, UnixListener, UnixStream, io};
 
@@ -232,7 +306,10 @@ mod long_path {
     }
 }
 
-#[cfg(all(test, any(target_os = "linux", target_os = "freebsd")))]
+#[cfg(all(
+    test,
+    any(target_os = "linux", target_os = "freebsd", target_os = "macos")
+))]
 mod tests {
     use std::fs;
     use std::path::PathBuf;

--- a/harmonia-utils-io/src/unix_socket.rs
+++ b/harmonia-utils-io/src/unix_socket.rs
@@ -1,0 +1,298 @@
+// SPDX-License-Identifier: EUPL-1.2 OR MIT
+
+//! Bind and connect AF_UNIX sockets at paths longer than `sockaddr_un.sun_path`.
+//! FreeBSD reaches them through bindat and connectat. Linux routes plain bind
+//! and connect through `/proc/self/fd/<N>/<base>`, as it's just a  magic symlink
+//! the kernel resolves via an open dirfd.
+
+use std::io;
+use std::path::Path;
+use tokio::net::{UnixListener, UnixStream};
+
+/// The maximum length of `sockaddr_un.sun_path` on the current platform,
+/// NUL-inclusive. Paths at or above this length need the dirfd workaround.
+#[cfg(target_os = "linux")]
+const SUN_PATH_MAX: usize = 108;
+#[cfg(not(target_os = "linux"))]
+const SUN_PATH_MAX: usize = 104;
+
+/// This is similar to [`tokio::net::UnixListener::bind`], but works for paths
+/// whose length reaches or exceeds [`SUN_PATH_MAX`].
+pub fn bind_unix_long(path: impl AsRef<Path>) -> io::Result<UnixListener> {
+    let path = path.as_ref();
+    if path.as_os_str().as_encoded_bytes().len() < SUN_PATH_MAX {
+        return UnixListener::bind(path);
+    }
+    long_path::bind(path)
+}
+
+/// This is similar to [`tokio::net::UnixStream::connect`], but works for paths
+/// whose length reaches or exceeds [`SUN_PATH_MAX`].
+pub async fn connect_unix_long(path: impl AsRef<Path>) -> io::Result<UnixStream> {
+    let path = path.as_ref();
+    if path.as_os_str().as_encoded_bytes().len() < SUN_PATH_MAX {
+        return UnixStream::connect(path).await;
+    }
+    long_path::connect(path).await
+}
+
+#[cfg(target_os = "linux")]
+mod long_path {
+    use super::{Path, SUN_PATH_MAX, UnixListener, UnixStream, io};
+
+    use std::ffi::OsString;
+    use std::os::fd;
+    use std::os::fd::AsRawFd;
+    use std::os::unix::ffi::{OsStrExt, OsStringExt};
+    use std::path::PathBuf;
+
+    use nix::fcntl::{OFlag, open};
+    use nix::sys::stat::Mode;
+
+    /// Open the socket's parent directory via [`O_PATH`](`OFlag::O_PATH`) (which only
+    /// needs the search permission) and build a `/proc/self/fd/<N>/<basename>` path
+    /// the kernel resolves through the open dirfd.
+    fn proc_path(path: &Path) -> io::Result<(fd::OwnedFd, PathBuf)> {
+        let dir = path
+            .parent()
+            .ok_or_else(|| io::Error::other("socket path has no parent directory"))?;
+        let base = path
+            .file_name()
+            .ok_or_else(|| io::Error::other("socket path has no file name"))?;
+
+        let dirfd = open(
+            dir,
+            OFlag::O_PATH | OFlag::O_DIRECTORY | OFlag::O_CLOEXEC,
+            Mode::empty(),
+        )
+        .map_err(io::Error::from)?;
+
+        let mut bytes = format!("/proc/self/fd/{}/", dirfd.as_raw_fd()).into_bytes();
+        bytes.extend_from_slice(base.as_bytes());
+        if bytes.len() >= SUN_PATH_MAX {
+            return Err(io::Error::other(format!(
+                "synthesized /proc path is too long ({} bytes)",
+                bytes.len()
+            )));
+        }
+        Ok((dirfd, PathBuf::from(OsString::from_vec(bytes))))
+    }
+
+    pub fn bind(path: &Path) -> io::Result<UnixListener> {
+        // `_dirfd` keeps the directory open across the bind, since
+        // /proc/self/fd/<N> resolution needs fd N to still be alive.
+        let (_dirfd, proc) = proc_path(path)?;
+        UnixListener::bind(&proc)
+    }
+
+    pub async fn connect(path: &Path) -> io::Result<UnixStream> {
+        let (_dirfd, proc) = proc_path(path)?;
+        UnixStream::connect(&proc).await
+    }
+}
+
+#[cfg(target_os = "freebsd")]
+#[allow(unsafe_code)]
+mod long_path {
+    use super::{Path, UnixListener, UnixStream, io};
+
+    use std::ffi::OsStr;
+    use std::os::fd::{AsRawFd, OwnedFd};
+    use std::os::unix::net::{UnixListener as StdUnixListener, UnixStream as StdUnixStream};
+
+    use nix::fcntl::{OFlag, open};
+    use nix::sys::socket::{
+        AddressFamily, Backlog, SockFlag, SockType, SockaddrLike, UnixAddr, listen, socket,
+    };
+    use nix::sys::stat::Mode;
+
+    // libc exposes CAP_BINDAT and CAP_CONNECTAT constants for these syscalls
+    // but not the syscalls themselves, so declare them.
+    unsafe extern "C" {
+        fn bindat(
+            fd: libc::c_int,
+            s: libc::c_int,
+            name: *const libc::sockaddr,
+            namelen: libc::socklen_t,
+        ) -> libc::c_int;
+
+        fn connectat(
+            fd: libc::c_int,
+            s: libc::c_int,
+            name: *const libc::sockaddr,
+            namelen: libc::socklen_t,
+        ) -> libc::c_int;
+    }
+
+    fn open_dir(dir: &Path) -> io::Result<OwnedFd> {
+        // `O_SEARCH` matches chdir's search-bit semantics.
+        let flags = OFlag::O_SEARCH | OFlag::O_DIRECTORY | OFlag::O_CLOEXEC;
+        open(dir, flags, Mode::empty()).map_err(io::Error::from)
+    }
+
+    fn split_path(path: &Path) -> io::Result<(&Path, &OsStr)> {
+        let dir = path
+            .parent()
+            .ok_or_else(|| io::Error::other("socket path has no parent directory"))?;
+        let base = path
+            .file_name()
+            .ok_or_else(|| io::Error::other("socket path has no file name"))?;
+        Ok((dir, base))
+    }
+
+    pub fn bind(path: &Path) -> io::Result<UnixListener> {
+        let (dir, base) = split_path(path)?;
+        let dirfd = open_dir(dir)?;
+        let addr = UnixAddr::new(base).map_err(io::Error::from)?;
+
+        let sock = socket(
+            AddressFamily::Unix,
+            SockType::Stream,
+            SockFlag::SOCK_CLOEXEC | SockFlag::SOCK_NONBLOCK,
+            None,
+        )
+        .map_err(io::Error::from)?;
+
+        // SAFETY: bindat is bind(2) plus a leading dirfd. UnixAddr's as_ptr/len uphold them.
+        let rc = unsafe {
+            bindat(
+                dirfd.as_raw_fd(),
+                sock.as_raw_fd(),
+                SockaddrLike::as_ptr(&addr),
+                addr.len(),
+            )
+        };
+        if rc < 0 {
+            return Err(io::Error::last_os_error());
+        }
+
+        let backlog = Backlog::new(128).map_err(io::Error::from)?;
+        listen(&sock, backlog).map_err(io::Error::from)?;
+
+        UnixListener::from_std(StdUnixListener::from(sock))
+    }
+
+    pub async fn connect(path: &Path) -> io::Result<UnixStream> {
+        // connect blocks until the server accepts, meaning running it on the tokio
+        // runtime would stall other tasks. So, we push it to a blocking pool.
+        let path = path.to_owned();
+        let std_stream = tokio::task::spawn_blocking(move || -> io::Result<StdUnixStream> {
+            let (dir, base) = split_path(&path)?;
+            let dirfd = open_dir(dir)?;
+            let addr = UnixAddr::new(base).map_err(io::Error::from)?;
+
+            let sock = socket(
+                AddressFamily::Unix,
+                SockType::Stream,
+                SockFlag::SOCK_CLOEXEC,
+                None,
+            )
+            .map_err(io::Error::from)?;
+
+            // SAFETY: connectat is connect(2) plus a leading dirfd.
+            let rc = unsafe {
+                connectat(
+                    dirfd.as_raw_fd(),
+                    sock.as_raw_fd(),
+                    SockaddrLike::as_ptr(&addr),
+                    addr.len(),
+                )
+            };
+            if rc < 0 {
+                return Err(io::Error::last_os_error());
+            }
+
+            let stream = StdUnixStream::from(sock);
+            stream.set_nonblocking(true)?;
+            Ok(stream)
+        })
+        .await
+        .map_err(|e| io::Error::other(format!("connect task panicked: {e}")))??;
+        UnixStream::from_std(std_stream)
+    }
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "freebsd")))]
+mod long_path {
+    use super::{Path, UnixListener, UnixStream, io};
+
+    fn unsupported() -> io::Error {
+        io::Error::other(
+            "AF_UNIX socket path exceeds sun_path and this platform has no \
+             dirfd-anchored bind/connect fast path",
+        )
+    }
+
+    pub fn bind(_path: &Path) -> io::Result<UnixListener> {
+        Err(unsupported())
+    }
+
+    pub async fn connect(_path: &Path) -> io::Result<UnixStream> {
+        Err(unsupported())
+    }
+}
+
+#[cfg(all(test, any(target_os = "linux", target_os = "freebsd")))]
+mod tests {
+    use std::fs;
+    use std::path::PathBuf;
+
+    use super::*;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    /// Build a directory tree under `root` until its absolute path reaches
+    /// `target_len` bytes, returning the deepest directory.
+    fn build_deep_dir(root: &Path, target_len: usize) -> PathBuf {
+        let mut cur = root.to_path_buf();
+        while cur.as_os_str().len() < target_len {
+            cur.push("deeper-segment-padding");
+            fs::create_dir_all(&cur).unwrap();
+        }
+        cur
+    }
+
+    #[tokio::test]
+    async fn long_path_roundtrip() {
+        let tmp = tempfile::tempdir().unwrap();
+        let deep = build_deep_dir(tmp.path(), SUN_PATH_MAX + 50);
+        let sock = deep.join("s");
+        assert!(sock.as_os_str().len() >= SUN_PATH_MAX);
+
+        let listener = bind_unix_long(&sock).unwrap();
+
+        let server = tokio::spawn(async move {
+            let (mut s, _) = listener.accept().await.unwrap();
+            let mut buf = Vec::new();
+            s.read_to_end(&mut buf).await.unwrap();
+            buf
+        });
+
+        let mut client = connect_unix_long(&sock).await.unwrap();
+        client.write_all(b"hello").await.unwrap();
+        client.shutdown().await.unwrap();
+
+        assert_eq!(server.await.unwrap(), b"hello");
+    }
+
+    #[tokio::test]
+    async fn short_path_roundtrip() {
+        let tmp = tempfile::tempdir().unwrap();
+        let sock = tmp.path().join("s");
+        assert!(sock.as_os_str().len() < SUN_PATH_MAX);
+
+        let listener = bind_unix_long(&sock).unwrap();
+
+        let server = tokio::spawn(async move {
+            let (mut s, _) = listener.accept().await.unwrap();
+            let mut buf = Vec::new();
+            s.read_to_end(&mut buf).await.unwrap();
+            buf
+        });
+
+        let mut client = connect_unix_long(&sock).await.unwrap();
+        client.write_all(b"world").await.unwrap();
+        client.shutdown().await.unwrap();
+
+        assert_eq!(server.await.unwrap(), b"world");
+    }
+}


### PR DESCRIPTION
Supersedes #1040 (rebased copy + macOS support).

Tokio's `UnixListener::bind` and `UnixStream::connect` copy the path into a fixed-size `sockaddr_un`, so paths approaching `sun_path` fail with `ENAMETOOLONG`. Anchor a dirfd to the socket's parent directory and route the call through it:

- FreeBSD: `bindat` / `connectat`
- Linux: `/proc/self/fd/N/base` magic symlink
- macOS: `__pthread_fchdir` per-thread cwd + relative basename

Other unix targets return a clear error rather than a process-global chdir fallback, which is not safe inside a tokio runtime.

Original work in #1040 by @obsidiansystems; macOS module added on top.