### PR TITLE
harmonia-store-ref-scan: add README.md

### DIFF
--- a/harmonia-store-ref-scan/README.md
+++ b/harmonia-store-ref-scan/README.md
@@ -1,0 +1,11 @@
+# harmonia-store-ref-scan
+
+Streaming reference scanner for Nix store path outputs.
+
+## Overview
+
+After a build completes, Nix needs to discover which store paths the
+output references. `RefScanSink` is a streaming scanner that can be
+fed arbitrary byte chunks (typically a NAR stream) and efficiently
+finds embedded store-path hash references using the same Boyer-Moore
+style window scan as Nix's `references.cc`.


### PR DESCRIPTION
Cargo.toml declares readme = "README.md" but the file did not exist,
which makes `cargo package` (and tooling that calls it, e.g. crane's
git-dep vendoring) fail with "readme README.md does not appear to
exist".  Every other workspace member already ships its own README.
