### PR TITLE
protocol: add `AddToStoreScanning` op

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -978,6 +978,7 @@ dependencies = [
  "harmonia-store-db",
  "harmonia-store-derivation",
  "harmonia-store-path",
+ "harmonia-store-remote",
  "harmonia-utils-hash",
  "harmonia-utils-io",
  "harmonia-utils-signature",

--- a/harmonia-daemon/Cargo.toml
+++ b/harmonia-daemon/Cargo.toml
@@ -26,8 +26,9 @@ tracing                        = { workspace = true }
 tracing-subscriber             = { workspace = true }
 
 [dev-dependencies]
-harmonia-utils-test = { workspace = true }
-tempfile            = { workspace = true }
+harmonia-store-remote = { workspace = true }
+harmonia-utils-test   = { workspace = true }
+tempfile              = { workspace = true }
 
 [lints]
 workspace = true

--- a/harmonia-daemon/src/server/mod.rs
+++ b/harmonia-daemon/src/server/mod.rs
@@ -36,7 +36,7 @@ use harmonia_protocol::log::LogMessage;
 use harmonia_protocol::ser::{NixWrite, NixWriter};
 use harmonia_protocol::types::{AddToStoreItem, DaemonPath};
 use harmonia_protocol::valid_path_info::ValidPathInfo;
-use harmonia_protocol::version::{FeatureSet, supported_features};
+use harmonia_protocol::version::{FEATURE_ADD_TO_STORE_SCANNING, FeatureSet, supported_features};
 use harmonia_store_content_address::ContentAddressMethodAlgorithm;
 use harmonia_store_derivation::derivation::BasicDerivation;
 use harmonia_store_derivation::derived_path::{DerivedPath, OutputName};
@@ -565,6 +565,21 @@ where
         ret
     }
 
+    fn add_to_store_scanning<'a, 'r, R>(
+        &'a mut self,
+        name: &'a str,
+        cam: ContentAddressMethodAlgorithm,
+        source: R,
+    ) -> Pin<Box<dyn ResultLog<Output = DaemonResult<ValidPathInfo>> + Send + 'r>>
+    where
+        R: AsyncBufRead + Send + Unpin + 'r,
+        'a: 'r,
+    {
+        let ret = self.0.add_to_store_scanning(name, cam, source);
+        trace!("AddToStoreScanning Size {}", size_of_val(ret.deref()));
+        ret
+    }
+
     fn shutdown(&mut self) -> impl std::future::Future<Output = DaemonResult<()>> + Send + '_ {
         let ret = Box::pin(self.0.shutdown());
         trace!("Shutdown Size {}", size_of_val(&ret));
@@ -737,6 +752,21 @@ where
         'p: 'r,
     {
         store.add_ca_to_store(name, cam, refs, repair, source)
+    }
+
+    fn add_to_store_scanning<'s, 'p, 'r, NW, S>(
+        store: &'s mut S,
+        name: &'p str,
+        cam: ContentAddressMethodAlgorithm,
+        source: NW,
+    ) -> impl ResultLog<Output = DaemonResult<ValidPathInfo>> + Send + 'r
+    where
+        S: DaemonStore + 's,
+        NW: AsyncBufRead + Unpin + Send + 'r,
+        's: 'r,
+        'p: 'r,
+    {
+        store.add_to_store_scanning(name, cam, source)
     }
 
     fn add_to_store_nar<'s, 'p, 'r, NW, S>(
