### PR TITLE
harmonia-store-remote: log daemon handshake at debug

### DIFF
--- a/harmonia-store-remote/src/client.rs
+++ b/harmonia-store-remote/src/client.rs
@@ -253,7 +253,7 @@ where
             }
             reader.set_features(features.clone());
             writer.set_features(features.clone());
-            info!(
+            debug!(
                 ?version,
                 ?server_version,
                 ?features,
@@ -278,7 +278,7 @@ where
             if version.minor() >= 33 {
                 writer.flush().await?;
                 let version = reader.read_value().await.with_field("nixVersion")?;
-                info!(version, "Nix Version {:?}", version);
+                debug!(version, "Nix Version {:?}", version);
                 daemon_nix_version = Some(version);
             }
 


### PR DESCRIPTION
The client logs the negotiated protocol version, server version, and Nix version at INFO on every connection. Callers that open a connection per RPC (e.g. Hydra's queue runner) flood the journal with these lines. They are handshake diagnostics, not per-request events, so log them at debug.