### PR TITLE
cache: set status code to 206 when responding with ranged NAR stream

### DIFF
--- a/harmonia-cache/src/nar.rs
+++ b/harmonia-cache/src/nar.rs
@@ -148,6 +148,7 @@ pub(crate) async fn get(
                 let ranged_stream = create_range_stream(stream, offset, range_length);
 
                 return Ok(res
+                    .status(http::StatusCode::PARTIAL_CONTENT)
                     .insert_header((http::header::CONTENT_TYPE, "application/x-nix-archive"))
                     .insert_header((http::header::ACCEPT_RANGES, "bytes"))
                     .insert_header(cache_control_max_age_1y())


### PR DESCRIPTION
Currently the `harmonia-cache` server can't correctly handle ranged HTTP requests for NAR files. The returned responses always use a 200 status code even if the actual data is a part of the whole NAR file. According to RFC 2616, a successful ranged HTTP response should use 206 Partial Content as its status code. In contrast, 200 is a fallback result and should only be used when the response contains the full content. Clients may not always check if the Content-Range header exists, so a 200 status code may result in unexpected truncated content.

How to reproduce:

Run `harmonia-cache` (here I choose the port 5001)

Run the following commands:

```sh
$ curl 'http://127.0.0.1:5001/q9na80xlbr9gh0607h13hmdx9ljzslng.narinfo'
StorePath: /nix/store/q9na80xlbr9gh0607h13hmdx9ljzslng-fzf-0.74.2
URL: nar/1s8g2cc3xmvrrk3w90dk2i1gv8pmvhx15qayinyrfrfznbl96zvf.nar?hash=q9na80xlbr9gh0607h13hmdx9ljzslng
Compression: none
FileHash: sha256:1s8g2cc3xmvrrk3w90dk2i1gv8pmvhx15qayinyrfrfznbl96zvf
FileSize: 5064272
NarHash: sha256:1s8g2cc3xmvrrk3w90dk2i1gv8pmvhx15qayinyrfrfznbl96zvf
NarSize: 5064272
References: 2nndxyf3phkb5aggxm3c16sapa0f49kz-tzdata-2026c 7ik8057hajl6vq9j40h3jracxjn0bb5x-bash-5.3p15 97n1jhfshhfcjmv09rq0q65k0var9ndf-bc-1.08.2 jab95mm9b2qb8ygk45l600mb2pp5xbr4-iana-etc-20251215 q9na80xlbr9gh0607h13hmdx9ljzslng-fzf-0.74.2
Deriver: 8f0z4xy5ric8ywwiplk69w2j99fcql71-fzf-0.74.2.drv
Sig: cache.nixos.org-1:pKJO4X98yMjX2bDpX0wJxyTvDnO02tb30xABDg//H0KEDNS0bu4rXW3x2vKoMLNOHdVa93eMfxud4YkfakjoCw==

$ curl -H 'Range: bytes=0-10000000' 'http://127.0.0.1:5001/nar/1s8g2cc3xmvrrk3w90dk2i1gv8pmvhx15qayinyrfrfznbl96zvf.nar?hash=q9na80xlbr9gh0607h13hmdx9ljzslng' -i
HTTP/1.1 200 OK
content-length: 5064272
content-type: application/x-nix-archive
cache-control: max-age=31536000
content-range: bytes 0-5064271/5064272
accept-ranges: bytes
date: Wed, 05 Aug 2026 13:55:14 GMT
```