@@ -1063,6 +1093,31 @@ where
             AddPermRoot(req) => {
                 let logs = store.add_perm_root(&req.store_path, &req.gc_root);
                 let value = self.process_logs(logs).await?;
+                self.writer.write_value(&value).await?;
+            }
+            AddToStoreScanning(req) => {
+                // Unlike upstream, drain the dump even on rejection so the
+                // connection stays usable.
+                let feature_negotiated = self
+                    .reader
+                    .features()
+                    .contains(FEATURE_ADD_TO_STORE_SCANNING);
+                let buf_reader = AsyncBufReadCompat::new(&mut self.reader);
+                let mut framed = FramedReader::new(buf_reader);
+                let res = if feature_negotiated {
+                    let logs =
+                        Self::add_to_store_scanning(&mut store, &req.name, req.cam, &mut framed);
+                    process_logs(&mut self.writer, logs).await
+                } else {
+                    Err(DaemonError::custom(
+                        "Adding to store with scanning was requested, but not supported in negotiated protocol",
+                    ))
+                    .recover()
+                };
+                let err = framed.drain_all().await;
+                let value = res?;
+                err?;
+                self.writer.write_value(&RawLogMessage::Last).await?;
                 self.writer.write_value(&value).await?;
             }
         }

--- a/harmonia-daemon/src/tests/add_to_store_scanning.rs
+++ b/harmonia-daemon/src/tests/add_to_store_scanning.rs
@@ -1,0 +1,179 @@
+// SPDX-License-Identifier: MIT
+
+//! Client/server tests for the `AddToStoreScanning` operation.
+//!
+//! Harmonia's daemon never advertises the `add-to-store-scanning` feature,
+//! so both sides must reject the operation gracefully.
+
+use std::future::ready;
+use std::io::Cursor;
+use std::time::Duration;
+
+use tokio::io::AsyncWriteExt as _;
+use tokio::time::timeout;
+
+use harmonia_protocol::ProtocolVersion;
+use harmonia_protocol::daemon::{
+    DaemonResult, DaemonStore, FutureResultExt as _, HandshakeDaemonStore, ResultLog,
+    wire::{CLIENT_MAGIC, SERVER_MAGIC, logger::RawLogMessage, types::Operation},
+};
+use harmonia_protocol::de::{NixRead as _, NixReader};
+use harmonia_protocol::ser::{NixWrite as _, NixWriter};
+use harmonia_protocol::types::TrustLevel;
+use harmonia_protocol::version::{FEATURE_ADD_TO_STORE_SCANNING, FeatureSet};
+use harmonia_store_content_address::ContentAddressMethodAlgorithm;
+use harmonia_store_path::StorePath;
+use harmonia_store_remote::DaemonClient;
+use harmonia_utils_hash::Algorithm;
+
+use crate::server::Builder;
+
+const TEST_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Reports every operation as unimplemented.
+#[derive(Debug)]
+struct NullStore;
+
+impl HandshakeDaemonStore for NullStore {
+    type Store = Self;
+
+    fn handshake(self) -> impl ResultLog<Output = DaemonResult<Self::Store>> + Send {
+        ready(Ok(self)).empty_logs()
+    }
+}
+
+impl DaemonStore for NullStore {
+    fn trust_level(&self) -> Option<TrustLevel> {
+        None
+    }
+
+    fn shutdown(&mut self) -> impl std::future::Future<Output = DaemonResult<()>> + Send + '_ {
+        ready(Ok(()))
+    }
+}
+
+fn spawn_server(stream: tokio::io::DuplexStream) -> tokio::task::JoinHandle<DaemonResult<()>> {
+    tokio::spawn(async move {
+        let (read, write) = tokio::io::split(stream);
+        Builder::new()
+            .serve_connection(read, write, NullStore)
+            .await
+    })
+}
+
+/// The client refuses to send the operation without the negotiated feature.
+#[tokio::test]
+async fn client_requires_negotiated_feature() {
+    timeout(TEST_TIMEOUT, async {
+        let (client_side, server_side) = tokio::io::duplex(64 * 1024);
+        let server = spawn_server(server_side);
+
+        let (read, write) = tokio::io::split(client_side);
+        let mut client = DaemonClient::builder()
+            .connect(read, write)
+            .await
+            .expect("client handshake");
+        assert!(!client.has_feature(FEATURE_ADD_TO_STORE_SCANNING));
+
+        let cam = ContentAddressMethodAlgorithm::NixArchive(Algorithm::SHA256);
+        let err = client
+            .add_to_store_scanning("example", cam, Cursor::new(&b""[..]))
+            .await
+            .expect_err("must fail without the negotiated feature");
+        assert!(
+            err.to_string().contains(FEATURE_ADD_TO_STORE_SCANNING),
+            "unexpected error: {err}"
+        );
+
+        drop(client);
+        server.await.expect("join").expect("server");
+    })
+    .await
+    .expect("test timed out");
+}
+
+/// A client that sends the operation anyway gets a recoverable error and
+/// the connection stays usable.
+#[tokio::test]
+async fn server_rejects_unnegotiated_scanning_op() {
+    timeout(TEST_TIMEOUT, async {
+        let (client_side, server_side) = tokio::io::duplex(64 * 1024);
+        let server = spawn_server(server_side);
+
+        let (read, write) = tokio::io::split(client_side);
+        let mut reader = NixReader::builder().build_buffered(read);
+        let mut writer = NixWriter::builder().build(write);
+
+        // Handshake, advertising the scanning feature ourselves.
+        writer.write_number(CLIENT_MAGIC).await.unwrap();
+        writer.flush().await.unwrap();
+        assert_eq!(reader.read_number().await.unwrap(), SERVER_MAGIC);
+        let version: ProtocolVersion = reader.read_value().await.unwrap();
+        writer.write_value(&version).await.unwrap();
+        reader.set_version(version);
+        writer.set_version(version);
+
+        let local: FeatureSet = [FEATURE_ADD_TO_STORE_SCANNING.to_owned()].into();
+        writer.write_value(&local).await.unwrap();
+        writer.flush().await.unwrap();
+        let daemon_features: FeatureSet = reader.read_value().await.unwrap();
+        assert!(
+            !daemon_features.contains(FEATURE_ADD_TO_STORE_SCANNING),
+            "daemon must not advertise the scanning feature"
+        );
+
+        writer.write_value(&false).await.unwrap(); // obsolete CPU affinity
+        writer.write_value(&false).await.unwrap(); // obsolete reserve space
+        writer.flush().await.unwrap();
+        let _nix_version: String = reader.read_value().await.unwrap();
+        let _trust: Option<TrustLevel> = reader.read_value().await.unwrap();
+
+        // Drain the store handshake's stderr stream.
+        loop {
+            match reader.read_value::<RawLogMessage>().await.unwrap() {
+                RawLogMessage::Last => break,
+                RawLogMessage::Error(err) => panic!("handshake error: {:?}", err.msg),
+                _ => {}
+            }
+        }
+
+        // Send the operation despite the failed negotiation.
+        let cam = ContentAddressMethodAlgorithm::NixArchive(Algorithm::SHA256);
+        writer
+            .write_value(&Operation::AddToStoreScanning)
+            .await
+            .unwrap();
+        writer.write_value("example").await.unwrap();
+        writer.write_value(&cam).await.unwrap();
+        writer.write_number(0).await.unwrap(); // framed stream terminator
+        writer.flush().await.unwrap();
+
+        let RawLogMessage::Error(err) = reader.read_value::<RawLogMessage>().await.unwrap() else {
+            panic!("expected an error for the unnegotiated operation");
+        };
+        let msg = String::from_utf8_lossy(&err.msg).into_owned();
+        assert!(
+            msg.contains("not supported in negotiated protocol"),
+            "unexpected error: {msg}"
+        );
+
+        // The connection must still be in sync for the next request.
+        let path = StorePath::from_bytes(b"00000000000000000000000000000000-x").unwrap();
+        writer.write_value(&Operation::IsValidPath).await.unwrap();
+        writer.write_value(&path).await.unwrap();
+        writer.flush().await.unwrap();
+
+        let RawLogMessage::Error(err) = reader.read_value::<RawLogMessage>().await.unwrap() else {
+            panic!("expected NullStore to report IsValidPath as unimplemented");
+        };
+        let msg = String::from_utf8_lossy(&err.msg).into_owned();
+        assert!(msg.contains("IsValidPath"), "unexpected error: {msg}");
+
+        // Both halves must drop or the server never sees EOF.
+        drop(reader);
+        drop(writer);
+        server.await.expect("join").expect("server");
+    })
+    .await
+    .expect("test timed out");
+}

