### PR TITLE
harmonia-cache: skip TLS key permission warning under $CREDENTIALS_DIRECTORY

### DIFF
--- a/harmonia-cache/src/tls.rs
+++ b/harmonia-cache/src/tls.rs
@@ -39,10 +39,6 @@ pub fn load_tls_config(cert_path: &Path, key_path: &Path) -> Result<ServerConfig
 }
 
 /// Warn (not fail) when a secret file is group/other-readable.
-///
-/// Skips the check if the file lives under `$CREDENTIALS_DIRECTORY`:
-/// systemd exposes credentials with restrictive ACLs but mode 0440, and the
-/// chmod bits alone are not meaningful there (systemd/systemd#29435).
 pub(crate) fn warn_insecure_permissions(path: &Path) {
     if let Some(mode) = insecure_permissions(path, std::env::var_os("CREDENTIALS_DIRECTORY")) {
         tracing::warn!(
@@ -54,14 +50,16 @@ pub(crate) fn warn_insecure_permissions(path: &Path) {
 }
 
 /// Returns the file mode if it is group/other-readable, `None` otherwise.
+///
+/// Files under `$CREDENTIALS_DIRECTORY` are exempt: systemd provisions
+/// credentials with mode 0440 but restricts access via ACLs, so the mode bits
+/// alone are not meaningful (systemd/systemd#29435).
 fn insecure_permissions(path: &Path, credentials_dir: Option<OsString>) -> Option<u32> {
-    if let Some(dir) = credentials_dir {
-        let dir = Path::new(&dir);
-        if let (Ok(p), Ok(d)) = (path.canonicalize(), dir.canonicalize())
-            && p.starts_with(&d)
-        {
-            return None;
-        }
+    if let Some(dir) = credentials_dir
+        && let (Ok(p), Ok(d)) = (path.canonicalize(), Path::new(&dir).canonicalize())
+        && p.starts_with(&d)
+    {
+        return None;
     }
 
     let meta = std::fs::metadata(path).ok()?;
@@ -82,17 +80,16 @@ mod tests {
     }
 
     #[test]
-    fn warns_on_group_or_other_readable() {
+    fn flags_group_or_other_readable() {
         let dir = tempfile::tempdir().unwrap();
-        let path = key_file(dir.path(), 0o644);
-        assert_eq!(insecure_permissions(&path, None), Some(0o644));
-    }
-
-    #[test]
-    fn accepts_owner_only() {
-        let dir = tempfile::tempdir().unwrap();
-        let path = key_file(dir.path(), 0o600);
-        assert_eq!(insecure_permissions(&path, None), None);
+        assert_eq!(
+            insecure_permissions(&key_file(dir.path(), 0o644), None),
+            Some(0o644)
+        );
+        assert_eq!(
+            insecure_permissions(&key_file(dir.path(), 0o600), None),
+            None
+        );
     }
 
     #[test]

--- a/harmonia-cache/src/tls.rs
+++ b/harmonia-cache/src/tls.rs
@@ -2,6 +2,7 @@ use crate::error::{Result, ServerError as ServerErrorType};
 use rustls::ServerConfig;
 use rustls_pki_types::pem::PemObject;
 use rustls_pki_types::{CertificateDer, PrivateKeyDer};
+use std::ffi::OsString;
 use std::os::unix::fs::PermissionsExt;
 use std::path::Path;
 
@@ -38,15 +39,76 @@ pub fn load_tls_config(cert_path: &Path, key_path: &Path) -> Result<ServerConfig
 }
 
 /// Warn (not fail) when a secret file is group/other-readable.
+///
+/// Skips the check if the file lives under `$CREDENTIALS_DIRECTORY`:
+/// systemd exposes credentials with restrictive ACLs but mode 0440, and the
+/// chmod bits alone are not meaningful there (systemd/systemd#29435).
 pub(crate) fn warn_insecure_permissions(path: &Path) {
-    if let Ok(meta) = std::fs::metadata(path) {
-        let mode = meta.permissions().mode() & 0o777;
-        if mode & 0o077 != 0 {
-            tracing::warn!(
-                "{} has insecure permissions {:#o}; recommend 0600",
-                path.display(),
-                mode
-            );
+    if let Some(mode) = insecure_permissions(path, std::env::var_os("CREDENTIALS_DIRECTORY")) {
+        tracing::warn!(
+            "{} has insecure permissions {:#o}; recommend 0600",
+            path.display(),
+            mode
+        );
+    }
+}
+
+/// Returns the file mode if it is group/other-readable, `None` otherwise.
+fn insecure_permissions(path: &Path, credentials_dir: Option<OsString>) -> Option<u32> {
+    if let Some(dir) = credentials_dir {
+        let dir = Path::new(&dir);
+        if let (Ok(p), Ok(d)) = (path.canonicalize(), dir.canonicalize())
+            && p.starts_with(&d)
+        {
+            return None;
         }
+    }
+
+    let meta = std::fs::metadata(path).ok()?;
+    let mode = meta.permissions().mode() & 0o777;
+    (mode & 0o077 != 0).then_some(mode)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs::Permissions;
+
+    fn key_file(dir: &Path, mode: u32) -> std::path::PathBuf {
+        let path = dir.join("key.pem");
+        std::fs::write(&path, "secret").unwrap();
+        std::fs::set_permissions(&path, Permissions::from_mode(mode)).unwrap();
+        path
+    }
+
+    #[test]
+    fn warns_on_group_or_other_readable() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = key_file(dir.path(), 0o644);
+        assert_eq!(insecure_permissions(&path, None), Some(0o644));
+    }
+
+    #[test]
+    fn accepts_owner_only() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = key_file(dir.path(), 0o600);
+        assert_eq!(insecure_permissions(&path, None), None);
+    }
+
+    #[test]
+    fn skips_files_under_credentials_directory() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = key_file(dir.path(), 0o440);
+        let creds = Some(dir.path().as_os_str().to_owned());
+        assert_eq!(insecure_permissions(&path, creds), None);
+    }
+
+    #[test]
+    fn still_warns_outside_credentials_directory() {
+        let dir = tempfile::tempdir().unwrap();
+        let creds_dir = tempfile::tempdir().unwrap();
+        let path = key_file(dir.path(), 0o644);
+        let creds = Some(creds_dir.path().as_os_str().to_owned());
+        assert_eq!(insecure_permissions(&path, creds), Some(0o644));
     }
 }


### PR DESCRIPTION
## Summary

`warn_insecure_permissions` currently warns about TLS private keys (and signing keys) provisioned via systemd's `LoadCredential`/`ImportCredential`: systemd exposes credentials with restrictive ACLs but mode 0440, so the chmod bits alone are not meaningful there (see systemd/systemd#29435).

This PR suppresses the warning when the secret file resolves (after `canonicalize`) to a path under `$CREDENTIALS_DIRECTORY`. Files outside that directory are checked as before.

- Extracted the check into `insecure_permissions(path, credentials_dir) -> Option<u32>` so the decision logic is unit-testable; the public wrapper still just emits a `tracing::warn!`.
- Added tests covering: warns on 0644, accepts 0600, skips 0440 under `$CREDENTIALS_DIRECTORY`, still warns outside it.

## Test plan

- `cargo test -p harmonia-cache` (new `tls::tests` pass)
- `cargo clippy -p harmonia-cache --all-targets` clean