### PR TITLE
store-gc: add crate skeleton for garbage collection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1183,6 +1183,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "harmonia-store-gc"
+version = "3.2.0"
+dependencies = [
+ "foldhash",
+ "harmonia-store-db",
+ "harmonia-store-fs",
+ "harmonia-store-path",
+ "nix",
+ "rusqlite",
+ "tempfile",
+ "thiserror",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "harmonia-store-nar-info"
 version = "3.2.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ members = [
     "harmonia-store-ref-scan",
     "harmonia-store-db",
     "harmonia-store-fs",
+    "harmonia-store-gc",
     "harmonia-store-path",
     "harmonia-utils-signature",
     "harmonia-store-nar-info",
@@ -46,6 +47,14 @@ async-stream = "0.3"
 blake3 = "1.8"
 bstr = "1.11"
 bytes = "1.11"
+clap = { version = "4", default-features = false, features = [
+    "std",
+    "help",
+    "usage",
+    "error-context",
+    "suggestions",
+    "derive",
+] }
 data-encoding = "2.11"
 derive_more = { version = "2.1", features = [ "display" ] }
 ed25519-dalek = "3.0.0-rc.0"
@@ -57,10 +66,21 @@ getrandom = "0.4"
 libc = "0.2"
 md5 = "0.8"
 memchr = "2"
-nix = { version = "0.31", features = [ "signal", "mman", "fs", "user", "mount", "sched" ] }
+nix = { version = "0.31", features = [
+    "signal",
+    "mman",
+    "fs",
+    "user",
+    "dir",
+    "mount",
+    "sched",
+    "socket",
+    "poll",
+] }
 num_enum = "0.7"
 pin-project-lite = "0.2"
 prometheus = { version = "0.14", default-features = false }
+rayon = "1"
 rusqlite = { version = "0.40", features = [ "bundled" ] }
 serde = { version = "1.0", features = [ "derive" ] }
 serde_json = "1.0"
@@ -84,6 +104,7 @@ tokio-util = "0.7"
 toml = "1.1"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = [ "env-filter" ] }
+walkdir = "2"
 
 # Proc-macro toolkit (harmonia-protocol-derive)
 proc-macro2 = "1.0"
@@ -109,6 +130,7 @@ harmonia-store-content-address = { path = "harmonia-store-content-address" }
 harmonia-store-db              = { path = "harmonia-store-db" }
 harmonia-store-derivation      = { path = "harmonia-store-derivation" }
 harmonia-store-fs              = { path = "harmonia-store-fs" }
+harmonia-store-gc              = { path = "harmonia-store-gc" }
 harmonia-store-nar-info        = { path = "harmonia-store-nar-info" }
 harmonia-store-path            = { path = "harmonia-store-path" }
 harmonia-store-path-info       = { path = "harmonia-store-path-info" }

--- a/docs/architecture/harmonia-store-structure.md
+++ b/docs/architecture/harmonia-store-structure.md
@@ -130,6 +130,8 @@ graph BT
     protocol --> store-aterm
     protocol --> store-build-result
     protocol --> store-path-info
+    store-gc --> store-db
+    store-gc --> store-fs
     daemon --> protocol
     daemon --> store-db
     store-remote --> protocol

--- a/harmonia-store-gc/Cargo.toml
+++ b/harmonia-store-gc/Cargo.toml
@@ -1,0 +1,29 @@
+# SPDX-FileCopyrightText: 2026 Jörg Thalheim
+# SPDX-License-Identifier: MIT
+
+[package]
+name                 = "harmonia-store-gc"
+version.workspace    = true
+authors.workspace    = true
+edition.workspace    = true
+license.workspace    = true
+homepage.workspace   = true
+repository.workspace = true
+description          = "Garbage collection for the Nix store"
+
+[dependencies]
+foldhash            = { workspace = true }
+harmonia-store-db   = { workspace = true }
+harmonia-store-fs   = { workspace = true }
+harmonia-store-path = { workspace = true }
+nix                 = { workspace = true }
+thiserror           = { workspace = true }
+tracing             = { workspace = true }
+tracing-subscriber  = { workspace = true }
+
+[dev-dependencies]
+rusqlite = { workspace = true }
+tempfile = { workspace = true }
+
+[lints]
+workspace = true

