### PR TITLE
store-db: add bulk path invalidation and freelist-aware vacuum

### DIFF
--- a/harmonia-store-db/src/write.rs
+++ b/harmonia-store-db/src/write.rs
@@ -6,6 +6,7 @@
 //! These are primarily used for testing and local store management.
 
 use rusqlite::params;
+use tracing::info;
 
 use harmonia_store_path::{StoreDir, StorePath};
 
@@ -210,5 +211,126 @@ impl StoreDb {
             params![drv_path, output_name, output_path, signatures],
         )?;
         Ok(self.conn.last_insert_rowid())
+    }
+
+    /// Remove paths by their `ValidPaths.id` in a single transaction.
+    ///
+    /// Intended for bulk garbage collection. The ids come from
+    /// [`StoreGraph::db_id`](crate::StoreGraph::db_id). Reference edges
+    /// among the dead set are removed first, because cycles between dead paths would
+    /// otherwise violate the `ON DELETE RESTRICT` constraint on
+    /// `Refs.reference` (Nix avoids it by deleting one path at a time in
+    /// topological order).
+    ///
+    /// The caller must include every referrer: if some path outside `ids`
+    /// still references a path inside `ids`, the referenced path is deleted
+    /// anyway and the surviving referrer is left with a missing dependency.
+    /// Nix rejects such a deletion, this function does not detect it.
+    ///
+    /// ```
+    /// # fn main() -> harmonia_store_db::Result<()> {
+    /// use harmonia_store_db::{GraphOptions, StoreDb};
+    /// use harmonia_store_path::StoreDir;
+    ///
+    /// let db = StoreDb::open_memory()?;
+    /// let graph = db.load_graph(&StoreDir::default(), &GraphOptions::default())?;
+    /// let dead: Vec<i64> = graph.nodes().map(|n| graph.db_id(n)).collect();
+    /// db.invalidate_ids(dead)?; // everything is dead
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn invalidate_ids(&self, ids: impl IntoIterator<Item = i64>) -> Result<()> {
+        self.conn.execute_batch("BEGIN")?;
+        let result = self.invalidate_ids_in_txn(ids);
+        match result {
+            Ok(()) => {
+                self.conn.execute_batch("COMMIT")?;
+                // Truncate the WAL so its disk use doesn't accumulate across
+                // chunks. On a full disk an unbounded WAL would abort a later
+                // chunk. Best effort: a blocked checkpoint leaves the WAL for
+                // the next one.
+                let _ = self.conn.execute_batch("PRAGMA wal_checkpoint(TRUNCATE)");
+                Ok(())
+            }
+            Err(e) => {
+                self.conn.execute_batch("ROLLBACK").ok();
+                Err(e)
+            }
+        }
+    }
+
+    fn invalidate_ids_in_txn(&self, ids: impl IntoIterator<Item = i64>) -> Result<()> {
+        // A temp table lets the Refs of all dead paths be batch-deleted in
+        // two statements instead of one subquery per path.
+        self.conn
+            .execute_batch("CREATE TEMP TABLE IF NOT EXISTS DeadPaths (id INTEGER PRIMARY KEY)")?;
+        self.conn.execute_batch("DELETE FROM DeadPaths")?;
+        {
+            let mut ins = self.conn.prepare("INSERT INTO DeadPaths VALUES (?)")?;
+            for id in ids {
+                ins.execute([id])?;
+            }
+        }
+        self.conn.execute_batch(
+            "DELETE FROM Refs WHERE referrer IN (SELECT id FROM DeadPaths) \
+             OR reference IN (SELECT id FROM DeadPaths)",
+        )?;
+        // Same cycle problem for the CA realisations of Nix <= 2.34:
+        // RealisationsRefs.realisationReference is ON DELETE RESTRICT.
+        if crate::graph::has_table(&self.conn, "Realisations")? {
+            self.conn.execute_batch(
+                "DELETE FROM RealisationsRefs WHERE referrer IN \
+                     (SELECT id FROM Realisations WHERE outputPath IN \
+                         (SELECT id FROM DeadPaths)) \
+                 OR realisationReference IN \
+                     (SELECT id FROM Realisations WHERE outputPath IN \
+                         (SELECT id FROM DeadPaths)); \
+                 DELETE FROM Realisations WHERE outputPath IN \
+                     (SELECT id FROM DeadPaths)",
+            )?;
+        }
+        self.conn
+            .execute_batch("DELETE FROM ValidPaths WHERE id IN (SELECT id FROM DeadPaths)")?;
+        Ok(())
+    }
+
+    /// Run `VACUUM` if enough of the database file consists of free pages
+    /// to be worth a full rewrite: at least a quarter of the file and at
+    /// least 64 pages. Returns whether a vacuum ran.
+    ///
+    /// The caller must ensure no concurrent writer (e.g. by holding the
+    /// GC lock). Concurrent readers are fine in WAL mode.
+    pub fn maybe_vacuum(&self) -> Result<bool> {
+        let freelist: i64 = self
+            .conn
+            .query_row("PRAGMA freelist_count", [], |r| r.get(0))?;
+        let pages: i64 = self.conn.query_row("PRAGMA page_count", [], |r| r.get(0))?;
+        if !vacuum_worthwhile(freelist, pages) {
+            return Ok(false);
+        }
+        info!("vacuuming database ({freelist} of {pages} pages free)...");
+        let start = std::time::Instant::now();
+        self.conn.execute_batch("VACUUM")?;
+        let _ = self.conn.execute_batch("PRAGMA wal_checkpoint(TRUNCATE)");
+        info!("vacuum done in {:.1}s", start.elapsed().as_secs_f64());
+        Ok(true)
+    }
+}
+
+/// At least a quarter of the file and at least 64 pages must be free.
+fn vacuum_worthwhile(freelist: i64, pages: i64) -> bool {
+    freelist >= 64 && freelist * 4 >= pages
+}
+
+#[cfg(test)]
+mod tests {
+    use super::vacuum_worthwhile;
+
+    #[test]
+    fn vacuum_thresholds() {
+        assert!(!vacuum_worthwhile(63, 1), "below absolute minimum");
+        assert!(vacuum_worthwhile(64, 256), "exactly a quarter free");
+        assert!(!vacuum_worthwhile(64, 257), "just under a quarter free");
+        assert!(vacuum_worthwhile(1000, 1000), "mostly free");
     }
 }

