### PR TITLE
store-ref-scan: fix buffer overrun on invalid byte before boundary hash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -985,6 +985,8 @@ name = "harmonia-bench"
 version = "3.1.0"
 dependencies = [
  "criterion",
+ "harmonia-store-path",
+ "harmonia-store-ref-scan",
  "nix",
  "tempfile",
  "tokio",

--- a/harmonia-bench/Cargo.toml
+++ b/harmonia-bench/Cargo.toml
@@ -4,10 +4,12 @@ version.workspace = true
 edition.workspace = true
 
 [dev-dependencies]
-criterion          = { version = "0.8", features = [ "html_reports" ] }
-nix.workspace      = true
-tempfile.workspace = true
-tokio              = { workspace = true, features = [ "rt-multi-thread", "time", "net", "io-util" ] }
+criterion                         = { version = "0.8", features = [ "html_reports" ] }
+harmonia-store-path.workspace     = true
+harmonia-store-ref-scan.workspace = true
+nix.workspace                     = true
+tempfile.workspace                = true
+tokio                             = { workspace = true, features = [ "rt-multi-thread", "time", "net", "io-util" ] }
 
 [[bench]]
 harness = false
@@ -16,3 +18,7 @@ name    = "closure_download"
 [[bench]]
 harness = false
 name    = "http_download"
+
+[[bench]]
+harness = false
+name    = "ref_scan"

--- a/harmonia-bench/benches/ref_scan.rs
+++ b/harmonia-bench/benches/ref_scan.rs
@@ -1,0 +1,73 @@
+use std::collections::BTreeSet;
+
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use harmonia_store_path::StorePath;
+use harmonia_store_ref_scan::RefScanSink;
+
+/// Cheap deterministic PRNG so benchmark inputs are reproducible without a
+/// dependency on `rand`.
+fn xorshift(state: &mut u64) -> u64 {
+    *state ^= *state << 13;
+    *state ^= *state >> 7;
+    *state ^= *state << 17;
+    *state
+}
+
+/// Build `count` distinct candidate store paths.
+fn candidates(count: usize) -> Vec<StorePath> {
+    const ALPHABET: &[u8] = b"0123456789abcdfghijklmnpqrsvwxyz";
+    let mut state = 0x9e37_79b9_7f4a_7c15;
+    (0..count)
+        .map(|i| {
+            let hash: String = (0..32)
+                .map(|_| ALPHABET[(xorshift(&mut state) % 32) as usize] as char)
+                .collect();
+            StorePath::from_base_path(&format!("{hash}-candidate-{i}")).unwrap()
+        })
+        .collect()
+}
+
+/// A NAR-sized blob of mostly random binary data with a fraction of the
+/// candidate hashes embedded at random offsets: the realistic worker case
+/// where an output references a handful of its many build inputs.
+fn make_blob(size: usize, cands: &[StorePath], embed: usize) -> Vec<u8> {
+    let mut state = 0x1234_5678_9abc_def0;
+    let mut data: Vec<u8> = (0..size)
+        .map(|_| (xorshift(&mut state) & 0xff) as u8)
+        .collect();
+    for c in cands.iter().take(embed) {
+        let hash = c.hash().to_string();
+        let off = (xorshift(&mut state) as usize) % (size - hash.len());
+        data[off..off + hash.len()].copy_from_slice(hash.as_bytes());
+    }
+    data
+}
+
+fn benchmark_ref_scan(c: &mut Criterion) {
+    const SIZE: usize = 16 * 1024 * 1024;
+    let cands = candidates(512);
+    let cand_set: BTreeSet<StorePath> = cands.iter().cloned().collect();
+    let blob = make_blob(SIZE, &cands, 8);
+
+    let mut group = c.benchmark_group("ref_scan");
+    group.throughput(Throughput::Bytes(SIZE as u64));
+
+    // Vary the chunk size to exercise the boundary/overlap path at different
+    // frequencies (NAR streams arrive in fixed-size reads).
+    for chunk in [4096usize, 65536, 1024 * 1024] {
+        group.bench_with_input(BenchmarkId::new("chunk", chunk), &chunk, |b, &chunk| {
+            b.iter(|| {
+                let mut sink = RefScanSink::new(&cand_set, None);
+                for part in blob.chunks(chunk) {
+                    sink.feed(part);
+                }
+                sink.found_paths()
+            });
+        });
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, benchmark_ref_scan);
+criterion_main!(benches);

--- a/harmonia-store-ref-scan/src/lib.rs
+++ b/harmonia-store-ref-scan/src/lib.rs
@@ -175,12 +175,18 @@ fn search(data: &[u8], pending: &mut HashSet<[u8; HASH_LEN]>, seen: &mut HashSet
 
     let mut i = 0;
     while i + HASH_LEN <= data.len() {
+        // Fixed-size window: the single bounds check here lets the compiler
+        // elide the per-byte checks on `window[j]` (j < HASH_LEN) below.
+        let window: &[u8; HASH_LEN] = data[i..i + HASH_LEN]
+            .try_into()
+            .expect("slice length matches HASH_LEN");
+
         // Scan the window right-to-left for valid nix-base32 characters.
         let mut j = HASH_LEN;
         let mut invalid = false;
         while j > 0 {
             j -= 1;
-            if !NIX_BASE32_VALID[data[i + j] as usize] {
+            if !NIX_BASE32_VALID[window[j] as usize] {
                 i += j + 1;
                 invalid = true;
                 break;
@@ -192,13 +198,8 @@ fn search(data: &[u8], pending: &mut HashSet<[u8; HASH_LEN]>, seen: &mut HashSet
             continue;
         }
 
-        // All HASH_LEN characters are valid nix-base32. Check the HashSet.
-        let window: [u8; HASH_LEN] = data[i..i + HASH_LEN]
-            .try_into()
-            .expect("slice length matches HASH_LEN");
-
-        if pending.remove(&window) {
-            seen.insert(window);
+        if pending.remove(window) {
+            seen.insert(*window);
         }
 
         i += 1;

--- a/harmonia-store-ref-scan/src/lib.rs
+++ b/harmonia-store-ref-scan/src/lib.rs
@@ -177,18 +177,18 @@ fn search(data: &[u8], pending: &mut HashSet<[u8; HASH_LEN]>, seen: &mut HashSet
     while i + HASH_LEN <= data.len() {
         // Scan the window right-to-left for valid nix-base32 characters.
         let mut j = HASH_LEN;
-        loop {
-            if j == 0 {
-                break;
-            }
+        let mut invalid = false;
+        while j > 0 {
             j -= 1;
             if !NIX_BASE32_VALID[data[i + j] as usize] {
                 i += j + 1;
+                invalid = true;
                 break;
             }
         }
-        if j > 0 {
-            // Broke out early due to invalid character, already advanced i.
+        // `j` alone cannot signal this: an invalid char at j==0 leaves j==0,
+        // just like a fully-valid window.
+        if invalid {
             continue;
         }
 
@@ -332,5 +332,38 @@ mod tests {
         let candidates = BTreeSet::new();
         let refs = scan_nar_for_references(&output_dir, &candidates, Some(&self_path)).await;
         assert!(refs.contains(&self_path), "Should detect self-reference");
+    }
+}
+
+#[cfg(test)]
+mod boundary_tests {
+    use super::*;
+
+    /// An invalid nix-base32 byte just left of a hash that straddles a chunk
+    /// boundary used to overrun the overlap buffer: the leftmost-char skip
+    /// leaves j==0, which the old guard mistook for a fully-valid window.
+    #[test]
+    fn invalid_byte_before_boundary_straddling_hash() {
+        let sp = StorePath::from_base_path("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-input").unwrap();
+        let mut cands = BTreeSet::new();
+        cands.insert(sp.clone());
+        let hash = b"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+
+        // 'e' is not in the nix-base32 alphabet. Sweep every prefix length and
+        // split point so the hash lands on each possible chunk boundary.
+        for prefix in 1..=(2 * HASH_LEN) {
+            let mut data = vec![b'e'; prefix];
+            data.extend_from_slice(hash);
+
+            for split in 1..data.len() {
+                let mut sink = RefScanSink::new(&cands, None);
+                sink.feed(&data[..split]);
+                sink.feed(&data[split..]);
+                assert!(
+                    sink.found_paths().contains(&sp),
+                    "hash not found with prefix={prefix} split={split}",
+                );
+            }
+        }
     }
 }


### PR DESCRIPTION
The window scan used `j > 0` to decide whether the inner loop broke on an invalid nix-base32 char. That is wrong when the invalid char is at the leftmost position: j reaches 0 and breaks, indistinguishable from a fully-valid window, so the code sliced data[i..i + HASH_LEN] at the already-advanced i.

When a hash straddles a chunk boundary and the byte before it is not valid base32, the overlap buffer is exactly HASH_LEN * 2 and the advanced index runs one past its end, panicking the worker mid-build:

    range end index 65 out of range for slice of length 64

Record the exit reason in an explicit flag instead.