### PR TITLE
utils: make `Hash` and `BorrowedHash` enums with per-algorithm variants

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1342,6 +1342,7 @@ dependencies = [
  "data-encoding",
  "derive_more",
  "harmonia-utils-base-encoding",
+ "harmonia-utils-hash",
  "hex-literal",
  "md5",
  "proptest",

--- a/harmonia-cache/src/nar.rs
+++ b/harmonia-cache/src/nar.rs
@@ -6,7 +6,7 @@ use actix_web::{HttpRequest, HttpResponse, http, web};
 use harmonia_file_nar::NarByteStream;
 use harmonia_store_path::StorePathHash;
 use harmonia_utils_hash::Hash;
-use harmonia_utils_hash::fmt::CommonHash;
+use harmonia_utils_hash::HashFormat as _;
 use serde::Deserialize;
 
 /// Represents the query string of a NAR URL.

--- a/harmonia-protocol/src/store_impls.rs
+++ b/harmonia-protocol/src/store_impls.rs
@@ -25,7 +25,7 @@ use harmonia_store_derivation::derivation::{BasicDerivation, DerivationOutput, S
 use harmonia_store_derivation::derived_path::{DerivedPath, LegacyDerivedPath, OutputName};
 use harmonia_store_derivation::realisation::{DrvOutput, Realisation, UnkeyedRealisation};
 use harmonia_store_path::{StorePath, StorePathName};
-use harmonia_utils_hash::fmt::CommonHash;
+use harmonia_utils_hash::HashFormat as _;
 
 // ========== BasicDerivation ==========
 

--- a/harmonia-store-aterm/src/raw_output.rs
+++ b/harmonia-store-aterm/src/raw_output.rs
@@ -3,7 +3,7 @@ use harmonia_store_derivation::derivation::DerivationOutput;
 use harmonia_store_derivation::derived_path::OutputName;
 use harmonia_store_path::{StoreDir, StorePath, StorePathName};
 use harmonia_utils_hash::Hash;
-use harmonia_utils_hash::fmt::CommonHash as _;
+use harmonia_utils_hash::HashFormat as _;
 use harmonia_utils_hash::fmt::NonSRI;
 
 use crate::error::ParseError;

--- a/harmonia-store-content-address/src/to_store_path.rs
+++ b/harmonia-store-content-address/src/to_store_path.rs
@@ -19,7 +19,7 @@
 //!
 
 use harmonia_store_path::{StoreDir, StoreDirDisplay, StorePathSet};
-use harmonia_utils_hash::{self, Algorithm};
+use harmonia_utils_hash::{self, Algorithm, HashView as _};
 
 use super::ContentAddress;
 

--- a/harmonia-store-content-address/src/types.rs
+++ b/harmonia-store-content-address/src/types.rs
@@ -7,8 +7,10 @@ use proptest_derive::Arbitrary;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use thiserror::Error;
 
-use harmonia_utils_hash::fmt::{CommonHash, NonSRI, ParseHashError, ParseHashErrorKind};
-use harmonia_utils_hash::{Algorithm, Hash, Sha256, UnknownAlgorithm};
+use harmonia_utils_hash::fmt::{NonSRI, ParseHashError, ParseHashErrorKind};
+use harmonia_utils_hash::{
+    Algorithm, BorrowedHash, Hash, HashFormat as _, HashView as _, Sha256, UnknownAlgorithm,
+};
 
 #[derive(
     Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Display, Serialize, Deserialize,
@@ -131,11 +133,7 @@ impl ContentAddress {
         self.method_algorithm().algorithm()
     }
     pub fn method(&self) -> ContentAddressMethod {
-        match self {
-            ContentAddress::Text(_) => ContentAddressMethod::Text,
-            ContentAddress::Flat(_) => ContentAddressMethod::Flat,
-            ContentAddress::NixArchive(_) => ContentAddressMethod::NixArchive,
-        }
+        self.method_algorithm().method()
     }
 
     pub fn method_algorithm(&self) -> ContentAddressMethodAlgorithm {
@@ -148,11 +146,11 @@ impl ContentAddress {
         }
     }
 
-    pub fn hash(&self) -> Hash {
-        match *self {
-            ContentAddress::Text(sha256) => sha256.into(),
-            ContentAddress::Flat(hash) => hash,
-            ContentAddress::NixArchive(hash) => hash,
+    pub fn hash(&self) -> BorrowedHash<'_> {
+        match self {
+            ContentAddress::Text(sha256) => BorrowedHash::SHA256(sha256),
+            ContentAddress::Flat(hash) => hash.borrow(),
+            ContentAddress::NixArchive(hash) => hash.borrow(),
         }
     }
 }
@@ -172,7 +170,7 @@ impl Serialize for ContentAddress {
     {
         let raw = RawContentAddress {
             method: self.method(),
-            hash: self.hash(),
+            hash: self.hash().to_owned(),
         };
         raw.serialize(serializer)
     }

--- a/harmonia-store-derivation/src/derivation/derivation_output.rs
+++ b/harmonia-store-derivation/src/derivation/derivation_output.rs
@@ -72,7 +72,7 @@ impl Serialize for DerivationOutput {
             },
             DerivationOutput::CAFixed(ca) => RawDerivationOutput {
                 path: None,
-                hash: Some(ca.hash()),
+                hash: Some(ca.hash().to_owned()),
                 method: Some(ca.method()),
                 hash_algo: None,
                 impure: false,

--- a/harmonia-store-nar-info/src/lib.rs
+++ b/harmonia-store-nar-info/src/lib.rs
@@ -41,7 +41,7 @@ pub fn build_narinfo(
     hash: &str,
     sign_keys: &[SecretKey],
 ) -> NarInfo {
-    use harmonia_utils_hash::fmt::CommonHash as _;
+    use harmonia_utils_hash::HashFormat as _;
 
     let nar_hash_obj: Hash = info.info.nar_hash.into();
     let nar_hash_bare = format!("{}", nar_hash_obj.as_base32().as_bare());
@@ -83,7 +83,7 @@ macro_rules! push_line {
 
 /// Format a `NarInfo` as the textual narinfo format used by the binary cache protocol.
 pub fn format_narinfo_txt(store_dir: &StoreDir, narinfo: &NarInfo) -> Vec<u8> {
-    use harmonia_utils_hash::fmt::CommonHash as _;
+    use harmonia_utils_hash::HashFormat as _;
 
     let path = &narinfo.path;
     let ni = &narinfo.info;

--- a/harmonia-store-path-info/src/lib.rs
+++ b/harmonia-store-path-info/src/lib.rs
@@ -21,7 +21,7 @@ pub use nar_hash::NarHash;
 
 use harmonia_store_content_address::ContentAddress;
 use harmonia_store_path::{StoreDir, StorePath};
-use harmonia_utils_hash::fmt::CommonHash as _;
+use harmonia_utils_hash::HashFormat as _;
 use harmonia_utils_signature::Signature;
 #[cfg(any(test, feature = "test"))]
 use harmonia_utils_signature::proptests::arb_signatures;

--- a/harmonia-store-path-info/src/nar_hash.rs
+++ b/harmonia-store-path-info/src/nar_hash.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use proptest_derive::Arbitrary;
 
 use harmonia_utils_hash::fmt::{self, CommonHash};
-use harmonia_utils_hash::{Algorithm, InvalidHashError, Sha256};
+use harmonia_utils_hash::{Algorithm, HashFormat as _, HashView, InvalidHashError, Sha256};
 
 /// A NAR hash - always SHA256.
 #[derive(Clone, Copy, Eq, Hash, PartialEq, PartialOrd, Ord)]
@@ -81,7 +81,9 @@ impl CommonHash for NarHash {
     fn implied_algorithm() -> Option<Algorithm> {
         Some(Algorithm::SHA256)
     }
+}
 
+impl HashView for NarHash {
     #[inline]
     fn algorithm(&self) -> Algorithm {
         Algorithm::SHA256

--- a/harmonia-utils-hash/Cargo.toml
+++ b/harmonia-utils-hash/Cargo.toml
@@ -28,11 +28,12 @@ thiserror                    = { workspace = true }
 tokio                        = { workspace = true, features = [ "io-util" ] }
 
 [dev-dependencies]
-hex-literal     = { workspace = true }
-proptest        = { workspace = true }
-proptest-derive = { workspace = true }
-rstest          = { workspace = true }
-serde_json      = { workspace = true }
+harmonia-utils-hash = { path = ".", features = [ "test" ] }
+hex-literal         = { workspace = true }
+proptest            = { workspace = true }
+proptest-derive     = { workspace = true }
+rstest              = { workspace = true }
+serde_json          = { workspace = true }
 
 [features]
 test = [ "proptest", "proptest-derive" ]

--- a/harmonia-utils-hash/src/algo.rs
+++ b/harmonia-utils-hash/src/algo.rs
@@ -47,8 +47,7 @@ impl Algorithm {
     /// Returns the digest of `data` using the given digest algorithm.
     ///
     /// ```
-    /// # use harmonia_utils_hash::Algorithm;
-    /// # use harmonia_utils_hash::fmt::CommonHash;
+    /// # use harmonia_utils_hash::{Algorithm, HashFormat as _};
     /// let hash = Algorithm::SHA256.digest("abc");
     ///
     /// assert_eq!("sha256:1b8m03r63zqhnjf7l5wnldhh7c134ap5vpj0850ymkq1iyzicy5s", hash.as_base32().to_string());
@@ -99,5 +98,151 @@ impl<'de> Deserialize<'de> for Algorithm {
     {
         let s = String::deserialize(deserializer)?;
         s.parse().map_err(serde::de::Error::custom)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use hex_literal::hex;
+    use rstest::rstest;
+
+    use super::*;
+    use crate::Hash;
+    use crate::view::HashView as _;
+    use harmonia_utils_base_encoding::Base;
+
+    /// value taken from: https://tools.ietf.org/html/rfc1321
+    const MD5_EMPTY: Hash = Hash::new(Algorithm::MD5, &hex!("d41d8cd98f00b204e9800998ecf8427e"));
+    /// value taken from: https://tools.ietf.org/html/rfc1321
+    const MD5_ABC: Hash = Hash::new(Algorithm::MD5, &hex!("900150983cd24fb0d6963f7d28e17f72"));
+
+    /// value taken from: https://tools.ietf.org/html/rfc3174
+    const SHA1_ABC: Hash = Hash::new(
+        Algorithm::SHA1,
+        &hex!("a9993e364706816aba3e25717850c26c9cd0d89d"),
+    );
+    /// value taken from: https://tools.ietf.org/html/rfc3174
+    const SHA1_LONG: Hash = Hash::new(
+        Algorithm::SHA1,
+        &hex!("84983e441c3bd26ebaae4aa1f95129e5e54670f1"),
+    );
+
+    /// value taken from: https://tools.ietf.org/html/rfc4634
+    const SHA256_ABC: Hash = Hash::new(
+        Algorithm::SHA256,
+        &hex!("ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"),
+    );
+    /// value taken from: https://tools.ietf.org/html/rfc4634
+    const SHA256_LONG: Hash = Hash::new(
+        Algorithm::SHA256,
+        &hex!("248d6a61d20638b8e5c026930c3e6039a33ce45964ff2167f6ecedd419db06c1"),
+    );
+
+    /// value taken from: https://tools.ietf.org/html/rfc4634
+    const SHA512_ABC: Hash = Hash::new(
+        Algorithm::SHA512,
+        &hex!(
+            "ddaf35a193617abacc417349ae20413112e6fa4e89a97ea20a9eeee64b55d39a2192992a274fc1a836ba3c23a3feebbd454d4423643ce80e2a9ac94fa54ca49f"
+        ),
+    );
+    /// value taken from: https://tools.ietf.org/html/rfc4634
+    const SHA512_LONG: Hash = Hash::new(
+        Algorithm::SHA512,
+        &hex!(
+            "8e959b75dae313da8cf4f72814fc143f8f7779c6eb9f7fa17299aeadb6889018501d289e4900f7e4331b99dec4b5433ac7d329eeb6dd26545e96e55b874be909"
+        ),
+    );
+
+    /// value cross-checked against NixOS/nix PR #12379 BLAKE3 test vectors
+    const BLAKE3_ABC: Hash = Hash::new(
+        Algorithm::BLAKE3,
+        &hex!("6437b3ac38465133ffb63b75273a8db548c558465d79db03fd359c6cd5bd9d85"),
+    );
+    /// value cross-checked against NixOS/nix PR #12379 BLAKE3 test vectors
+    const BLAKE3_LONG: Hash = Hash::new(
+        Algorithm::BLAKE3,
+        &hex!("c19012cc2aaf0dc3d8e5c45a1b79114d2df42abb2a410bf54be09e891af06ff8"),
+    );
+
+    #[rstest]
+    #[case::md5(Algorithm::MD5, 16, 32, 26, 24, 18)]
+    #[case::sha1(Algorithm::SHA1, 20, 40, 32, 28, 21)]
+    #[case::sha256(Algorithm::SHA256, 32, 64, 52, 44, 33)]
+    #[case::sha512(Algorithm::SHA512, 64, 128, 103, 88, 66)]
+    #[case::blake3(Algorithm::BLAKE3, 32, 64, 52, 44, 33)]
+    fn algorithm_size(
+        #[case] algorithm: Algorithm,
+        #[case] size: usize,
+        #[case] base16_len: usize,
+        #[case] base32_len: usize,
+        #[case] base64_len: usize,
+        #[case] base64_decoded: usize,
+    ) {
+        assert_eq!(algorithm.size(), size, "mismatched size");
+        assert_eq!(
+            Base::Hex.input_len(algorithm.size()),
+            base16_len,
+            "mismatched base16_len"
+        );
+        assert_eq!(
+            Base::NixBase32.input_len(algorithm.size()),
+            base32_len,
+            "mismatched base32_len"
+        );
+        assert_eq!(
+            Base::Base64.input_len(algorithm.size()),
+            base64_len,
+            "mismatched base64_len"
+        );
+        assert_eq!(
+            Base::Base64.scratch_len(algorithm.size()),
+            base64_decoded,
+            "mismatched base64_decoded"
+        );
+    }
+
+    #[rstest]
+    #[case::md5("md5", Algorithm::MD5)]
+    #[case::sha1("sha1", Algorithm::SHA1)]
+    #[case::sha256("sha256", Algorithm::SHA256)]
+    #[case::sha512("sha512", Algorithm::SHA512)]
+    #[case::blake3("blake3", Algorithm::BLAKE3)]
+    #[case::md5_upper("MD5", Algorithm::MD5)]
+    #[case::sha1_upper("SHA1", Algorithm::SHA1)]
+    #[case::sha256_upper("SHA256", Algorithm::SHA256)]
+    #[case::sha512_upper("SHA512", Algorithm::SHA512)]
+    #[case::blake3_upper("BLAKE3", Algorithm::BLAKE3)]
+    #[case::md5_mixed("mD5", Algorithm::MD5)]
+    #[case::sha1_mixed("ShA1", Algorithm::SHA1)]
+    #[case::sha256_mixed("ShA256", Algorithm::SHA256)]
+    #[case::sha512_mixed("ShA512", Algorithm::SHA512)]
+    #[case::blake3_mixed("BlAkE3", Algorithm::BLAKE3)]
+    fn algorithm_from_str(#[case] input: &str, #[case] expected: Algorithm) {
+        let actual = input.parse().unwrap();
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn unknown_algorithm() {
+        assert_eq!(
+            Err(UnknownAlgorithm("test".into())),
+            "test".parse::<Algorithm>()
+        );
+    }
+
+    #[rstest]
+    #[case::md5_empty(&MD5_EMPTY, "")]
+    #[case::md5_abc(&MD5_ABC, "abc")]
+    #[case::sha1_abc(&SHA1_ABC, "abc")]
+    #[case::sha1_long(&SHA1_LONG, "abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq")]
+    #[case::sha256_abc(&SHA256_ABC, "abc")]
+    #[case::sha256_long(&SHA256_LONG, "abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq")]
+    #[case::sha512_abc(&SHA512_ABC, "abc")]
+    #[case::sha512_long(&SHA512_LONG, "abcdefghbcdefghicdefghijdefghijkefghijklfghijklmghijklmnhijklmnoijklmnopjklmnopqklmnopqrlmnopqrsmnopqrstnopqrstu")]
+    #[case::blake3_abc(&BLAKE3_ABC, "abc")]
+    #[case::blake3_long(&BLAKE3_LONG, "abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq")]
+    fn test_digest(#[case] expected: &Hash, #[case] input: &str) {
+        let actual = expected.algorithm().digest(input);
+        assert_eq!(actual, *expected);
     }
 }

--- a/harmonia-utils-hash/src/borrowed.rs
+++ b/harmonia-utils-hash/src/borrowed.rs
@@ -1,0 +1,81 @@
+use crate::owned::Hash;
+use crate::view::HashView;
+use crate::{Algorithm, Sha256};
+
+/// A borrowed view of a hash digest.
+///
+/// Each variant borrows a fixed-size array, so the slice is
+/// statically guaranteed to be the right length for its algorithm.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BorrowedHash<'a> {
+    MD5(&'a [u8; Algorithm::MD5.size()]),
+    SHA1(&'a [u8; Algorithm::SHA1.size()]),
+    SHA256(&'a Sha256),
+    SHA512(&'a [u8; Algorithm::SHA512.size()]),
+    BLAKE3(&'a [u8; Algorithm::BLAKE3.size()]),
+}
+
+impl<'a> BorrowedHash<'a> {
+    /// Convert to an owned [`Hash`].
+    pub fn to_owned(self) -> Hash {
+        match self {
+            BorrowedHash::MD5(d) => Hash::MD5(*d),
+            BorrowedHash::SHA1(d) => Hash::SHA1(*d),
+            BorrowedHash::SHA256(d) => Hash::SHA256(*d),
+            BorrowedHash::SHA512(d) => Hash::SHA512(*d),
+            BorrowedHash::BLAKE3(d) => Hash::BLAKE3(*d),
+        }
+    }
+
+    #[inline]
+    fn algorithm(self) -> Algorithm {
+        match self {
+            BorrowedHash::MD5(_) => Algorithm::MD5,
+            BorrowedHash::SHA1(_) => Algorithm::SHA1,
+            BorrowedHash::SHA256(_) => Algorithm::SHA256,
+            BorrowedHash::SHA512(_) => Algorithm::SHA512,
+            BorrowedHash::BLAKE3(_) => Algorithm::BLAKE3,
+        }
+    }
+
+    /// Returns the raw digest bytes with the original data lifetime,
+    /// not tied to `&self`.
+    #[inline]
+    pub fn digest_bytes(self) -> &'a [u8] {
+        match self {
+            BorrowedHash::MD5(d) => d,
+            BorrowedHash::SHA1(d) => d,
+            BorrowedHash::SHA256(d) => d.digest_bytes(),
+            BorrowedHash::SHA512(d) => d,
+            BorrowedHash::BLAKE3(d) => d,
+        }
+    }
+}
+
+impl HashView for BorrowedHash<'_> {
+    #[inline]
+    fn algorithm(&self) -> Algorithm {
+        (*self).algorithm()
+    }
+
+    #[inline]
+    fn digest_bytes(&self) -> &[u8] {
+        (*self).digest_bytes()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use proptest::prelude::*;
+
+    proptest! {
+        #[test]
+        fn borrow_roundtrip(hash in any::<Hash>()) {
+            let borrowed = hash.borrow();
+            prop_assert_eq!(borrowed.algorithm(), hash.algorithm());
+            prop_assert_eq!(borrowed.digest_bytes(), hash.digest_bytes());
+            prop_assert_eq!(borrowed.to_owned(), hash);
+        }
+    }
+}

--- a/harmonia-utils-hash/src/fmt.rs
+++ b/harmonia-utils-hash/src/fmt.rs
@@ -9,7 +9,8 @@ use thiserror::Error;
 use harmonia_utils_base_encoding::base32;
 use harmonia_utils_base_encoding::{Base, decode_for_base};
 
-use crate as hash;
+use crate::Algorithm;
+use crate::HashView;
 use crate::InvalidHashError;
 use crate::UnknownAlgorithm;
 
@@ -30,25 +31,22 @@ pub enum Encoding {
 #[derive(derive_more::Display, Debug, PartialEq, Clone)]
 pub enum ParseHashErrorKind {
     #[display("has {_0}")]
-    Algorithm(hash::UnknownAlgorithm),
+    Algorithm(crate::UnknownAlgorithm),
     #[display("is not SRI")]
     NotSRI,
     #[display("should have type '{expected}' but got '{actual}'")]
     TypeMismatch {
-        expected: hash::Algorithm,
-        actual: hash::Algorithm,
+        expected: Algorithm,
+        actual: Algorithm,
     },
     #[display("does not include a type, nor is the type otherwise known from context")]
     MissingType,
     #[display("has {_1} when decoding as {_0}")]
     BadEncoding(Encoding, data_encoding::DecodeError),
     #[display("has wrong length for hash type '{_0}'")]
-    WrongHashLength(hash::Algorithm),
+    WrongHashLength(Algorithm),
     #[display("has wrong length {length} != {} for hash type '{algorithm}'", algorithm.size())]
-    WrongHashLength2 {
-        algorithm: hash::Algorithm,
-        length: usize,
-    },
+    WrongHashLength2 { algorithm: Algorithm, length: usize },
 }
 
 impl ParseHashErrorKind {
@@ -109,12 +107,7 @@ impl From<UnknownAlgorithm> for ParseHashErrorKind {
     }
 }
 
-pub trait CommonHash: Sized {
-    fn from_slice(algorithm: hash::Algorithm, hash: &[u8]) -> Result<Self, ParseHashErrorKind>;
-    fn implied_algorithm() -> Option<hash::Algorithm>;
-    fn algorithm(&self) -> hash::Algorithm;
-    fn digest_bytes(&self) -> &[u8];
-
+pub trait HashFormat: HashView + Sized {
     #[inline]
     fn as_base16(&self) -> &Base16<Self> {
         Base16::from_hash_ref(self)
@@ -156,54 +149,54 @@ pub trait CommonHash: Sized {
     }
 }
 
-impl CommonHash for hash::Hash {
+impl<H: HashView + Sized> HashFormat for H {}
+
+/// Extension of [`HashView`] for hash types that can be parsed from a
+/// byte slice. Not implemented by [`BorrowedHash`](crate::BorrowedHash)
+/// since it cannot own the data.
+pub trait CommonHash: HashFormat {
+    fn from_slice(algorithm: Algorithm, hash: &[u8]) -> Result<Self, ParseHashErrorKind>;
+    fn implied_algorithm() -> Option<Algorithm>;
+}
+
+impl CommonHash for crate::Hash {
     #[inline]
-    fn from_slice(algorithm: hash::Algorithm, hash: &[u8]) -> Result<Self, ParseHashErrorKind> {
-        Ok(hash::Hash::from_slice(algorithm, hash)?)
+    fn from_slice(algorithm: Algorithm, hash: &[u8]) -> Result<Self, ParseHashErrorKind> {
+        Ok(crate::Hash::from_slice(algorithm, hash)?)
     }
 
     #[inline]
-    fn implied_algorithm() -> Option<hash::Algorithm> {
+    fn implied_algorithm() -> Option<Algorithm> {
         None
-    }
-
-    #[inline]
-    fn algorithm(&self) -> hash::Algorithm {
-        self.algorithm
-    }
-
-    #[inline]
-    fn digest_bytes(&self) -> &[u8] {
-        self.as_ref()
     }
 }
 
 /*
-impl FromStr for hash::Hash {
-    type Err = hash::ParseHashError;
+impl FromStr for crate::Hash {
+    type Err = crate::ParseHashError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         s.parse::<Any<Self>>().map(From::from)
     }
 }
 
-impl sfmt::Display for hash::Hash {
+impl sfmt::Display for crate::Hash {
     fn fmt(&self, f: &mut sfmt::Formatter<'_>) -> sfmt::Result {
         self.as_base32().fmt(f)
     }
 }
 */
 
-impl sfmt::Debug for hash::Hash {
+impl sfmt::Debug for crate::Hash {
     fn fmt(&self, f: &mut sfmt::Formatter<'_>) -> sfmt::Result {
         f.debug_struct("Hash")
-            .field("algorithm", &self.algorithm)
+            .field("algorithm", &self.algorithm())
             .field("data", &format_args!("{}", self.as_base32()))
             .finish()
     }
 }
 
-impl sfmt::LowerHex for hash::Hash {
+impl sfmt::LowerHex for crate::Hash {
     fn fmt(&self, f: &mut sfmt::Formatter<'_>) -> sfmt::Result {
         if !f.alternate() {
             write!(f, "{}:", self.algorithm())?;
@@ -215,7 +208,7 @@ impl sfmt::LowerHex for hash::Hash {
     }
 }
 
-impl sfmt::UpperHex for hash::Hash {
+impl sfmt::UpperHex for crate::Hash {
     fn fmt(&self, f: &mut sfmt::Formatter<'_>) -> sfmt::Result {
         if !f.alternate() {
             write!(f, "{}:", self.algorithm())?;
@@ -227,51 +220,41 @@ impl sfmt::UpperHex for hash::Hash {
     }
 }
 
-impl CommonHash for hash::Sha256 {
+impl CommonHash for crate::Sha256 {
     #[inline]
-    fn from_slice(algorithm: hash::Algorithm, hash: &[u8]) -> Result<Self, ParseHashErrorKind> {
-        if algorithm != hash::Algorithm::SHA256 {
+    fn from_slice(algorithm: Algorithm, hash: &[u8]) -> Result<Self, ParseHashErrorKind> {
+        if algorithm != Algorithm::SHA256 {
             return Err(ParseHashErrorKind::TypeMismatch {
-                expected: hash::Algorithm::SHA256,
+                expected: Algorithm::SHA256,
                 actual: algorithm,
             });
         }
-        hash::Sha256::from_slice(hash).map_err(From::from)
+        crate::Sha256::from_slice(hash).map_err(From::from)
     }
 
     #[inline]
-    fn implied_algorithm() -> Option<hash::Algorithm> {
-        Some(hash::Algorithm::SHA256)
-    }
-
-    #[inline]
-    fn algorithm(&self) -> hash::Algorithm {
-        hash::Algorithm::SHA256
-    }
-
-    #[inline]
-    fn digest_bytes(&self) -> &[u8] {
-        self.as_ref()
+    fn implied_algorithm() -> Option<Algorithm> {
+        Some(Algorithm::SHA256)
     }
 }
 
 /*
-impl FromStr for hash::Sha256 {
-    type Err = hash::ParseHashError;
+impl FromStr for crate::Sha256 {
+    type Err = crate::ParseHashError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         s.parse::<Bare<NonSRI<Self>>>().map(From::from)
     }
 }
 
-impl sfmt::Display for hash::Sha256 {
+impl sfmt::Display for crate::Sha256 {
     fn fmt(&self, f: &mut sfmt::Formatter<'_>) -> sfmt::Result {
         self.as_base32().as_bare().fmt(f)
     }
 }
  */
 
-impl sfmt::Debug for hash::Sha256 {
+impl sfmt::Debug for crate::Sha256 {
     fn fmt(&self, f: &mut sfmt::Formatter<'_>) -> sfmt::Result {
         f.debug_tuple("Sha256")
             .field(&format_args!("{}", self.as_base32().as_bare()))
@@ -279,7 +262,7 @@ impl sfmt::Debug for hash::Sha256 {
     }
 }
 
-impl sfmt::LowerHex for hash::Sha256 {
+impl sfmt::LowerHex for crate::Sha256 {
     fn fmt(&self, f: &mut sfmt::Formatter<'_>) -> sfmt::Result {
         for val in self.digest_bytes() {
             write!(f, "{val:02x}")?;
@@ -288,7 +271,7 @@ impl sfmt::LowerHex for hash::Sha256 {
     }
 }
 
-impl sfmt::UpperHex for hash::Sha256 {
+impl sfmt::UpperHex for crate::Sha256 {
     fn fmt(&self, f: &mut sfmt::Formatter<'_>) -> sfmt::Result {
         for val in self.digest_bytes() {
             write!(f, "{val:02X}")?;
@@ -299,7 +282,7 @@ impl sfmt::UpperHex for hash::Sha256 {
 
 /// Helper function for parsing hash strings with a given base encoding
 pub(crate) fn parse_with_base<H, const SCRATCH_SIZE: usize>(
-    algorithm: hash::Algorithm,
+    algorithm: Algorithm,
     s: &str,
     base: Base,
 ) -> Result<H, ParseHashError>
@@ -342,7 +325,7 @@ where
 
 pub trait Format: private::Sealed {
     type Hash;
-    fn parse(algorithm: hash::Algorithm, s: &str) -> Result<Self::Hash, ParseHashError>;
+    fn parse(algorithm: Algorithm, s: &str) -> Result<Self::Hash, ParseHashError>;
     fn into_inner(self) -> Self::Hash;
     fn from_inner(inner: Self::Hash) -> Self;
 }
@@ -350,7 +333,7 @@ pub trait Format: private::Sealed {
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
 #[repr(transparent)]
 pub struct Base16<H>(H);
-impl<H: CommonHash + Sized> Base16<H> {
+impl<H: HashView + Sized> Base16<H> {
     pub const fn from_hash(hash: H) -> Self {
         Self(hash)
     }
@@ -369,16 +352,15 @@ impl<H: CommonHash + Sized> Base16<H> {
         &self.0
     }
 
-    /// Consumes the [`Base16`], returning the underlying [`Hash`](hash::Hash).
+    /// Consumes the [`Base16`], returning the underlying [`Hash`](crate::Hash).
     ///
     /// # Examples
     ///
     /// ```rust
-    /// use harmonia_utils_hash as hash;
-    /// use hash::fmt::CommonHash;
+    /// use harmonia_utils_hash::{Algorithm, HashFormat as _};
     ///
-    /// let hex = hash::Algorithm::SHA256.digest(b"Hello World!").base16();
-    /// assert_eq!(hex.into_hash(), hash::Algorithm::SHA256.digest(b"Hello World!"));
+    /// let hex = Algorithm::SHA256.digest(b"Hello World!").base16();
+    /// assert_eq!(hex.into_hash(), Algorithm::SHA256.digest(b"Hello World!"));
     /// ```
     #[inline]
     pub fn into_hash(self) -> H {
@@ -397,7 +379,7 @@ impl<H: CommonHash + Sized> Base16<H> {
     }
 }
 impl<H: CommonHash> Base16<H> {
-    pub fn parse(algorithm: hash::Algorithm, s: &str) -> Result<H, ParseHashError> {
+    pub fn parse(algorithm: Algorithm, s: &str) -> Result<H, ParseHashError> {
         <Self as Format>::parse(algorithm, s)
     }
 }
@@ -405,8 +387,8 @@ impl<H> private::Sealed for Base16<H> {}
 impl<H: CommonHash> Format for Base16<H> {
     type Hash = H;
 
-    fn parse(algorithm: hash::Algorithm, s: &str) -> Result<Self::Hash, ParseHashError> {
-        parse_with_base::<_, { Base::Hex.scratch_len(hash::LARGEST_ALGORITHM.size()) }>(
+    fn parse(algorithm: Algorithm, s: &str) -> Result<Self::Hash, ParseHashError> {
+        parse_with_base::<_, { Base::Hex.scratch_len(Algorithm::LARGEST.size()) }>(
             algorithm,
             s,
             Base::Hex,
@@ -422,7 +404,7 @@ impl<H: CommonHash> Format for Base16<H> {
     }
 }
 
-impl<H: CommonHash> sfmt::Display for Base16<H> {
+impl<H: HashView> sfmt::Display for Base16<H> {
     fn fmt(&self, f: &mut sfmt::Formatter<'_>) -> sfmt::Result {
         if !f.alternate() {
             write!(f, "{}:", self.0.algorithm())?;
@@ -443,7 +425,7 @@ impl<H: CommonHash> FromStr for Base16<H> {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         if let Some((prefix, rest)) = s.split_once(':') {
             let algorithm = prefix
-                .parse::<hash::Algorithm>()
+                .parse::<Algorithm>()
                 .map_err(|err| ParseHashError::new(s, err.into()))?;
             Self::parse(algorithm, rest).map(Self).map_err(|mut err| {
                 err.hash = s.into();
@@ -459,7 +441,7 @@ impl<H: CommonHash> FromStr for Base16<H> {
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
 #[repr(transparent)]
 pub struct Base32<H>(H);
-impl<H: CommonHash + Sized> Base32<H> {
+impl<H: HashView + Sized> Base32<H> {
     pub const fn from_hash(hash: H) -> Self {
         Self(hash)
     }
@@ -478,16 +460,15 @@ impl<H: CommonHash + Sized> Base32<H> {
         &self.0
     }
 
-    /// Consumes the [`Base32`], returning the underlying [`Hash`](hash::Hash).
+    /// Consumes the [`Base32`], returning the underlying [`Hash`](crate::Hash).
     ///
     /// # Examples
     ///
     /// ```rust
-    /// use harmonia_utils_hash as hash;
-    /// use hash::fmt::CommonHash;
+    /// use harmonia_utils_hash::{Algorithm, HashFormat as _};
     ///
-    /// let base32 = hash::Algorithm::SHA256.digest(b"Hello World!").base32();
-    /// assert_eq!(base32.into_hash(), hash::Algorithm::SHA256.digest(b"Hello World!"));
+    /// let base32 = Algorithm::SHA256.digest(b"Hello World!").base32();
+    /// assert_eq!(base32.into_hash(), Algorithm::SHA256.digest(b"Hello World!"));
     /// ```
     #[inline]
     pub fn into_hash(self) -> H {
@@ -506,7 +487,7 @@ impl<H: CommonHash + Sized> Base32<H> {
     }
 }
 impl<H: CommonHash> Base32<H> {
-    pub fn parse(algorithm: hash::Algorithm, s: &str) -> Result<H, ParseHashError> {
+    pub fn parse(algorithm: Algorithm, s: &str) -> Result<H, ParseHashError> {
         <Self as Format>::parse(algorithm, s)
     }
 }
@@ -514,8 +495,8 @@ impl<H> private::Sealed for Base32<H> {}
 impl<H: CommonHash> Format for Base32<H> {
     type Hash = H;
 
-    fn parse(algorithm: hash::Algorithm, s: &str) -> Result<Self::Hash, ParseHashError> {
-        parse_with_base::<_, { Base::NixBase32.scratch_len(hash::LARGEST_ALGORITHM.size()) }>(
+    fn parse(algorithm: Algorithm, s: &str) -> Result<Self::Hash, ParseHashError> {
+        parse_with_base::<_, { Base::NixBase32.scratch_len(Algorithm::LARGEST.size()) }>(
             algorithm,
             s,
             Base::NixBase32,
@@ -531,9 +512,9 @@ impl<H: CommonHash> Format for Base32<H> {
     }
 }
 
-impl<H: CommonHash> sfmt::Display for Base32<H> {
+impl<H: HashView> sfmt::Display for Base32<H> {
     fn fmt(&self, f: &mut sfmt::Formatter<'_>) -> sfmt::Result {
-        let mut buf = [0u8; Base::NixBase32.input_len(hash::LARGEST_ALGORITHM.size())];
+        let mut buf = [0u8; Base::NixBase32.input_len(Algorithm::LARGEST.size())];
         let output = &mut buf[..Base::NixBase32.input_len(self.0.algorithm().size())];
         base32::encode_mut(self.0.digest_bytes(), output);
 
@@ -556,7 +537,7 @@ impl<H: CommonHash> FromStr for Base32<H> {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         if let Some((prefix, rest)) = s.split_once(':') {
             let algorithm = prefix
-                .parse::<hash::Algorithm>()
+                .parse::<Algorithm>()
                 .map_err(|err| ParseHashError::new(s, err.into()))?;
             Self::parse(algorithm, rest).map(Self).map_err(|mut err| {
                 err.hash = s.into();
@@ -572,7 +553,7 @@ impl<H: CommonHash> FromStr for Base32<H> {
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
 #[repr(transparent)]
 pub struct Base64<H>(H);
-impl<H: CommonHash> Base64<H> {
+impl<H: HashView> Base64<H> {
     pub const fn from_hash(hash: H) -> Self {
         Self(hash)
     }
@@ -591,16 +572,15 @@ impl<H: CommonHash> Base64<H> {
         &self.0
     }
 
-    /// Consumes the [`Base64`], returning the underlying [`Hash`](hash::Hash).
+    /// Consumes the [`Base64`], returning the underlying [`Hash`](crate::Hash).
     ///
     /// # Examples
     ///
     /// ```rust
-    /// use harmonia_utils_hash as hash;
-    /// use hash::fmt::CommonHash;
+    /// use harmonia_utils_hash::{Algorithm, HashFormat as _};
     ///
-    /// let base64 = hash::Algorithm::SHA256.digest(b"Hello World!").base64();
-    /// assert_eq!(base64.into_hash(), hash::Algorithm::SHA256.digest(b"Hello World!"));
+    /// let base64 = Algorithm::SHA256.digest(b"Hello World!").base64();
+    /// assert_eq!(base64.into_hash(), Algorithm::SHA256.digest(b"Hello World!"));
     /// ```
     pub fn into_hash(self) -> H {
         self.0
@@ -618,16 +598,16 @@ impl<H: CommonHash> Base64<H> {
     }
 }
 impl<H: CommonHash> Base64<H> {
-    pub fn parse(algorithm: hash::Algorithm, s: &str) -> Result<H, ParseHashError> {
+    pub fn parse(algorithm: Algorithm, s: &str) -> Result<H, ParseHashError> {
         <Self as Format>::parse(algorithm, s)
     }
 }
-impl<H: CommonHash> private::Sealed for Base64<H> {}
+impl<H: HashView> private::Sealed for Base64<H> {}
 impl<H: CommonHash> Format for Base64<H> {
     type Hash = H;
 
-    fn parse(algorithm: hash::Algorithm, s: &str) -> Result<Self::Hash, ParseHashError> {
-        parse_with_base::<_, { Base::Base64.scratch_len(hash::LARGEST_ALGORITHM.size()) }>(
+    fn parse(algorithm: Algorithm, s: &str) -> Result<Self::Hash, ParseHashError> {
+        parse_with_base::<_, { Base::Base64.scratch_len(Algorithm::LARGEST.size()) }>(
             algorithm,
             s,
             Base::Base64,
@@ -643,9 +623,9 @@ impl<H: CommonHash> Format for Base64<H> {
     }
 }
 
-impl<H: CommonHash> sfmt::Display for Base64<H> {
+impl<H: HashView> sfmt::Display for Base64<H> {
     fn fmt(&self, f: &mut sfmt::Formatter<'_>) -> sfmt::Result {
-        let mut buf = [0u8; Base::Base64.input_len(hash::LARGEST_ALGORITHM.size())];
+        let mut buf = [0u8; Base::Base64.input_len(Algorithm::LARGEST.size())];
         let output = &mut buf[..Base::Base64.input_len(self.0.algorithm().size())];
         BASE64.encode_mut(self.0.digest_bytes(), output);
 
@@ -669,7 +649,7 @@ impl<H: CommonHash> FromStr for Base64<H> {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         if let Some((prefix, rest)) = s.split_once(':') {
             let algorithm = prefix
-                .parse::<hash::Algorithm>()
+                .parse::<Algorithm>()
                 .map_err(|err| ParseHashError::new(s, err.into()))?;
             Self::parse(algorithm, rest).map(Self).map_err(|mut err| {
                 err.hash = s.into();
@@ -704,7 +684,7 @@ impl<H> Any<H> {
     }
 }
 impl<H: CommonHash> Any<H> {
-    pub fn parse(algorithm: hash::Algorithm, s: &str) -> Result<H, ParseHashError> {
+    pub fn parse(algorithm: Algorithm, s: &str) -> Result<H, ParseHashError> {
         <Self as Format>::parse(algorithm, s)
     }
 }
@@ -712,7 +692,7 @@ impl<H> private::Sealed for Any<H> {}
 impl<H: CommonHash> Format for Any<H> {
     type Hash = H;
 
-    fn parse(algorithm: hash::Algorithm, s: &str) -> Result<Self::Hash, ParseHashError> {
+    fn parse(algorithm: Algorithm, s: &str) -> Result<Self::Hash, ParseHashError> {
         if s.len() == Base::Hex.input_len(algorithm.size()) {
             Ok(Base16::parse(algorithm, s)?)
         } else if s.len() == Base::NixBase32.input_len(algorithm.size()) {
@@ -742,7 +722,7 @@ impl<H: CommonHash> FromStr for Any<H> {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         if let Some((prefix, rest)) = s.split_once(':') {
             let algorithm = prefix
-                .parse::<hash::Algorithm>()
+                .parse::<Algorithm>()
                 .map_err(|err| ParseHashError::new(s, err.into()))?;
             let hash = Self::parse(algorithm, rest).map_err(|mut err| {
                 err.hash = s.into();
@@ -752,7 +732,7 @@ impl<H: CommonHash> FromStr for Any<H> {
             Ok(Self(hash))
         } else if let Some((prefix, rest)) = s.split_once('-') {
             let algorithm = prefix
-                .parse::<hash::Algorithm>()
+                .parse::<Algorithm>()
                 .map_err(|err| ParseHashError::new(s, err.into()))?;
             if rest.len() == Base::Base64.input_len(algorithm.size()) {
                 let hash = Base64::parse(algorithm, rest).map_err(|mut err| {
@@ -782,7 +762,7 @@ impl<H: CommonHash> FromStr for Any<H> {
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 #[repr(transparent)]
 pub struct SRI<H>(H);
-impl<H: CommonHash + Sized> SRI<H> {
+impl<H: HashView + Sized> SRI<H> {
     pub const fn from_hash(hash: H) -> Self {
         Self(hash)
     }
@@ -801,23 +781,22 @@ impl<H: CommonHash + Sized> SRI<H> {
         &self.0
     }
 
-    /// Consumes the [`SRI`], returning the underlying [`Hash`](hash::Hash).
+    /// Consumes the [`SRI`], returning the underlying [`Hash`](crate::Hash).
     ///
     /// # Examples
     ///
     /// ```rust
-    /// use harmonia_utils_hash as hash;
-    /// use hash::fmt::CommonHash;
+    /// use harmonia_utils_hash::{Algorithm, HashFormat as _};
     ///
-    /// let sri = hash::Algorithm::SHA256.digest(b"Hello World!").sri();
-    /// assert_eq!(sri.into_hash(), hash::Algorithm::SHA256.digest(b"Hello World!"));
+    /// let sri = Algorithm::SHA256.digest(b"Hello World!").sri();
+    /// assert_eq!(sri.into_hash(), Algorithm::SHA256.digest(b"Hello World!"));
     /// ```
     pub fn into_hash(self) -> H {
         self.0
     }
 }
 
-impl<H: CommonHash> sfmt::Display for SRI<H> {
+impl<H: HashView> sfmt::Display for SRI<H> {
     fn fmt(&self, f: &mut sfmt::Formatter<'_>) -> sfmt::Result {
         write!(f, "{}-{}", self.0.algorithm(), self.0.as_base64().as_bare())
     }
@@ -832,7 +811,7 @@ impl<H: CommonHash> FromStr for SRI<H> {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         if let Some((prefix, rest)) = s.split_once('-') {
             let algorithm = prefix
-                .parse::<hash::Algorithm>()
+                .parse::<Algorithm>()
                 .map_err(|err| ParseHashError::new(s, err.into()))?;
             Base64::parse(algorithm, rest).map(Self).map_err(|mut err| {
                 err.hash = s.into();
@@ -846,7 +825,7 @@ impl<H: CommonHash> FromStr for SRI<H> {
     }
 }
 
-impl<H: CommonHash> serde::Serialize for SRI<H> {
+impl<H: HashView> serde::Serialize for SRI<H> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
@@ -882,7 +861,7 @@ impl<H> NonSRI<H> {
     }
 }
 impl<H: CommonHash> NonSRI<H> {
-    pub fn parse(algorithm: hash::Algorithm, s: &str) -> Result<H, ParseHashError> {
+    pub fn parse(algorithm: Algorithm, s: &str) -> Result<H, ParseHashError> {
         <Self as Format>::parse(algorithm, s)
     }
 }
@@ -890,7 +869,7 @@ impl<H> private::Sealed for NonSRI<H> {}
 impl<H: CommonHash> Format for NonSRI<H> {
     type Hash = H;
 
-    fn parse(algorithm: hash::Algorithm, s: &str) -> Result<Self::Hash, ParseHashError> {
+    fn parse(algorithm: Algorithm, s: &str) -> Result<Self::Hash, ParseHashError> {
         if s.len() == Base::Hex.input_len(algorithm.size()) {
             Ok(Base16::parse(algorithm, s)?)
         } else if s.len() == Base::NixBase32.input_len(algorithm.size()) {
@@ -920,7 +899,7 @@ impl<H: CommonHash> FromStr for NonSRI<H> {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         if let Some((prefix, rest)) = s.split_once(':') {
             let algorithm = prefix
-                .parse::<hash::Algorithm>()
+                .parse::<Algorithm>()
                 .map_err(|err| ParseHashError::new(s, err.into()))?;
             let hash = Self::parse(algorithm, rest).map_err(|mut err| {
                 err.hash = s.into();
@@ -1068,18 +1047,18 @@ macro_rules! impl_hash_format_from {
     };
 }
 
-impl_hash_format_from!(SRI<hash::Hash>);
-impl_hash_format_from!(SRI<hash::Sha256>);
-impl_hash_format_from!(Base64<hash::Hash>);
-impl_hash_format_from!(Base64<hash::Sha256>);
-impl_hash_format_from!(Base32<hash::Hash>);
-impl_hash_format_from!(Base32<hash::Sha256>);
-impl_hash_format_from!(Base16<hash::Hash>);
-impl_hash_format_from!(Base16<hash::Sha256>);
-impl_hash_format_from!(Any<hash::Hash>);
-impl_hash_format_from!(Any<hash::Sha256>);
-impl_hash_format_from!(NonSRI<hash::Hash>);
-impl_hash_format_from!(NonSRI<hash::Sha256>);
+impl_hash_format_from!(SRI<crate::Hash>);
+impl_hash_format_from!(SRI<crate::Sha256>);
+impl_hash_format_from!(Base64<crate::Hash>);
+impl_hash_format_from!(Base64<crate::Sha256>);
+impl_hash_format_from!(Base32<crate::Hash>);
+impl_hash_format_from!(Base32<crate::Sha256>);
+impl_hash_format_from!(Base16<crate::Hash>);
+impl_hash_format_from!(Base16<crate::Sha256>);
+impl_hash_format_from!(Any<crate::Hash>);
+impl_hash_format_from!(Any<crate::Sha256>);
+impl_hash_format_from!(NonSRI<crate::Hash>);
+impl_hash_format_from!(NonSRI<crate::Sha256>);
 
 #[cfg(test)]
 mod unittests {
@@ -1475,25 +1454,25 @@ mod unittests {
 
         for_all_hashes!(hash_from_str_base16, |hash| {
             let s = hash.prefix_base16();
-            let actual = s.parse::<Any<hash::Hash>>().unwrap().into_hash();
+            let actual = s.parse::<Any<crate::Hash>>().unwrap().into_hash();
             assert_eq!(hash.hash, actual);
         });
 
         for_all_hashes!(hash_from_str_base32, |hash| {
             let s = hash.prefix_base32();
-            let actual = s.parse::<Any<hash::Hash>>().unwrap().into_hash();
+            let actual = s.parse::<Any<crate::Hash>>().unwrap().into_hash();
             assert_eq!(hash.hash, actual);
         });
 
         for_all_hashes!(hash_from_str_base64, |hash| {
             let s = hash.prefix_base64();
-            let actual = s.parse::<Any<hash::Hash>>().unwrap().into_hash();
+            let actual = s.parse::<Any<crate::Hash>>().unwrap().into_hash();
             assert_eq!(hash.hash, actual);
         });
 
         for_all_hashes!(hash_from_str_sri, |hash| {
             let s = hash.sri();
-            let actual = s.parse::<Any<hash::Hash>>().unwrap().into_hash();
+            let actual = s.parse::<Any<crate::Hash>>().unwrap().into_hash();
             assert_eq!(hash.hash, actual);
         });
 
@@ -1525,19 +1504,19 @@ mod unittests {
 
         for_all_hashes!(hash_from_str_base16, |hash| {
             let s = hash.prefix_base16();
-            let actual = s.parse::<NonSRI<hash::Hash>>().unwrap().into_hash();
+            let actual = s.parse::<NonSRI<crate::Hash>>().unwrap().into_hash();
             assert_eq!(hash.hash, actual);
         });
 
         for_all_hashes!(hash_from_str_base32, |hash| {
             let s = hash.prefix_base32();
-            let actual = s.parse::<NonSRI<hash::Hash>>().unwrap().into_hash();
+            let actual = s.parse::<NonSRI<crate::Hash>>().unwrap().into_hash();
             assert_eq!(hash.hash, actual);
         });
 
         for_all_hashes!(hash_from_str_base64, |hash| {
             let s = hash.prefix_base64();
-            let actual = s.parse::<NonSRI<hash::Hash>>().unwrap().into_hash();
+            let actual = s.parse::<NonSRI<crate::Hash>>().unwrap().into_hash();
             assert_eq!(hash.hash, actual);
         });
 

--- a/harmonia-utils-hash/src/lib.rs
+++ b/harmonia-utils-hash/src/lib.rs
@@ -1,327 +1,32 @@
-use std::fmt as sfmt;
-
-#[cfg(any(test, feature = "test"))]
-use proptest_derive::Arbitrary;
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
-use sha1::Digest;
 use thiserror::Error;
 
 mod algo;
+mod borrowed;
 pub mod fmt;
-
-use fmt::CommonHash;
+mod owned;
+mod sha256;
+mod sink;
+mod view;
 
 pub use algo::{Algorithm, UnknownAlgorithm};
-
-const LARGEST_ALGORITHM: Algorithm = Algorithm::LARGEST;
+pub use borrowed::BorrowedHash;
+pub use fmt::HashFormat;
+pub use owned::Hash;
+pub use sha256::Sha256;
+pub use sink::{Context, HashSink};
+pub use view::HashView;
 
 #[derive(Error, Debug, PartialEq, Eq, Clone, Copy)]
 #[error("hash has wrong length {length} != {} for hash type '{algorithm}'", algorithm.size())]
 pub struct InvalidHashError {
-    algorithm: Algorithm,
-    length: usize,
+    pub(crate) algorithm: Algorithm,
+    pub(crate) length: usize,
 }
 
-#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Hash)]
-pub struct Hash {
-    algorithm: Algorithm,
-    data: [u8; LARGEST_ALGORITHM.size()],
-}
-
-impl Hash {
-    pub const fn new(algorithm: Algorithm, hash: &[u8]) -> Hash {
-        let mut data = [0u8; LARGEST_ALGORITHM.size()];
-        let (hash_data, _postfix) = data.split_at_mut(algorithm.size());
-        hash_data.copy_from_slice(hash);
-        Hash { algorithm, data }
-    }
-
-    pub fn from_slice(algorithm: Algorithm, hash: &[u8]) -> Result<Hash, InvalidHashError> {
-        if hash.len() != algorithm.size() {
-            return Err(InvalidHashError {
-                algorithm,
-                length: hash.len(),
-            });
-        }
-        Ok(Hash::new(algorithm, hash))
-    }
-
-    #[inline]
-    pub fn algorithm(&self) -> Algorithm {
-        self.algorithm
-    }
-
-    #[inline]
-    pub fn digest_bytes(&self) -> &[u8] {
-        &self.data[0..(self.algorithm.size())]
-    }
-}
-
-impl std::ops::Deref for Hash {
-    type Target = [u8];
-    fn deref(&self) -> &[u8] {
-        self.digest_bytes()
-    }
-}
-
-impl AsRef<[u8]> for Hash {
-    fn as_ref(&self) -> &[u8] {
-        self.digest_bytes()
-    }
-}
-
-impl Serialize for Hash {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        // Serialize as SRI string: "sha256-base64hash="
-        serializer.serialize_str(&self.as_sri().to_string())
-    }
-}
-
-impl<'de> Deserialize<'de> for Hash {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        use serde::de;
-
-        let s = String::deserialize(deserializer)?;
-        // Try SRI format first, then fall back to Any format for flexibility
-        s.parse::<fmt::SRI<Hash>>()
-            .map(|sri| sri.into_hash())
-            .or_else(|_| s.parse::<fmt::Any<Hash>>().map(|any| any.into_hash()))
-            .map_err(de::Error::custom)
-    }
-}
-
-#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Hash)]
-#[cfg_attr(any(test, feature = "test"), derive(Arbitrary))]
-pub struct Sha256([u8; Algorithm::SHA256.size()]);
-impl Sha256 {
-    pub const fn new(digest: &[u8]) -> Self {
-        let mut data = [0u8; Algorithm::SHA256.size()];
-        data.copy_from_slice(digest);
-        Self(data)
-    }
-
-    pub const fn from_slice(digest: &[u8]) -> Result<Self, InvalidHashError> {
-        if digest.len() != Algorithm::SHA256.size() {
-            return Err(InvalidHashError {
-                algorithm: Algorithm::SHA256,
-                length: digest.len(),
-            });
-        }
-        Ok(Self::new(digest))
-    }
-
-    /// Returns the digest of `data` using the sha256
-    ///
-    /// ```
-    /// # use harmonia_utils_hash::Sha256;
-    /// # use harmonia_utils_hash::fmt::CommonHash;
-    /// let hash = Sha256::digest("abc");
-    ///
-    /// assert_eq!("1b8m03r63zqhnjf7l5wnldhh7c134ap5vpj0850ymkq1iyzicy5s", hash.as_base32().as_bare().to_string());
-    /// ```
-    pub fn digest<B: AsRef<[u8]>>(data: B) -> Self {
-        Algorithm::SHA256.digest(data).try_into().unwrap()
-    }
-
-    #[inline]
-    pub fn digest_bytes(&self) -> &[u8] {
-        &self.0
-    }
-}
-
-impl AsRef<[u8]> for Sha256 {
-    fn as_ref(&self) -> &[u8] {
-        self.digest_bytes()
-    }
-}
-
-impl From<Sha256> for Hash {
-    fn from(value: Sha256) -> Self {
-        Hash::new(Algorithm::SHA256, value.as_ref())
-    }
-}
-
-impl TryFrom<Hash> for Sha256 {
-    type Error = fmt::ParseHashErrorKind;
-
-    fn try_from(value: Hash) -> Result<Self, Self::Error> {
-        if value.algorithm() != Algorithm::SHA256 {
-            return Err(fmt::ParseHashErrorKind::TypeMismatch {
-                expected: Algorithm::SHA256,
-                actual: value.algorithm(),
-            });
-        }
-        Ok(Self::new(value.as_ref()))
-    }
-}
-
-#[derive(Clone)]
-enum InnerContext {
-    MD5(md5::Context),
-    SHA1(sha1::Sha1),
-    SHA256(sha2::Sha256),
-    SHA512(sha2::Sha512),
-    BLAKE3(Box<blake3::Hasher>),
-}
-
-/// A context for multi-step (Init-Update-Finish) digest calculation.
-///
-/// # Examples
-///
-/// ```
-/// use harmonia_utils_hash as hash;
-///
-/// let one_shot = hash::Algorithm::SHA256.digest("hello, world");
-///
-/// let mut ctx = hash::Context::new(hash::Algorithm::SHA256);
-/// ctx.update("hello");
-/// ctx.update(", ");
-/// ctx.update("world");
-/// let multi_path = ctx.finish();
-///
-/// assert_eq!(one_shot, multi_path);
-/// ```
-#[derive(Clone)]
-pub struct Context(Algorithm, InnerContext);
-
-impl Context {
-    /// Constructs a new context with `algorithm`.
-    pub fn new(algorithm: Algorithm) -> Self {
-        let inner = match algorithm {
-            Algorithm::MD5 => InnerContext::MD5(md5::Context::new()),
-            Algorithm::SHA1 => InnerContext::SHA1(sha1::Sha1::new()),
-            Algorithm::SHA256 => InnerContext::SHA256(sha2::Sha256::new()),
-            Algorithm::SHA512 => InnerContext::SHA512(sha2::Sha512::new()),
-            Algorithm::BLAKE3 => InnerContext::BLAKE3(Box::new(blake3::Hasher::new())),
-        };
-        Context(algorithm, inner)
-    }
-
-    /// Update the digest with all the data in `data`.
-    /// `update` may be called zero or more times before `finish` is called.
-    pub fn update<D: AsRef<[u8]>>(&mut self, data: D) {
-        let data = data.as_ref();
-        match &mut self.1 {
-            InnerContext::MD5(ctx) => ctx.consume(data),
-            InnerContext::SHA1(ctx) => ctx.update(data),
-            InnerContext::SHA256(ctx) => ctx.update(data),
-            InnerContext::SHA512(ctx) => ctx.update(data),
-            InnerContext::BLAKE3(ctx) => {
-                ctx.update(data);
-            }
-        }
-    }
-
-    /// Finalizes the digest calculation and returns the [`Hash`] value.
-    /// This consumes the context to prevent misuse.
-    ///
-    /// [`Hash`]: struct@Hash
-    pub fn finish(self) -> Hash {
-        match self.1 {
-            InnerContext::MD5(ctx) => Hash::new(self.0, ctx.finalize().as_ref()),
-            InnerContext::SHA1(ctx) => Hash::new(self.0, ctx.finalize().as_ref()),
-            InnerContext::SHA256(ctx) => Hash::new(self.0, ctx.finalize().as_ref()),
-            InnerContext::SHA512(ctx) => Hash::new(self.0, ctx.finalize().as_ref()),
-            InnerContext::BLAKE3(ctx) => Hash::new(self.0, ctx.finalize().as_bytes()),
-        }
-    }
-
-    /// The algorithm that this context is using.
-    pub fn algorithm(&self) -> Algorithm {
-        self.0
-    }
-}
-
-impl sfmt::Debug for Context {
-    fn fmt(&self, f: &mut sfmt::Formatter<'_>) -> sfmt::Result {
-        f.debug_tuple("Context").field(&self.0).finish()
-    }
-}
-
-/// A hash sink that implements [`AsyncWrite`].
-///
-/// # Examples
-///
-/// ```
-/// use tokio::io;
-/// use harmonia_utils_hash as hash;
-///
-/// # #[tokio::main]
-/// # async fn main() -> std::io::Result<()> {
-/// let mut reader: &[u8] = b"hello, world";
-/// let mut sink = hash::HashSink::new(hash::Algorithm::SHA256);
-///
-/// io::copy(&mut reader, &mut sink).await?;
-/// let (size, hash) = sink.finish();
-///
-/// let one_shot = hash::Algorithm::SHA256.digest("hello, world");
-/// assert_eq!(one_shot, hash);
-/// assert_eq!(12, size);
-/// # Ok(())
-/// # }
-/// ```
-///
-/// [`AsyncWrite`]: tokio::io::AsyncWrite
-#[derive(Debug)]
-pub struct HashSink(Option<(u64, Context)>);
-impl HashSink {
-    /// Constructs a new sink with `algorithm`.
-    pub fn new(algorithm: Algorithm) -> HashSink {
-        HashSink(Some((0, Context::new(algorithm))))
-    }
-
-    /// Finalizes this sink and returns the hash and number of bytes written to the sink.
-    pub fn finish(self) -> (u64, Hash) {
-        let (read, ctx) = self.0.unwrap();
-        (read, ctx.finish())
-    }
-}
-
-impl tokio::io::AsyncWrite for HashSink {
-    fn poll_write(
-        mut self: std::pin::Pin<&mut Self>,
-        _cx: &mut std::task::Context<'_>,
-        buf: &[u8],
-    ) -> std::task::Poll<Result<usize, std::io::Error>> {
-        match self.0.as_mut() {
-            None => {
-                return std::task::Poll::Ready(Err(std::io::Error::new(
-                    std::io::ErrorKind::BrokenPipe,
-                    "cannot write to HashSink after calling finish()",
-                )));
-            }
-            Some((read, ctx)) => {
-                *read += buf.len() as u64;
-                ctx.update(buf)
-            }
-        }
-        std::task::Poll::Ready(Ok(buf.len()))
-    }
-
-    fn poll_flush(
-        self: std::pin::Pin<&mut Self>,
-        _cx: &mut std::task::Context<'_>,
-    ) -> std::task::Poll<Result<(), std::io::Error>> {
-        std::task::Poll::Ready(Ok(()))
-    }
-
-    fn poll_shutdown(
-        self: std::pin::Pin<&mut Self>,
-        _cx: &mut std::task::Context<'_>,
-    ) -> std::task::Poll<Result<(), std::io::Error>> {
-        std::task::Poll::Ready(Ok(()))
-    }
-}
-
-#[cfg(any(test, feature = "test"))]
+#[cfg(feature = "test")]
 mod proptests {
     use super::*;
+
     use ::proptest::prelude::*;
 
     impl Arbitrary for Algorithm {
@@ -357,148 +62,34 @@ mod proptests {
     }
 }
 
+// Serde and formatting tests remain here because they use `fmt` traits.
+// Algorithm and digest tests moved to `algo.rs`.
 #[cfg(test)]
 mod unittests {
     use hex_literal::hex;
     use rstest::rstest;
 
     use super::*;
-    use harmonia_utils_base_encoding::Base;
 
-    /// value taken from: https://tools.ietf.org/html/rfc1321
-    const MD5_EMPTY: Hash = Hash::new(Algorithm::MD5, &hex!("d41d8cd98f00b204e9800998ecf8427e"));
-    /// value taken from: https://tools.ietf.org/html/rfc1321
     const MD5_ABC: Hash = Hash::new(Algorithm::MD5, &hex!("900150983cd24fb0d6963f7d28e17f72"));
-
-    /// value taken from: https://tools.ietf.org/html/rfc3174
     const SHA1_ABC: Hash = Hash::new(
         Algorithm::SHA1,
         &hex!("a9993e364706816aba3e25717850c26c9cd0d89d"),
     );
-    /// value taken from: https://tools.ietf.org/html/rfc3174
-    const SHA1_LONG: Hash = Hash::new(
-        Algorithm::SHA1,
-        &hex!("84983e441c3bd26ebaae4aa1f95129e5e54670f1"),
-    );
-
-    /// value taken from: https://tools.ietf.org/html/rfc4634
     const SHA256_ABC: Hash = Hash::new(
         Algorithm::SHA256,
         &hex!("ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"),
     );
-    /// value taken from: https://tools.ietf.org/html/rfc4634
-    const SHA256_LONG: Hash = Hash::new(
-        Algorithm::SHA256,
-        &hex!("248d6a61d20638b8e5c026930c3e6039a33ce45964ff2167f6ecedd419db06c1"),
-    );
-
-    /// value taken from: https://tools.ietf.org/html/rfc4634
     const SHA512_ABC: Hash = Hash::new(
         Algorithm::SHA512,
         &hex!(
             "ddaf35a193617abacc417349ae20413112e6fa4e89a97ea20a9eeee64b55d39a2192992a274fc1a836ba3c23a3feebbd454d4423643ce80e2a9ac94fa54ca49f"
         ),
     );
-    /// value taken from: https://tools.ietf.org/html/rfc4634
-    const SHA512_LONG: Hash = Hash::new(
-        Algorithm::SHA512,
-        &hex!(
-            "8e959b75dae313da8cf4f72814fc143f8f7779c6eb9f7fa17299aeadb6889018501d289e4900f7e4331b99dec4b5433ac7d329eeb6dd26545e96e55b874be909"
-        ),
-    );
-
-    /// value cross-checked against NixOS/nix PR #12379 BLAKE3 test vectors
     const BLAKE3_ABC: Hash = Hash::new(
         Algorithm::BLAKE3,
         &hex!("6437b3ac38465133ffb63b75273a8db548c558465d79db03fd359c6cd5bd9d85"),
     );
-    /// value cross-checked against NixOS/nix PR #12379 BLAKE3 test vectors
-    const BLAKE3_LONG: Hash = Hash::new(
-        Algorithm::BLAKE3,
-        &hex!("c19012cc2aaf0dc3d8e5c45a1b79114d2df42abb2a410bf54be09e891af06ff8"),
-    );
-
-    #[rstest]
-    #[case::md5(Algorithm::MD5, 16, 32, 26, 24, 18)]
-    #[case::sha1(Algorithm::SHA1, 20, 40, 32, 28, 21)]
-    #[case::sha256(Algorithm::SHA256, 32, 64, 52, 44, 33)]
-    #[case::sha512(Algorithm::SHA512, 64, 128, 103, 88, 66)]
-    #[case::blake3(Algorithm::BLAKE3, 32, 64, 52, 44, 33)]
-    fn algorithm_size(
-        #[case] algorithm: Algorithm,
-        #[case] size: usize,
-        #[case] base16_len: usize,
-        #[case] base32_len: usize,
-        #[case] base64_len: usize,
-        #[case] base64_decoded: usize,
-    ) {
-        assert_eq!(algorithm.size(), size, "mismatched size");
-        assert_eq!(
-            Base::Hex.input_len(algorithm.size()),
-            base16_len,
-            "mismatched base16_len"
-        );
-        assert_eq!(
-            Base::NixBase32.input_len(algorithm.size()),
-            base32_len,
-            "mismatched base32_len"
-        );
-        assert_eq!(
-            Base::Base64.input_len(algorithm.size()),
-            base64_len,
-            "mismatched base64_len"
-        );
-        assert_eq!(
-            Base::Base64.scratch_len(algorithm.size()),
-            base64_decoded,
-            "mismatched base64_decoded"
-        );
-    }
-
-    #[rstest]
-    #[case::md5("md5", Algorithm::MD5)]
-    #[case::sha1("sha1", Algorithm::SHA1)]
-    #[case::sha256("sha256", Algorithm::SHA256)]
-    #[case::sha512("sha512", Algorithm::SHA512)]
-    #[case::blake3("blake3", Algorithm::BLAKE3)]
-    #[case::md5_upper("MD5", Algorithm::MD5)]
-    #[case::sha1_upper("SHA1", Algorithm::SHA1)]
-    #[case::sha256_upper("SHA256", Algorithm::SHA256)]
-    #[case::sha512_upper("SHA512", Algorithm::SHA512)]
-    #[case::blake3_upper("BLAKE3", Algorithm::BLAKE3)]
-    #[case::md5_mixed("mD5", Algorithm::MD5)]
-    #[case::sha1_mixed("ShA1", Algorithm::SHA1)]
-    #[case::sha256_mixed("ShA256", Algorithm::SHA256)]
-    #[case::sha512_mixed("ShA512", Algorithm::SHA512)]
-    #[case::blake3_mixed("BlAkE3", Algorithm::BLAKE3)]
-    fn algorithm_from_str(#[case] input: &str, #[case] expected: Algorithm) {
-        let actual = input.parse().unwrap();
-        assert_eq!(expected, actual);
-    }
-
-    #[rstest]
-    #[case::md5_empty(&MD5_EMPTY, "")]
-    #[case::md5_abc(&MD5_ABC, "abc")]
-    #[case::sha1_abc(&SHA1_ABC, "abc")]
-    #[case::sha1_long(&SHA1_LONG, "abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq")]
-    #[case::sha256_abc(&SHA256_ABC, "abc")]
-    #[case::sha256_long(&SHA256_LONG, "abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq")]
-    #[case::sha512_abc(&SHA512_ABC, "abc")]
-    #[case::sha512_long(&SHA512_LONG, "abcdefghbcdefghicdefghijdefghijkefghijklfghijklmghijklmnhijklmnoijklmnopjklmnopqklmnopqrlmnopqrsmnopqrstnopqrstu")]
-    #[case::blake3_abc(&BLAKE3_ABC, "abc")]
-    #[case::blake3_long(&BLAKE3_LONG, "abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq")]
-    fn test_digest(#[case] expected: &Hash, #[case] input: &str) {
-        let actual = expected.algorithm().digest(input);
-        assert_eq!(actual, *expected);
-    }
-
-    #[test]
-    fn unknown_algorithm() {
-        assert_eq!(
-            Err(UnknownAlgorithm("test".into())),
-            "test".parse::<Algorithm>()
-        );
-    }
 
     #[rstest]
     #[case::sha256(&SHA256_ABC, "sha256-ungWv48Bz+pBQUDeXa4iI7ADYaOWF3qctBD/YfIAFa0=")]

--- a/harmonia-utils-hash/src/owned.rs
+++ b/harmonia-utils-hash/src/owned.rs
@@ -1,0 +1,123 @@
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+use crate::borrowed::BorrowedHash;
+use crate::fmt::HashFormat as _;
+use crate::view::HashView;
+use crate::{Algorithm, InvalidHashError, Sha256, fmt};
+
+#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Hash)]
+pub enum Hash {
+    MD5([u8; Algorithm::MD5.size()]),
+    SHA1([u8; Algorithm::SHA1.size()]),
+    SHA256(Sha256),
+    SHA512([u8; Algorithm::SHA512.size()]),
+    BLAKE3([u8; Algorithm::BLAKE3.size()]),
+}
+
+impl Hash {
+    /// Create a hash from an algorithm and digest bytes.
+    ///
+    /// The input slice must be at least `algorithm.size()` bytes;
+    /// trailing bytes beyond the algorithm's digest size are ignored.
+    pub const fn new(algorithm: Algorithm, hash: &[u8]) -> Hash {
+        /// Copy the first `N` bytes from `src` into a fixed-size array.
+        const fn copy_into<const N: usize>(src: &[u8]) -> [u8; N] {
+            let mut data = [0u8; N];
+            let (src, _) = src.split_at(N);
+            data.copy_from_slice(src);
+            data
+        }
+
+        match algorithm {
+            Algorithm::MD5 => Hash::MD5(copy_into(hash)),
+            Algorithm::SHA1 => Hash::SHA1(copy_into(hash)),
+            Algorithm::SHA256 => Hash::SHA256(Sha256(copy_into(hash))),
+            Algorithm::SHA512 => Hash::SHA512(copy_into(hash)),
+            Algorithm::BLAKE3 => Hash::BLAKE3(copy_into(hash)),
+        }
+    }
+
+    pub fn from_slice(algorithm: Algorithm, hash: &[u8]) -> Result<Hash, InvalidHashError> {
+        if hash.len() != algorithm.size() {
+            return Err(InvalidHashError {
+                algorithm,
+                length: hash.len(),
+            });
+        }
+        Ok(Hash::new(algorithm, hash))
+    }
+
+    /// Borrow this hash as a [`BorrowedHash`].
+    pub fn borrow(&self) -> BorrowedHash<'_> {
+        match self {
+            Hash::MD5(d) => BorrowedHash::MD5(d),
+            Hash::SHA1(d) => BorrowedHash::SHA1(d),
+            Hash::SHA256(d) => BorrowedHash::SHA256(d),
+            Hash::SHA512(d) => BorrowedHash::SHA512(d),
+            Hash::BLAKE3(d) => BorrowedHash::BLAKE3(d),
+        }
+    }
+}
+
+impl HashView for Hash {
+    #[inline]
+    fn algorithm(&self) -> Algorithm {
+        match self {
+            Hash::MD5(_) => Algorithm::MD5,
+            Hash::SHA1(_) => Algorithm::SHA1,
+            Hash::SHA256(_) => Algorithm::SHA256,
+            Hash::SHA512(_) => Algorithm::SHA512,
+            Hash::BLAKE3(_) => Algorithm::BLAKE3,
+        }
+    }
+
+    #[inline]
+    fn digest_bytes(&self) -> &[u8] {
+        match self {
+            Hash::MD5(d) => d,
+            Hash::SHA1(d) => d,
+            Hash::SHA256(d) => &d.0,
+            Hash::SHA512(d) => d,
+            Hash::BLAKE3(d) => d,
+        }
+    }
+}
+
+impl std::ops::Deref for Hash {
+    type Target = [u8];
+    fn deref(&self) -> &[u8] {
+        self.digest_bytes()
+    }
+}
+
+impl AsRef<[u8]> for Hash {
+    fn as_ref(&self) -> &[u8] {
+        self.digest_bytes()
+    }
+}
+
+impl Serialize for Hash {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        // Serialize as SRI string: "sha256-base64hash="
+        serializer.serialize_str(&self.as_sri().to_string())
+    }
+}
+
+impl<'de> Deserialize<'de> for Hash {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        use serde::de;
+
+        let s = String::deserialize(deserializer)?;
+        // Try SRI format first, then fall back to Any format for flexibility
+        s.parse::<fmt::SRI<Hash>>()
+            .map(|sri| sri.into_hash())
+            .or_else(|_| s.parse::<fmt::Any<Hash>>().map(|any| any.into_hash()))
+            .map_err(de::Error::custom)
+    }
+}

--- a/harmonia-utils-hash/src/sha256.rs
+++ b/harmonia-utils-hash/src/sha256.rs
@@ -1,0 +1,86 @@
+#[cfg(any(test, feature = "test"))]
+use proptest_derive::Arbitrary;
+
+use crate::fmt;
+use crate::owned::Hash;
+use crate::view::HashView;
+use crate::{Algorithm, InvalidHashError};
+
+#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Hash)]
+#[cfg_attr(any(test, feature = "test"), derive(Arbitrary))]
+pub struct Sha256(pub(crate) [u8; Algorithm::SHA256.size()]);
+
+impl Sha256 {
+    pub const fn new(digest: &[u8]) -> Self {
+        let mut data = [0u8; Algorithm::SHA256.size()];
+        data.copy_from_slice(digest);
+        Self(data)
+    }
+
+    pub const fn from_slice(digest: &[u8]) -> Result<Self, InvalidHashError> {
+        if digest.len() != Algorithm::SHA256.size() {
+            return Err(InvalidHashError {
+                algorithm: Algorithm::SHA256,
+                length: digest.len(),
+            });
+        }
+        Ok(Self::new(digest))
+    }
+
+    /// Returns the digest of `data` using the sha256
+    ///
+    /// ```
+    /// # use harmonia_utils_hash::Sha256;
+    /// # use harmonia_utils_hash::fmt::HashFormat;
+    /// let hash = Sha256::digest("abc");
+    ///
+    /// assert_eq!("1b8m03r63zqhnjf7l5wnldhh7c134ap5vpj0850ymkq1iyzicy5s", hash.as_base32().as_bare().to_string());
+    /// ```
+    pub fn digest<B: AsRef<[u8]>>(data: B) -> Self {
+        Algorithm::SHA256.digest(data).try_into().unwrap()
+    }
+
+    /// Returns a reference to the inner fixed-size array.
+    #[inline]
+    pub fn digest_bytes(&self) -> &[u8; Algorithm::SHA256.size()] {
+        &self.0
+    }
+}
+
+impl HashView for Sha256 {
+    #[inline]
+    fn algorithm(&self) -> Algorithm {
+        Algorithm::SHA256
+    }
+
+    #[inline]
+    fn digest_bytes(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+impl AsRef<[u8; Algorithm::SHA256.size()]> for Sha256 {
+    fn as_ref(&self) -> &[u8; Algorithm::SHA256.size()] {
+        self.digest_bytes()
+    }
+}
+
+impl From<Sha256> for Hash {
+    fn from(value: Sha256) -> Self {
+        Hash::SHA256(value)
+    }
+}
+
+impl TryFrom<Hash> for Sha256 {
+    type Error = fmt::ParseHashErrorKind;
+
+    fn try_from(value: Hash) -> Result<Self, Self::Error> {
+        match value {
+            Hash::SHA256(sha) => Ok(sha),
+            other => Err(fmt::ParseHashErrorKind::TypeMismatch {
+                expected: Algorithm::SHA256,
+                actual: other.algorithm(),
+            }),
+        }
+    }
+}

--- a/harmonia-utils-hash/src/sink.rs
+++ b/harmonia-utils-hash/src/sink.rs
@@ -1,0 +1,164 @@
+use std::fmt as sfmt;
+
+use sha1::Digest;
+
+use crate::{Algorithm, Hash};
+
+#[derive(Clone)]
+enum InnerContext {
+    MD5(md5::Context),
+    SHA1(sha1::Sha1),
+    SHA256(sha2::Sha256),
+    SHA512(sha2::Sha512),
+    BLAKE3(Box<blake3::Hasher>),
+}
+
+/// A context for multi-step (Init-Update-Finish) digest calculation.
+///
+/// # Examples
+///
+/// ```
+/// use harmonia_utils_hash as hash;
+///
+/// let one_shot = hash::Algorithm::SHA256.digest("hello, world");
+///
+/// let mut ctx = hash::Context::new(hash::Algorithm::SHA256);
+/// ctx.update("hello");
+/// ctx.update(", ");
+/// ctx.update("world");
+/// let multi_path = ctx.finish();
+///
+/// assert_eq!(one_shot, multi_path);
+/// ```
+#[derive(Clone)]
+pub struct Context(Algorithm, InnerContext);
+
+impl Context {
+    /// Constructs a new context with `algorithm`.
+    pub fn new(algorithm: Algorithm) -> Self {
+        let inner = match algorithm {
+            Algorithm::MD5 => InnerContext::MD5(md5::Context::new()),
+            Algorithm::SHA1 => InnerContext::SHA1(sha1::Sha1::new()),
+            Algorithm::SHA256 => InnerContext::SHA256(sha2::Sha256::new()),
+            Algorithm::SHA512 => InnerContext::SHA512(sha2::Sha512::new()),
+            Algorithm::BLAKE3 => InnerContext::BLAKE3(Box::new(blake3::Hasher::new())),
+        };
+        Context(algorithm, inner)
+    }
+
+    /// Update the digest with all the data in `data`.
+    /// `update` may be called zero or more times before `finish` is called.
+    pub fn update<D: AsRef<[u8]>>(&mut self, data: D) {
+        let data = data.as_ref();
+        match &mut self.1 {
+            InnerContext::MD5(ctx) => ctx.consume(data),
+            InnerContext::SHA1(ctx) => ctx.update(data),
+            InnerContext::SHA256(ctx) => ctx.update(data),
+            InnerContext::SHA512(ctx) => ctx.update(data),
+            InnerContext::BLAKE3(ctx) => {
+                ctx.update(data);
+            }
+        }
+    }
+
+    /// Finalizes the digest calculation and returns the [`Hash`] value.
+    /// This consumes the context to prevent misuse.
+    ///
+    /// [`Hash`]: struct@Hash
+    pub fn finish(self) -> Hash {
+        match self.1 {
+            InnerContext::MD5(ctx) => Hash::new(self.0, ctx.finalize().as_ref()),
+            InnerContext::SHA1(ctx) => Hash::new(self.0, ctx.finalize().as_ref()),
+            InnerContext::SHA256(ctx) => Hash::new(self.0, ctx.finalize().as_ref()),
+            InnerContext::SHA512(ctx) => Hash::new(self.0, ctx.finalize().as_ref()),
+            InnerContext::BLAKE3(ctx) => Hash::new(self.0, ctx.finalize().as_bytes()),
+        }
+    }
+
+    /// The algorithm that this context is using.
+    pub fn algorithm(&self) -> Algorithm {
+        self.0
+    }
+}
+
+impl sfmt::Debug for Context {
+    fn fmt(&self, f: &mut sfmt::Formatter<'_>) -> sfmt::Result {
+        f.debug_tuple("Context").field(&self.0).finish()
+    }
+}
+
+/// A hash sink that implements [`AsyncWrite`].
+///
+/// # Examples
+///
+/// ```
+/// use tokio::io;
+/// use harmonia_utils_hash as hash;
+///
+/// # #[tokio::main]
+/// # async fn main() -> std::io::Result<()> {
+/// let mut reader: &[u8] = b"hello, world";
+/// let mut sink = hash::HashSink::new(hash::Algorithm::SHA256);
+///
+/// io::copy(&mut reader, &mut sink).await?;
+/// let (size, hash) = sink.finish();
+///
+/// let one_shot = hash::Algorithm::SHA256.digest("hello, world");
+/// assert_eq!(one_shot, hash);
+/// assert_eq!(12, size);
+/// # Ok(())
+/// # }
+/// ```
+///
+/// [`AsyncWrite`]: tokio::io::AsyncWrite
+#[derive(Debug)]
+pub struct HashSink(Option<(u64, Context)>);
+
+impl HashSink {
+    /// Constructs a new sink with `algorithm`.
+    pub fn new(algorithm: Algorithm) -> HashSink {
+        HashSink(Some((0, Context::new(algorithm))))
+    }
+
+    /// Finalizes this sink and returns the hash and number of bytes written to the sink.
+    pub fn finish(self) -> (u64, Hash) {
+        let (read, ctx) = self.0.unwrap();
+        (read, ctx.finish())
+    }
+}
+
+impl tokio::io::AsyncWrite for HashSink {
+    fn poll_write(
+        mut self: std::pin::Pin<&mut Self>,
+        _cx: &mut std::task::Context<'_>,
+        buf: &[u8],
+    ) -> std::task::Poll<Result<usize, std::io::Error>> {
+        match self.0.as_mut() {
+            None => {
+                return std::task::Poll::Ready(Err(std::io::Error::new(
+                    std::io::ErrorKind::BrokenPipe,
+                    "cannot write to HashSink after calling finish()",
+                )));
+            }
+            Some((read, ctx)) => {
+                *read += buf.len() as u64;
+                ctx.update(buf)
+            }
+        }
+        std::task::Poll::Ready(Ok(buf.len()))
+    }
+
+    fn poll_flush(
+        self: std::pin::Pin<&mut Self>,
+        _cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Result<(), std::io::Error>> {
+        std::task::Poll::Ready(Ok(()))
+    }
+
+    fn poll_shutdown(
+        self: std::pin::Pin<&mut Self>,
+        _cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Result<(), std::io::Error>> {
+        std::task::Poll::Ready(Ok(()))
+    }
+}

--- a/harmonia-utils-hash/src/view.rs
+++ b/harmonia-utils-hash/src/view.rs
@@ -1,0 +1,11 @@
+use crate::Algorithm;
+
+/// Read-only access to a hash's algorithm and digest bytes.
+///
+/// This is the minimal trait needed for formatting (`as_base16`,
+/// `as_base32`, etc.). Implemented by both owned and borrowed hash
+/// types.
+pub trait HashView {
+    fn algorithm(&self) -> Algorithm;
+    fn digest_bytes(&self) -> &[u8];
+}


### PR DESCRIPTION
Add a `BorrowedHash` enum that borrows fixed-size array references, so `ContentAddress::hash()` can return a `BorrowedHash<'_>` without copying.

In order to facilitate this, convert the owning `Hash` from a padded-buffer struct `Hash { algorithm, data: [u8; 64] }` to an enum whose variants carry correctly-sized arrays: `Hash::MD5([u8; 16])`, `Hash::SHA256(Sha256)`, etc. The `SHA256` variant reuses the existing `Sha256` newtype, so `BorrowedHash::SHA256(&Sha256)` can borrow directly from a `ContentAddress::Text(Sha256)`.

Also needed is splitting the `CommonHash` trait into three layers:

- `HashView` (`view.rs`): read-only `algorithm()` + `digest_bytes()`

- `HashFormat`: formatting methods (`as_base16`, `as_base32`, etc.), blanket-implemented for all `HashView + Sized`

- `CommonHash`: adds `from_slice` + `implied_algorithm` for types that can be parsed from bytes (not `BorrowedHash`)

Extract `Hash`, `BorrowedHash`, `Sha256`, `Context`/`HashSink` into separate private modules (`owned.rs`, `borrowed.rs`, `sha256.rs`, `sink.rs`); this does not affect the external interface however.