--- a/harmonia-daemon/src/tests/mod.rs
+++ b/harmonia-daemon/src/tests/mod.rs
@@ -1,1 +1,2 @@
+mod add_to_store_scanning;
 mod sqlite_nix_store;

--- a/harmonia-protocol/src/daemon_wire/types.rs
+++ b/harmonia-protocol/src/daemon_wire/types.rs
@@ -55,6 +55,7 @@ pub enum Operation {
     AddBuildLog = 45,
     BuildPathsWithResults = 46,
     AddPermRoot = 47,
+    AddToStoreScanning = 1001,
 }
 
 impl Operation {

--- a/harmonia-protocol/src/daemon_wire/types2.rs
+++ b/harmonia-protocol/src/daemon_wire/types2.rs
@@ -148,6 +148,7 @@ pub enum Request {
     AddBuildLog(BaseStorePath),
     BuildPathsWithResults(BuildPathsRequest),
     AddPermRoot(AddPermRootRequest),
+    AddToStoreScanning(AddToStoreScanningRequest),
 }
 
 impl Request {
@@ -183,6 +184,7 @@ impl Request {
             Request::AddBuildLog(_) => Operation::AddBuildLog,
             Request::BuildPathsWithResults(_) => Operation::BuildPathsWithResults,
             Request::AddPermRoot(_) => Operation::AddPermRoot,
+            Request::AddToStoreScanning(_) => Operation::AddToStoreScanning,
         }
     }
 
@@ -278,6 +280,9 @@ impl Request {
             Request::AddPermRoot(req) => {
                 let gc_root = String::from_utf8_lossy(&req.gc_root);
                 debug_span!("AddPermRoot", path=?req.store_path, ?gc_root)
+            }
+            Request::AddToStoreScanning(req) => {
+                debug_span!("AddToStoreScanning", name=?req.name, cam=?req.cam)
             }
         }
     }