--- a/harmonia-store-gc/src/error.rs
+++ b/harmonia-store-gc/src/error.rs
@@ -1,0 +1,134 @@
+// SPDX-FileCopyrightText: 2026 Jörg Thalheim
+// SPDX-License-Identifier: MIT
+
+//! Error types for store garbage collection.
+
+use std::path::PathBuf;
+
+use thiserror::Error;
+
+/// Result type for store garbage collection.
+pub type Result<T> = std::result::Result<T, Error>;
+
+/// Errors that can occur during garbage collection.
+#[derive(Debug, Error)]
+pub enum Error {
+    /// Store database operation failed
+    #[error(transparent)]
+    Db(#[from] harmonia_store_db::Error),
+
+    /// The store filesystem layout could not be resolved
+    #[error(transparent)]
+    StoreFs(#[from] harmonia_store_fs::Error),
+
+    /// The configured store dir matches nothing in the database.
+    /// Proceeding would make every path look dead and wipe the store.
+    #[error(
+        "store dir {store_dir} does not match any path in the Nix database \
+         (e.g. {example}), refusing to collect garbage"
+    )]
+    StoreDirMismatch { store_dir: PathBuf, example: String },
+
+    /// Opening or acquiring the exclusive `gc.lock` failed. This is the
+    /// lock Nix and this crate use to serialize garbage collections
+    /// against each other and against builders registering roots.
+    #[error("GC lock {path}: {source}")]
+    GcLock {
+        path: PathBuf,
+        source: std::io::Error,
+    },
+
+    /// Scanning a GC roots directory failed. Skipping it could hide
+    /// live roots and delete paths that are still in use.
+    #[error("scanning roots in {dir}: {source}")]
+    ScanRoots {
+        dir: PathBuf,
+        #[source]
+        source: Box<Error>,
+    },
+
+    /// Reading a directory failed
+    #[error("reading directory {path}: {source}")]
+    ReadDir {
+        path: PathBuf,
+        source: std::io::Error,
+    },
+
+    /// stat() on a path failed
+    #[error("stat {path}: {source}")]
+    Stat {
+        path: PathBuf,
+        source: std::io::Error,
+    },
+
+    /// readlink() on a path failed
+    #[error("readlink {path}: {source}")]
+    ReadLink {
+        path: PathBuf,
+        source: std::io::Error,
+    },
+
+    /// Opening or reading a temp roots file failed
+    #[error("temp roots file {path}: {source}")]
+    TempRootFile {
+        path: PathBuf,
+        source: std::io::Error,
+    },
+
+    /// Writing to this process's own temp roots file failed
+    #[error("writing temp root: {source}")]
+    TempRootWrite { source: std::io::Error },
+
+    /// Connecting or talking to a running GC's socket failed
+    #[error("gc-socket {path}: {source}")]
+    GcSocketClient {
+        path: PathBuf,
+        source: std::io::Error,
+    },
+
+    /// Creating the gc-socket directory or socket failed
+    #[error("serving gc-socket at {path}: {source}")]
+    GcSocketServe {
+        path: PathBuf,
+        source: std::io::Error,
+    },
+
+    /// Spawning a GC worker thread failed
+    #[error("spawning {name} thread: {source}")]
+    SpawnThread {
+        name: &'static str,
+        source: std::io::Error,
+    },
+
+    /// A gc-socket client sent an over-long line. Store paths are short,
+    /// and the socket is world-writable like Nix's, so an unbounded line
+    /// could only be an attempt to exhaust the collector's memory.
+    #[error("gc-socket: line too long")]
+    LineTooLong,
+
+    /// Reading from or writing to a gc-socket client failed
+    #[error("gc-socket client: {source}")]
+    ClientIo { source: std::io::Error },
+
+    /// Opening or acquiring a profile lock failed
+    #[error("profile lock {path}: {source}")]
+    ProfileLock {
+        path: PathBuf,
+        source: std::io::Error,
+    },
+
+    /// A time spec like "30d" could not be parsed
+    #[error("invalid time spec '{spec}': {reason}")]
+    TimeSpec { spec: String, reason: String },
+
+    /// Writing the dry-run report to stdout failed
+    #[error("writing report: {source}")]
+    Report { source: std::io::Error },
+
+    /// Deleting a store path failed
+    #[error("removing {path}: {source}")]
+    Remove {
+        path: PathBuf,
+        source: std::io::Error,
+    },
+}

