### PR TITLE
Remove dangling readme references from crate manifests

### DIFF
--- a/harmonia-cache/Cargo.toml
+++ b/harmonia-cache/Cargo.toml
@@ -6,7 +6,6 @@ edition.workspace    = true
 license.workspace    = true
 homepage.workspace   = true
 repository.workspace = true
-readme               = "README.md"
 
 [[bin]]
 name = "harmonia-cache"

--- a/harmonia-client/Cargo.toml
+++ b/harmonia-client/Cargo.toml
@@ -6,7 +6,6 @@ edition.workspace    = true
 license.workspace    = true
 homepage.workspace   = true
 repository.workspace = true
-readme               = "README.md"
 
 [[bin]]
 name = "harmonia"

--- a/harmonia-daemon/Cargo.toml
+++ b/harmonia-daemon/Cargo.toml
@@ -6,7 +6,6 @@ edition.workspace    = true
 license.workspace    = true
 homepage.workspace   = true
 repository.workspace = true
-readme               = "README.md"
 
 [dependencies]
 futures-core                   = { workspace = true }

--- a/harmonia-file-nar/Cargo.toml
+++ b/harmonia-file-nar/Cargo.toml
@@ -11,7 +11,6 @@ license.workspace    = true
 homepage.workspace   = true
 repository.workspace = true
 description          = "NAR (Nix ARchive) format packing and unpacking"
-readme               = "README.md"
 
 [dependencies]
 bstr               = { workspace = true }

--- a/harmonia-protocol-derive/Cargo.toml
+++ b/harmonia-protocol-derive/Cargo.toml
@@ -11,7 +11,6 @@ license.workspace    = true
 homepage.workspace   = true
 repository.workspace = true
 description          = "Procedural macros for Harmonia daemon wire protocol"
-readme               = "README.md"
 
 [lib]
 proc-macro = true

--- a/harmonia-protocol/Cargo.toml
+++ b/harmonia-protocol/Cargo.toml
@@ -11,7 +11,6 @@ license.workspace    = true
 homepage.workspace   = true
 repository.workspace = true
 description          = "Nix daemon wire protocol types and serialization"
-readme               = "README.md"
 
 [dependencies]
 async-stream     = { workspace = true }

--- a/harmonia-ssh-store/Cargo.toml
+++ b/harmonia-ssh-store/Cargo.toml
@@ -11,7 +11,6 @@ license.workspace    = true
 homepage.workspace   = true
 repository.workspace = true
 description          = "SSH remote store implementation (optional - pending Phase 3 assessment)"
-readme               = "README.md"
 
 [dependencies]
 # SSH dependencies (will be added if imported)

--- a/harmonia-store-aterm/Cargo.toml
+++ b/harmonia-store-aterm/Cargo.toml
@@ -10,7 +10,6 @@ edition.workspace    = true
 license.workspace    = true
 homepage.workspace   = true
 repository.workspace = true
-readme               = "README.md"
 
 [dependencies]
 bytes                          = { workspace = true }

--- a/harmonia-store-build-result/Cargo.toml
+++ b/harmonia-store-build-result/Cargo.toml
@@ -10,7 +10,6 @@ license.workspace    = true
 homepage.workspace   = true
 repository.workspace = true
 description          = "BuildResult types and JSON serialization for Nix build results"
-readme               = "README.md"
 
 [dependencies]
 harmonia-store-derivation = { workspace = true }

--- a/harmonia-store-db/Cargo.toml
+++ b/harmonia-store-db/Cargo.toml
@@ -10,7 +10,6 @@ license.workspace    = true
 homepage.workspace   = true
 repository.workspace = true
 description          = "SQLite database interface for Nix store metadata"
-readme               = "README.md"
 
 [dependencies]
 harmonia-store-content-address = { workspace = true }

--- a/harmonia-store-derivation/Cargo.toml
+++ b/harmonia-store-derivation/Cargo.toml
@@ -11,7 +11,6 @@ license.workspace    = true
 homepage.workspace   = true
 repository.workspace = true
 description          = "Core Nix store semantics - pure types and validation logic"
-readme               = "README.md"
 
 [dependencies]
 bytes                          = { workspace = true, features = [ "serde" ] }

--- a/harmonia-store-path-info/Cargo.toml
+++ b/harmonia-store-path-info/Cargo.toml
@@ -10,7 +10,6 @@ license.workspace    = true
 homepage.workspace   = true
 repository.workspace = true
 description          = "ValidPathInfo, NarHash, and JSON serialization for Nix store metadata"
-readme               = "README.md"
 
 [dependencies]
 harmonia-store-content-address = { workspace = true }

--- a/harmonia-store-remote/Cargo.toml
+++ b/harmonia-store-remote/Cargo.toml
@@ -14,7 +14,6 @@ edition.workspace    = true
 license.workspace    = true
 homepage.workspace   = true
 repository.workspace = true
-readme               = "README.md"
 
 [dependencies]
 # Harmonia crates

--- a/harmonia-utils-base-encoding/Cargo.toml
+++ b/harmonia-utils-base-encoding/Cargo.toml
@@ -11,7 +11,6 @@ license.workspace    = true
 homepage.workspace   = true
 repository.workspace = true
 description          = "Base encoding utilities for Harmonia (Nix base32, hex, base64)"
-readme               = "README.md"
 
 [dependencies]
 data-encoding = { workspace = true }

--- a/harmonia-utils-hash/Cargo.toml
+++ b/harmonia-utils-hash/Cargo.toml
@@ -11,7 +11,6 @@ license.workspace    = true
 homepage.workspace   = true
 repository.workspace = true
 description          = "Hash utilities for Harmonia (content addressing, hash types)"
-readme               = "README.md"
 
 [dependencies]
 blake3                       = { workspace = true }

--- a/harmonia-utils-io/Cargo.toml
+++ b/harmonia-utils-io/Cargo.toml
@@ -11,7 +11,6 @@ license.workspace    = true
 homepage.workspace   = true
 repository.workspace = true
 description          = "Async I/O utilities for Harmonia"
-readme               = "README.md"
 
 [dependencies]
 bytes            = { workspace = true }

--- a/harmonia-utils-test/Cargo.toml
+++ b/harmonia-utils-test/Cargo.toml
@@ -11,7 +11,6 @@ license.workspace    = true
 homepage.workspace   = true
 repository.workspace = true
 description          = "Test utilities for Harmonia (proptest strategies, macros)"
-readme               = "README.md"
 
 [dependencies]
 bytes      = { workspace = true }


### PR DESCRIPTION
Ran into this while building [hestia](https://github.com/Mic92/hestia), which uses these crates as git dependencies. Cargo checks that the readme path exists when vendoring, but README.md only exists in the repo root:

```
error: readme `README.md` does not appear to exist (relative to /build/source/harmonia-store-path-info)
```

We don't publish these crates, so just drop the field.