@@ -390,6 +395,15 @@ pub struct AddPermRootRequest {
     pub gc_root: DaemonPath,
 }
 
+/// Like [`AddToStoreRequest`] but without `refs`, which are instead discovered
+/// by scanning the dump.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, NixDeserialize, NixSerialize)]
+pub struct AddToStoreScanningRequest {
+    pub name: String,
+    pub cam: ContentAddressMethodAlgorithm,
+    // Framed NAR dump
+}
+
 macro_rules! optional_info {
     ($sub:ty) => {
         impl NixDeserializeTrait for Option<$sub> {
@@ -461,7 +475,6 @@ macro_rules! optional_from_str {
 }
 optional_from_str!(String);
 optional_from_str!(ContentAddress);
-optional_from_str!(ContentAddressMethodAlgorithm);
 
 impl NixDeserializeTrait for Option<Microseconds> {
     async fn try_deserialize<R>(reader: &mut R) -> Result<Option<Self>, R::Error>

--- a/harmonia-protocol/src/lib.rs
+++ b/harmonia-protocol/src/lib.rs
@@ -41,7 +41,8 @@ pub mod version;
 pub use harmonia_store_path_info::NarHash;
 
 pub use version::{
-    FEATURE_REALISATION_WITH_PATH, Feature, FeatureSet, ProtocolVersion, supported_features,
+    FEATURE_ADD_TO_STORE_SCANNING, FEATURE_REALISATION_WITH_PATH, Feature, FeatureSet,
+    ProtocolVersion, supported_features,
 };
 
 // Re-exports required by derive macros (harmonia_protocol_derive generates code using crate::store_path, etc.)

--- a/harmonia-protocol/src/store_impls.rs
+++ b/harmonia-protocol/src/store_impls.rs
@@ -648,14 +648,32 @@ nix_deserialize_remote!(#[nix(from_str)] harmonia_utils_hash::fmt::Bare<harmonia
 nix_serialize_remote!(#[nix(display)] harmonia_utils_hash::fmt::Bare<harmonia_utils_hash::fmt::Base16<crate::NarHash>>);
 
 // ContentAddressMethodAlgorithm
-nix_deserialize_remote!(
-    #[nix(from_str)]
-    harmonia_store_content_address::ContentAddressMethodAlgorithm
-);
-nix_serialize_remote!(
-    #[nix(display)]
-    harmonia_store_content_address::ContentAddressMethodAlgorithm
-);
+// The worker protocol uses the `renderWithAlgo` form, not the derivation
+// ATerm form ("r:sha256") that Display/FromStr use.
+impl crate::de::NixDeserialize for harmonia_store_content_address::ContentAddressMethodAlgorithm {
+    async fn try_deserialize<R>(reader: &mut R) -> Result<Option<Self>, R::Error>
+    where
+        R: ?Sized + crate::de::NixRead + Send,
+    {
+        use crate::de::Error;
+        if let Some(buf) = reader.try_read_bytes().await? {
+            let s = std::str::from_utf8(&buf).map_err(R::Error::invalid_data)?;
+            Self::parse_with_algo(s)
+                .map(Some)
+                .map_err(R::Error::invalid_data)
+        } else {
+            Ok(None)
+        }
+    }
+}
+impl crate::ser::NixSerialize for harmonia_store_content_address::ContentAddressMethodAlgorithm {
+    async fn serialize<W>(&self, writer: &mut W) -> Result<(), W::Error>
+    where
+        W: crate::ser::NixWrite,
+    {
+        writer.write_display(self.render_with_algo()).await
+    }
+}
 
 // StorePathHash
 nix_deserialize_remote!(

--- a/harmonia-protocol/src/types.rs
+++ b/harmonia-protocol/src/types.rs
@@ -627,6 +627,26 @@ pub trait DaemonStore: Send {
             .boxed_result()
     }
 
+    /// Add to store, scanning the dump for references.
+    ///
+    /// Only daemons serving a recursive-nix derivation builder support this.
+    fn add_to_store_scanning<'a, 'r, R>(
+        &'a mut self,
+        name: &'a str,
+        cam: ContentAddressMethodAlgorithm,
+        source: R,
+    ) -> Pin<Box<dyn ResultLog<Output = DaemonResult<ValidPathInfo>> + Send + 'r>>
+    where
+        R: AsyncBufRead + Send + Unpin + 'r,
+        'a: 'r,
+    {
+        ready(Err(DaemonError::unimplemented(
+            Operation::AddToStoreScanning,
+        )))
+        .empty_logs()
+        .boxed_result()
+    }
+
     fn shutdown(&mut self) -> impl Future<Output = DaemonResult<()>> + Send + '_;
 }
 
@@ -884,6 +904,19 @@ where
         'a: 'r,
     {
         (**self).add_ca_to_store(name, cam, refs, repair, source)
+    }
+
+    fn add_to_store_scanning<'a, 'r, R>(
+        &'a mut self,
+        name: &'a str,
+        cam: ContentAddressMethodAlgorithm,
+        source: R,
+    ) -> Pin<Box<dyn ResultLog<Output = DaemonResult<ValidPathInfo>> + Send + 'r>>
+    where
+        R: AsyncBufRead + Send + Unpin + 'r,
+        'a: 'r,
+    {
+        (**self).add_to_store_scanning(name, cam, source)
     }
 
     fn shutdown(&mut self) -> impl Future<Output = DaemonResult<()>> + Send + '_ {

--- a/harmonia-protocol/src/version.rs
+++ b/harmonia-protocol/src/version.rs
@@ -30,6 +30,12 @@ pub type FeatureSet = BTreeSet<Feature>;
 /// instead of the legacy `sha256:<hex>!out` JSON-string format.
 pub const FEATURE_REALISATION_WITH_PATH: &str = "realisation-with-path-not-hash";
 
+/// Enables the `AddToStoreScanning` operation.
+///
+/// Upstream daemons only advertise this on recursive-nix connections, so it is
+/// not in [`supported_features`] and the client adds it at handshake instead.
+pub const FEATURE_ADD_TO_STORE_SCANNING: &str = "add-to-store-scanning";
+
 /// Features harmonia advertises during handshake.
 pub fn supported_features() -> FeatureSet {
     [FEATURE_REALISATION_WITH_PATH.to_owned()].into()

--- a/harmonia-protocol/src/wire_roundtrip.rs
+++ b/harmonia-protocol/src/wire_roundtrip.rs
@@ -72,3 +72,38 @@ wire_roundtrip!(roundtrip_realisation, Realisation);
 wire_roundtrip!(roundtrip_build_result, BuildResult);
 wire_roundtrip!(roundtrip_query_missing_result, QueryMissingResult);
 wire_roundtrip!(roundtrip_derived_path, DerivedPath);
+
+#[test]
+fn roundtrip_add_to_store_scanning_request() {
+    use crate::daemon_wire::types2::{AddToStoreScanningRequest, Request};
+    use harmonia_store_content_address::ContentAddressMethodAlgorithm;
+    use harmonia_utils_hash::Algorithm;
+
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .build()
+        .unwrap();
+
+    let req = Request::AddToStoreScanning(AddToStoreScanningRequest {
+        name: "example".into(),
+        cam: ContentAddressMethodAlgorithm::NixArchive(Algorithm::SHA256),
+    });
+
+    let buf = rt.block_on(async {
+        let mut buf = Vec::new();
+        let mut w = NixWriter::builder().build(&mut buf);
+        w.write_value(&req).await.expect("write");
+        w.flush().await.expect("flush");
+        buf
+    });
+    assert_eq!(u64::from_le_bytes(buf[..8].try_into().unwrap()), 1001);
+    assert!(
+        buf.windows(14).any(|w| w == b"fixed:r:sha256"),
+        "cam must be transmitted in renderWithAlgo form"
+    );
+
+    let back: Request = rt.block_on(async {
+        let mut r = NixReader::builder().build_buffered(Cursor::new(buf));
+        r.read_value().await.expect("read")
+    });
+    assert_eq!(back, req);
+}

--- a/harmonia-store-content-address/src/types.rs
+++ b/harmonia-store-content-address/src/types.rs
@@ -91,6 +91,26 @@ impl ContentAddressMethodAlgorithm {
             ContentAddressMethodAlgorithm::NixArchive(_) => ContentAddressMethod::NixArchive,
         }
     }
+
+    /// Renders the worker protocol form.
+    pub fn render_with_algo(&self) -> String {
+        format!("{}:{}", self.method(), self.algorithm())
+    }
+
+    /// Parses the worker protocol form produced by [`Self::render_with_algo`].
+    pub fn parse_with_algo(s: &str) -> Result<Self, ParseContentAddressError> {
+        if s == "text:sha256" {
+            Ok(Self::Text)
+        } else if let Some(rest) = s.strip_prefix("fixed:") {
+            if let Some(algo) = rest.strip_prefix("r:") {
+                Ok(Self::NixArchive(algo.parse()?))
+            } else {
+                Ok(Self::Flat(rest.parse()?))
+            }
+        } else {
+            Err(ParseContentAddressError::InvalidForm(s.into()))
+        }
+    }
 }
 
 impl FromStr for ContentAddressMethodAlgorithm {
@@ -271,6 +291,45 @@ mod unittests {
 
         assert_eq!(content_address.to_string(), v);
         assert_eq!(content_address, v.parse().unwrap());
+    }
+
+    #[rstest]
+    #[case::text(ContentAddressMethodAlgorithm::Text, "text:sha256", "text:sha256")]
+    #[case::flat(
+        ContentAddressMethodAlgorithm::Flat(Algorithm::SHA256),
+        "fixed:sha256",
+        "sha256"
+    )]
+    #[case::recursive(
+        ContentAddressMethodAlgorithm::NixArchive(Algorithm::SHA256),
+        "fixed:r:sha256",
+        "r:sha256"
+    )]
+    fn method_algorithm_render_parse(
+        #[case] cama: ContentAddressMethodAlgorithm,
+        #[case] with_algo: &str,
+        #[case] aterm: &str,
+    ) {
+        assert_eq!(cama.render_with_algo(), with_algo);
+        assert_eq!(
+            ContentAddressMethodAlgorithm::parse_with_algo(with_algo).unwrap(),
+            cama
+        );
+
+        assert_eq!(cama.to_string(), aterm);
+        assert_eq!(
+            aterm.parse::<ContentAddressMethodAlgorithm>().unwrap(),
+            cama
+        );
+    }
+
+    /// The worker-protocol parser must not accept the ATerm form.
+    #[rstest]
+    #[case("r:sha256")]
+    #[case("sha256")]
+    #[case("text:sha1")]
+    fn method_algorithm_parse_with_algo_rejects(#[case] value: &str) {
+        ContentAddressMethodAlgorithm::parse_with_algo(value).unwrap_err();
     }
 
     #[rstest]

--- a/harmonia-store-remote/src/client.rs
+++ b/harmonia-store-remote/src/client.rs
@@ -41,7 +41,9 @@ use harmonia_protocol::types::{
 };
 use harmonia_protocol::valid_path_info::{UnkeyedValidPathInfo, ValidPathInfo};
 use harmonia_protocol::version::{FeatureSet, supported_features};
-use harmonia_protocol::{FEATURE_REALISATION_WITH_PATH, ProtocolVersion};
+use harmonia_protocol::{
+    FEATURE_ADD_TO_STORE_SCANNING, FEATURE_REALISATION_WITH_PATH, ProtocolVersion,
+};
 
 // From harmonia-store-derivation
 use harmonia_protocol::log::{LogMessage, Message, Verbosity};
@@ -244,7 +246,8 @@ where
             // Exchange features (protocol >= 1.38).
             let mut features = FeatureSet::new();
             if version.minor() >= 38 {
-                let local = supported_features();
+                let mut local = supported_features();
+                local.insert(FEATURE_ADD_TO_STORE_SCANNING.to_owned());
                 writer.write_value(&local).await.with_field("features")?;
                 writer.flush().await.with_field("features")?;
                 let daemon_features: FeatureSet =
@@ -996,6 +999,45 @@ where
         }
         .future_result()
         .fill_operation(Operation::AddToStore)
+        .boxed_result()
+    }
+
+    fn add_to_store_scanning<'a, 'r, S>(
+        &'a mut self,
+        name: &'a str,
+        cam: ContentAddressMethodAlgorithm,
+        source: S,
+    ) -> Pin<Box<dyn ResultLog<Output = DaemonResult<ValidPathInfo>> + Send + 'r>>
+    where
+        S: AsyncBufRead + Send + Unpin + 'r,
+        'a: 'r,
+    {
+        async move {
+            if !self.has_feature(FEATURE_ADD_TO_STORE_SCANNING) {
+                return Err(DaemonErrorKind::Custom(format!(
+                    "the daemon does not support the '{FEATURE_ADD_TO_STORE_SCANNING}' protocol feature, perhaps this is not in a recursive-nix builder?"
+                ))
+                .into());
+            }
+            self.writer
+                .write_value(&Operation::AddToStoreScanning)
+                .await?;
+            self.writer.write_value(name).await?;
+            self.writer.write_value(&cam).await?;
+            self.writer.flush().await?;
+            Ok(ProcessStderr::new(&mut self.reader)
+                .stream()
+                .drive_result(async {
+                    let mut source = source;
+                    let mut framed = FramedWriter::new(&mut self.writer);
+                    copy_buf(&mut source, &mut framed).await?;
+                    framed.shutdown().await?;
+                    self.writer.flush().await?;
+                    Ok(()) as DaemonResult<()>
+                }))
+        }
+        .future_result()
+        .fill_operation(Operation::AddToStoreScanning)
         .boxed_result()
     }
 


### PR DESCRIPTION
Harmonia's daemon plays the role of upstream's non-recursive daemon, so
only the client advertises the add-to-store-scanning feature. This also
fixes the worker protocol encoding of `ContentAddressMethodAlgorithm`,
which used the derivation ATerm form that upstream's `parseWithAlgo` rejects.