--- a/harmonia-store-gc/src/lib.rs
+++ b/harmonia-store-gc/src/lib.rs
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: 2026 Jörg Thalheim
+// SPDX-License-Identifier: MIT
+
+//! Garbage collection for the Nix store.
+//!
+//! A faster drop-in replacement for `nix-collect-garbage`. Instead of one
+//! SQLite query per store path, the reference graph is loaded once into
+//! memory (see [`harmonia_store_db::StoreGraph`]) and liveness is computed
+//! as a graph closure. Deletion runs in parallel.
+//!
+//! The crate speaks the same on-disk protocols as Nix itself. It takes
+//! the same `gc.lock`, honors the temp-root files that running builds
+//! register, and serves the `gc-socket` that builders use to protect new
+//! paths while a collection is in progress. Running it next to a busy
+//! nix-daemon is safe.
+//!
+//! Entry point: [`gc::collect_garbage`] with a [`store::GcStore`].
+
+mod error;
+pub mod store;
+
+pub use error::{Error, Result};
+
+/// Hash map keyed by store path strings.
+///
+/// SipHash showed up in GC profiles when hashing millions of ~50-char
+/// store paths, so foldhash is used instead.
+pub type HashMap<K, V> = std::collections::HashMap<K, V, foldhash::fast::RandomState>;
+/// Hash set counterpart of [`HashMap`].
+pub type HashSet<K> = std::collections::HashSet<K, foldhash::fast::RandomState>;

--- a/harmonia-store-gc/src/store.rs
+++ b/harmonia-store-gc/src/store.rs
@@ -1,0 +1,73 @@
+// SPDX-FileCopyrightText: 2026 Jörg Thalheim
+// SPDX-License-Identifier: MIT
+
+//! Store handle for garbage collection.
+
+use std::path::Path;
+
+use harmonia_store_db::{OpenMode, StoreDb};
+use harmonia_store_fs::StoreLayout;
+
+use crate::error::Result;
+
+/// A store database opened for garbage collection, plus its on-disk
+/// layout.
+///
+/// The constructors guarantee the connection is configured for GC use:
+/// [`GcStore::open`] installs a busy handler and switches to WAL before
+/// any write, [`GcStore::open_read_only`] takes no write lock at all.
+///
+/// ```no_run
+/// # fn main() -> harmonia_store_gc::Result<()> {
+/// use std::path::Path;
+/// use harmonia_store_gc::store::GcStore;
+///
+/// let store = GcStore::open(Path::new("/nix/store"), Path::new("/nix/var/nix"))?;
+/// # Ok(())
+/// # }
+/// ```
+pub struct GcStore {
+    /// The store database at `state_dir/db/db.sqlite`.
+    pub db: StoreDb,
+    /// Where the store lives on disk.
+    pub layout: StoreLayout,
+}
+
+impl GcStore {
+    /// Open the store database read-write, as needed for an actual
+    /// collection.
+    pub fn open(store_dir: &Path, state_dir: &Path) -> Result<Self> {
+        Self::open_with_mode(store_dir, state_dir, false)
+    }
+
+    /// Open the store database read-only, for dry runs. No journal-mode
+    /// flip, no write lock. This also works on a read-only filesystem.
+    pub fn open_read_only(store_dir: &Path, state_dir: &Path) -> Result<Self> {
+        Self::open_with_mode(store_dir, state_dir, true)
+    }
+
+    fn open_with_mode(store_dir: &Path, state_dir: &Path, read_only: bool) -> Result<Self> {
+        let layout = StoreLayout::new(store_dir, state_dir)?;
+        let db_path = layout.db_path();
+        let db = if read_only {
+            StoreDb::open_readonly(&db_path)?
+        } else {
+            let db = StoreDb::open(&db_path, OpenMode::ReadWrite)?;
+            configure_for_gc(&db)?;
+            db
+        };
+        Ok(GcStore { db, layout })
+    }
+}
+
+/// Prepare the connection for GC writes.
+fn configure_for_gc(db: &StoreDb) -> Result<()> {
+    let conn = db.connection();
+    // Install the busy handler first: the journal-mode flip takes a write
+    // lock and would otherwise fail instantly while the daemon writes.
+    conn.busy_timeout(std::time::Duration::from_secs(60))
+        .map_err(harmonia_store_db::Error::from)?;
+    conn.pragma_update(None, "journal_mode", "WAL")
+        .map_err(harmonia_store_db::Error::from)?;
+    Ok(())
+}

--- a/scripts/dependency-diagram.py
+++ b/scripts/dependency-diagram.py
@@ -141,6 +141,7 @@ def generate_mermaid(
     STORE_IMPURE = {
         "store-db",
         "store-fs",
+        "store-gc",
         "store-remote",
     }
     # Store crates that are I/O-free (whitelist — included in the pure group).


### PR DESCRIPTION
harmonia-store-gc is a garbage collector for the Nix store, designed
to work both as a library, because the daemon will call into it
later, and as a standalone CLI.

Nothing in here collects garbage yet. GcStore bundles an open store
database with the directory layout around it, since everything the
collector does needs both. Policy stays out of the library: reading
nix.conf and remounting a read-only store are left to the caller.