--- a/harmonia-store-db/tests/graph.rs
+++ b/harmonia-store-db/tests/graph.rs
@@ -53,6 +53,12 @@ fn refs_of(g: &StoreGraph, node: NodeIdx) -> Vec<NodeIdx> {
     refs
 }
 
+fn count(db: &StoreDb, table: &str) -> i64 {
+    db.connection()
+        .query_row(&format!("SELECT COUNT(*) FROM {table}"), [], |r| r.get(0))
+        .unwrap()
+}
+
 #[test]
 fn load_graph_builds_csr() {
     let (db, sd) = setup();
@@ -192,6 +198,90 @@ fn load_graph_build_trace_edges() {
 }
 
 #[test]
+fn invalidate_ids_handles_ref_cycles() {
+    let (db, sd) = setup();
+    let a = add_path(&db, &format!("{H1}-a"), 1, 1);
+    let b = add_path(&db, &format!("{H2}-b"), 1, 1);
+    add_path(&db, &format!("{H3}-c"), 1, 1);
+    // Cycle between the two dead paths. The FK on delete restrict would
+    // reject row-by-row deletion.
+    add_ref(&db, a, b);
+    add_ref(&db, b, a);
+
+    // Resolve rowids through the graph like a GC would, so db_id() is
+    // exercised against the real ValidPaths ids.
+    let g = db.load_graph(&sd, &NO_KEEP).unwrap();
+    let dead: Vec<i64> = ["-a", "-b"]
+        .iter()
+        .map(|s| g.db_id(idx_of(&g, s)))
+        .collect();
+    assert_eq!(dead, vec![a, b]);
+    db.invalidate_ids(dead).unwrap();
+
+    let remaining = db.query_all_valid_paths(&sd).unwrap();
+    assert_eq!(remaining.len(), 1);
+    assert!(remaining[0].to_string().ends_with("-c"));
+    assert_eq!(count(&db, "Refs"), 0);
+}
+
+#[test]
+fn invalidate_ids_cascades_derivation_outputs() {
+    let (db, _) = setup();
+    let drv = add_path(&db, &format!("{H1}-pkg.drv"), 1, 1);
+    add_path(&db, &format!("{H2}-pkg"), 1, 1);
+    db.connection()
+        .execute(
+            "INSERT INTO DerivationOutputs (drv, id, path) VALUES (?, 'out', ?)",
+            rusqlite::params![drv, full(&format!("{H2}-pkg"))],
+        )
+        .unwrap();
+
+    db.invalidate_ids([drv]).unwrap();
+
+    assert_eq!(count(&db, "DerivationOutputs"), 0);
+}
+
+#[test]
+fn invalidate_ids_clears_realisations_with_restrict_fk() {
+    // Nix <= 2.34 CA schema: RealisationsRefs.realisationReference is ON
+    // DELETE RESTRICT. Bulk-deleting two dead paths whose realisations
+    // reference each other must not trip the constraint.
+    let (db, _) = setup();
+    db.connection()
+        .execute_batch(
+            "CREATE TABLE Realisations (
+                 id integer primary key autoincrement not null,
+                 drvPath text not null,
+                 outputName text not null,
+                 outputPath integer not null references ValidPaths(id) on delete cascade,
+                 signatures text
+             );
+             CREATE TABLE RealisationsRefs (
+                 referrer integer not null,
+                 realisationReference integer,
+                 foreign key (referrer) references Realisations(id) on delete cascade,
+                 foreign key (realisationReference) references Realisations(id) on delete restrict
+             );",
+        )
+        .unwrap();
+    let a = add_path(&db, &format!("{H1}-a"), 1, 1);
+    let b = add_path(&db, &format!("{H2}-b"), 1, 1);
+    db.connection()
+        .execute_batch(&format!(
+            "INSERT INTO Realisations (drvPath, outputName, outputPath) \
+                 VALUES ('sha256:a!out', 'out', {a}), ('sha256:b!out', 'out', {b});
+             INSERT INTO RealisationsRefs (referrer, realisationReference) VALUES (1, 2);"
+        ))
+        .unwrap();
+
+    db.invalidate_ids([a, b]).unwrap();
+
+    for table in ["Realisations", "RealisationsRefs", "ValidPaths"] {
+        assert_eq!(count(&db, table), 0, "{table} not cleared");
+    }
+}
+
+#[test]
 fn basename_index_lookups() {
     let (db, sd) = setup();
     add_path(&db, &format!("{H1}-a"), 1, 1);
@@ -225,6 +315,41 @@ fn compute_closure_marks_reachable_only() {
     assert!(!closure.is_empty());
     assert!(closure.contains(ia));
     assert!(!closure.contains(ic));
+}
+
+#[test]
+fn maybe_vacuum_skips_small_freelist() {
+    let (db, _) = setup();
+    add_path(&db, &format!("{H1}-a"), 1, 1);
+    assert!(!db.maybe_vacuum().unwrap());
+}
+
+#[test]
+fn maybe_vacuum_runs_after_bulk_delete() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = StoreDb::open(
+        dir.path().join("db.sqlite"),
+        harmonia_store_db::OpenMode::Create,
+    )
+    .unwrap();
+    db.create_schema().unwrap();
+    // Fill and empty the database so most pages end up on the freelist.
+    let filler = "x".repeat(4096);
+    for i in 0..500 {
+        db.connection()
+            .execute(
+                "INSERT INTO ValidPaths (path, hash, registrationTime) VALUES (?, ?, 1)",
+                rusqlite::params![format!("/nix/store/{H1}-{i}"), filler],
+            )
+            .unwrap();
+    }
+    db.connection()
+        .execute_batch("DELETE FROM ValidPaths")
+        .unwrap();
+
+    assert!(db.maybe_vacuum().unwrap());
+    // The rewrite returned the free pages. A second vacuum is not worth it.
+    assert!(!db.maybe_vacuum().unwrap());
 }
 
 #[test]


### PR DESCRIPTION
Nix deletes garbage one path at a time, in topological order. That is
the safe thing to do when you look at one path in isolation, but it is
slow. Since the previous commit gives us all ValidPaths rowids up
front, we can take a shortcut here. We first delete the reference
edges of every dead path in one batch. After that, no cycle between
dead paths can trip the ON DELETE RESTRICT constraint on Refs anymore,
and the rows themselves go away in a single transaction.

I also checkpoint the WAL after every chunk. Without that, a big
collection on an almost-full disk can fail halfway through because the
WAL itself eats the remaining space.

maybe_vacuum() gives the freed pages back to the filesystem. A VACUUM
rewrites the whole database, so it only runs when it is actually worth
it: at least a quarter of the file and at least 64 pages must be
free.