### PR TITLE
harmonia-cache: enable zstd compression by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,9 +138,7 @@ max_connection_rate = 256
 # binary cache priority that is advertised in /nix-cache-info
 priority = 30
 # Whether to enable transparent compression with zstd.
-# Note that this is incompatible with resuming, so don't enable this
-# if any of your users are on a flaky connection.
-# Default: false
+# Default: true
 enable_compression = true
 
 # Allow to override the store path advertised in /nix-cache-info

--- a/flake.nix
+++ b/flake.nix
@@ -26,7 +26,6 @@
         "x86_64-linux"
         "aarch64-linux"
         "aarch64-darwin"
-        "x86_64-darwin"
       ];
 
       eachSystem =

--- a/harmonia-cache/src/config.rs
+++ b/harmonia-cache/src/config.rs
@@ -27,7 +27,7 @@ fn default_priority() -> usize {
 }
 
 fn default_enable_compression() -> bool {
-    false
+    true
 }
 
 /// zstd parameters applied to on-the-fly NAR encoding when the client sends

--- a/nix/herculesCI.nix
+++ b/nix/herculesCI.nix
@@ -11,9 +11,6 @@ let
   # Only run effect on main branch
   isMain = args.branch == "main";
 
-  # Skip x86_64-darwin for now - rustc builds are slow and often not cached
-  uploadSystems = builtins.filter (s: s != "x86_64-darwin") systems;
-
   # codecov-cli depends on test-results-parser which has an unfree license
   # Override just the license instead of using allowUnfree (expensive)
   codecov-cli = pkgs.codecov-cli.override {
@@ -27,7 +24,7 @@ let
   };
 
   # Get test outputs for all systems (list -> attrset)
-  testOutputs = lib.genAttrs uploadSystems (system: self.checks.${system}.tests);
+  testOutputs = lib.genAttrs systems (system: self.checks.${system}.tests);
 in
 {
   onPush.default.outputs.effects.uploadCodecov.run =
@@ -99,7 +96,7 @@ in
             else
               echo "No coverage file found for ${system}"
             fi
-          '') uploadSystems}
+          '') systems}
         '';
       }
     else


### PR DESCRIPTION
Serving NARs uncompressed makes substitution wire-bytes bound; compression should not require opt-in for a binary cache.