### PR TITLE
store-gc: add the garbage collector core

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1198,6 +1198,7 @@ dependencies = [
  "thiserror",
  "tracing",
  "tracing-subscriber",
+ "walkdir",
 ]
 
 [[package]]

--- a/harmonia-store-gc/Cargo.toml
+++ b/harmonia-store-gc/Cargo.toml
@@ -22,6 +22,7 @@ rayon               = { workspace = true }
 thiserror           = { workspace = true }
 tracing             = { workspace = true }
 tracing-subscriber  = { workspace = true }
+walkdir             = { workspace = true }
 
 [dev-dependencies]
 rusqlite = { workspace = true }

--- a/harmonia-store-gc/src/error.rs
+++ b/harmonia-store-gc/src/error.rs
@@ -121,10 +121,6 @@ pub enum Error {
     #[error("invalid time spec '{spec}': {reason}")]
     TimeSpec { spec: String, reason: String },
 
-    /// Writing the dry-run report to stdout failed
-    #[error("writing report: {source}")]
-    Report { source: std::io::Error },
-
     /// Deleting a store path failed
     #[error("removing {path}: {source}")]
     Remove {

--- a/harmonia-store-gc/src/gc.rs
+++ b/harmonia-store-gc/src/gc.rs
@@ -1,0 +1,818 @@
+// SPDX-FileCopyrightText: 2026 Jörg Thalheim
+// SPDX-License-Identifier: MIT
+
+//! Garbage collection: liveness computation and store path deletion.
+
+use std::env;
+use std::ffi::OsString;
+use std::fs;
+use std::io::{self, ErrorKind};
+use std::os::unix::fs::{MetadataExt, OpenOptionsExt, PermissionsExt};
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use harmonia_store_db::{BasenameIndex, Closure, GraphOptions, NodeIdx, StoreGraph};
+use nix::fcntl::{Flock, FlockArg};
+use rayon::prelude::*;
+use tracing::{debug, info, warn};
+
+use crate::error::{Error, Result};
+use crate::gc_socket::{GcSocketServer, LiveSet};
+use crate::roots::find_roots;
+use crate::store::GcStore;
+use crate::temp_roots::find_temp_roots;
+
+/// Delete a store path from disk, returning bytes freed.
+///
+/// Store paths are read-only on disk, so directories are made writable
+/// before removal, mirroring Nix's `deletePath`.
+fn delete_store_path(real_path: &Path) -> Result<u64> {
+    let meta = match fs::symlink_metadata(real_path) {
+        Ok(m) => m,
+        // Already gone: another process won the race.
+        Err(e) if e.kind() == ErrorKind::NotFound => return Ok(0),
+        Err(source) => {
+            return Err(Error::Stat {
+                path: real_path.to_owned(),
+                source,
+            });
+        }
+    };
+
+    if !meta.file_type().is_dir() {
+        let bytes = meta.blocks() * 512;
+        fs::remove_file(real_path).map_err(|source| Error::Remove {
+            path: real_path.to_owned(),
+            source,
+        })?;
+        return Ok(bytes);
+    }
+
+    let mut bytes_freed = 0u64;
+    // chmod and retry on permission errors; keep going on failure so one
+    // bad entry does not leave the rest behind, but report it at the end.
+    let mut last_err = None;
+    for entry in walkdir::WalkDir::new(real_path).contents_first(true) {
+        let entry = match entry {
+            Ok(e) => e,
+            Err(e) => {
+                if let Some(parent) = e.path().and_then(Path::parent) {
+                    let _ = fs::set_permissions(parent, fs::Permissions::from_mode(0o755));
+                }
+                last_err = Some((
+                    e.path().unwrap_or(real_path).to_owned(),
+                    e.into_io_error()
+                        .unwrap_or_else(|| io::Error::other("walkdir loop")),
+                ));
+                continue;
+            }
+        };
+        let p = entry.path();
+        if let Ok(m) = entry.metadata() {
+            bytes_freed += m.blocks() * 512;
+        }
+        let remove = |p: &Path| {
+            if entry.file_type().is_dir() {
+                fs::remove_dir(p)
+            } else {
+                fs::remove_file(p)
+            }
+        };
+        if remove(p).is_err() {
+            // Removal needs write permission on the parent, not on p.
+            if let Some(parent) = p.parent() {
+                let _ = fs::set_permissions(parent, fs::Permissions::from_mode(0o755));
+            }
+            if let Err(e) = remove(p) {
+                last_err = Some((p.to_owned(), e));
+            }
+        }
+    }
+
+    match last_err {
+        Some((path, source)) => Err(Error::Remove { path, source }),
+        None => Ok(bytes_freed),
+    }
+}
+
+/// Lock a `tmp-*` build dir before deleting. `None` means a builder
+/// still holds it. The caller keeps the fd through deletion to avoid a
+/// TOCTOU race.
+fn try_lock_dir(path: &Path) -> Option<Flock<fs::File>> {
+    // O_NONBLOCK: a stray FIFO named tmp-* must not block open() forever
+    // while we hold the exclusive gc.lock.
+    let f = match fs::OpenOptions::new()
+        .read(true)
+        .custom_flags(nix::libc::O_NONBLOCK)
+        .open(path)
+    {
+        Ok(f) => f,
+        Err(e) => {
+            if e.kind() != ErrorKind::NotFound {
+                warn!("cannot open {} for locking: {e}", path.display());
+            }
+            return None;
+        }
+    };
+    Flock::lock(f, FlockArg::LockExclusiveNonblock).ok()
+}
+
+/// Take the same lock Nix takes. Builders hold it shared while
+/// registering temp roots. We take it exclusive so the root set cannot
+/// change under us.
+fn acquire_gc_lock(state_dir: &Path) -> Result<Flock<fs::File>> {
+    let lock_path = state_dir.join("gc.lock");
+    let lock_err = |source| Error::GcLock {
+        path: lock_path.clone(),
+        source,
+    };
+    // 0600 like Nix: a world-readable lock would let any local user
+    // flock it and block GC and builders indefinitely.
+    let f = fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .mode(0o600)
+        .open(&lock_path)
+        .map_err(lock_err)?;
+
+    match Flock::lock(f, FlockArg::LockExclusiveNonblock) {
+        Ok(lock) => Ok(lock),
+        Err((f, _)) => {
+            info!("waiting for the big garbage collector lock...");
+            Flock::lock(f, FlockArg::LockExclusive).map_err(|(_, e)| lock_err(e.into()))
+        }
+    }
+}
+
+/// Tuning knobs for one garbage collection run.
+pub struct GcOptions {
+    /// Which liveness edges the reference graph should include.
+    pub graph_options: GraphOptions,
+    /// Report what would be deleted without touching anything.
+    pub dry_run: bool,
+    /// Stop after freeing this many bytes.
+    pub max_freed: Option<u64>,
+    /// Keep paths registered at or after this time.
+    pub keep_recent_after: Option<SystemTime>,
+    /// Run VACUUM after deletion. Disable on busy builders, where
+    /// concurrent readers keep the VACUUM's database-sized WAL from
+    /// being truncated.
+    pub vacuum: bool,
+    /// Max dead paths invalidated per database transaction. Smaller keeps
+    /// the WAL lower, larger means fewer checkpoints.
+    pub chunk_size: usize,
+    /// Extra directories scanned for GC roots. Nix only scans its fixed
+    /// state dirs, so roots outside them would go uncounted.
+    pub extra_gc_roots_dirs: Vec<PathBuf>,
+}
+
+impl Default for GcOptions {
+    fn default() -> Self {
+        Self {
+            graph_options: GraphOptions::default(),
+            dry_run: false,
+            max_freed: None,
+            keep_recent_after: None,
+            vacuum: true,
+            chunk_size: 65_536,
+            extra_gc_roots_dirs: Vec::new(),
+        }
+    }
+}
+
+/// Result of a garbage collection run.
+///
+/// In a dry run `bytes_freed` is the estimated NAR size of `would_delete`
+/// and `paths_deleted` is its length.
+#[derive(Debug, Clone, Default)]
+pub struct GcReport {
+    /// Bytes freed on disk, including hard-link savings reclaimed from
+    /// `.links`.
+    pub bytes_freed: u64,
+    /// Number of store paths deleted.
+    pub paths_deleted: u64,
+    /// Dry run only: full store paths that would be deleted.
+    pub would_delete: Vec<String>,
+}
+
+/// Collect garbage: find roots, compute the alive closure, delete dead
+/// paths.
+///
+/// Interoperates with running builds throughout: the exclusive `gc.lock`
+/// is held, temp roots are honored, and new roots arriving over the
+/// gc-socket are protected before their closure is touched.
+///
+/// The store directory must be writable. On NixOS, where /nix/store is
+/// bind-mounted read-only, the caller has to remount it first (see the
+/// harmonia-gc binary).
+pub fn collect_garbage(store: &GcStore, opts: &GcOptions) -> Result<GcReport> {
+    let dry_run = opts.dry_run;
+    let max_freed = opts.max_freed;
+
+    // Free the reserved space file first. On a 100% full disk the SQLite
+    // invalidation needs room to write before anything was unlinked.
+    if !dry_run {
+        let reserved = store.layout.state_dir().join("db/reserved");
+        match fs::remove_file(&reserved) {
+            Ok(()) => {}
+            Err(e) if e.kind() == ErrorKind::NotFound => {}
+            Err(e) => warn!("cannot remove {}: {e}", reserved.display()),
+        }
+    }
+
+    let _gc_lock = acquire_gc_lock(store.layout.state_dir())?;
+
+    // Serve the gc-socket immediately after taking the lock, like Nix:
+    // builders that lost the shared-lock race retry connecting every
+    // 100ms, so the socket must exist before the potentially long graph
+    // load, and during dry runs, which hold the lock too.
+    //
+    // Phase 1: no graph yet, so every received root is acked instantly
+    // and recorded by basename. That is sound because nothing can be
+    // deleted before the graph exists. The roots are replayed below.
+    let store_prefix = format!("{}/", store.layout.store_dir().to_str());
+    let early_live = Arc::new(LiveSet::new(0));
+    // A dry run on a read-only state dir can still report. Without the
+    // socket no builder can run anyway (they need temproots).
+    let start_socket = |live: Arc<LiveSet>, graph: Arc<StoreGraph>| -> Result<_> {
+        match GcSocketServer::start(store.layout.state_dir(), live, graph) {
+            Ok(s) => Ok(Some(s)),
+            Err(e) if dry_run => {
+                warn!("cannot serve gc-socket: {e}");
+                Ok(None)
+            }
+            Err(e) => Err(e),
+        }
+    };
+    let early_socket = start_socket(
+        Arc::clone(&early_live),
+        Arc::new(StoreGraph::empty(store_prefix.clone())),
+    )?;
+
+    // Test sync point: block until the named fifo is readable, so tests
+    // can deterministically exercise the early-socket window.
+    if let Ok(p) = env::var("_HARMONIA_GC_TEST_SYNC_EARLY") {
+        let _ = fs::read(&p);
+    }
+
+    info!("loading store graph...");
+    let graph = Arc::new(
+        store
+            .db
+            .load_graph(store.layout.store_dir(), &opts.graph_options)?,
+    );
+    info!("{} total valid paths", graph.len());
+
+    // Phase 2: swap to the real server. Builders whose connection drops
+    // during the swap reconnect (Nix's addTempRoot restart loop).
+    drop(early_socket);
+    let early_roots = early_live.protected_unknown_snapshot();
+    let live = Arc::new(LiveSet::new(graph.len()));
+    let _gc_socket = start_socket(Arc::clone(&live), Arc::clone(&graph))?;
+
+    let bidx = BasenameIndex::new(&graph);
+
+    // Replay phase-1 roots: known paths become ordinary GC roots (their
+    // closure stays alive), unknown basenames stay protected.
+    let mut early_root_nodes: Vec<NodeIdx> = Vec::new();
+    for b in &early_roots {
+        match bidx.get_basename(b) {
+            Some(n) => early_root_nodes.push(n),
+            None => live.protect_unknown_basename(b),
+        }
+    }
+
+    // A --store-dir that does not match the DB contents would make every
+    // root lookup miss and every DB path look dead, wiping the store.
+    if !graph.is_empty() && bidx.is_empty() {
+        let first = graph.nodes().next().expect("graph is non-empty");
+        return Err(Error::StoreDirMismatch {
+            store_dir: store.layout.store_dir().to_path().to_owned(),
+            example: graph.path(first).to_owned(),
+        });
+    }
+
+    info!("finding garbage collector roots...");
+    let mut roots = find_roots(&store.layout, &opts.extra_gc_roots_dirs, &bidx)?;
+    roots.extend(early_root_nodes);
+
+    // Add temp roots. Some may reference paths registered after our graph
+    // snapshot (a builder can register paths while we hold gc.lock as
+    // long as it wrote its temp root before we acquired it). Track those
+    // by basename so the unknown-on-disk scan won't delete them.
+    let mut temp_root_basenames: crate::HashSet<String> = crate::HashSet::default();
+    // Nix matches temp roots by hash part so that sibling files of an
+    // active build (`<path>.lock`, `<path>.chroot`, `<path>.check`) are
+    // protected too.
+    let mut temp_root_hashes: crate::HashSet<String> = crate::HashSet::default();
+    for tr in find_temp_roots(store.layout.state_dir())? {
+        if let Some(b) = tr.strip_prefix(&store_prefix) {
+            if b.len() > 32 && b.as_bytes()[32] == b'-' {
+                temp_root_hashes.insert(b[..32].to_owned());
+            }
+            if bidx.get_basename(b).is_none() {
+                temp_root_basenames.insert(b.to_owned());
+            }
+        }
+        if let Some(n) = bidx.get(&tr) {
+            roots.push(n);
+        }
+    }
+    // --keep-recent: treat recently registered paths as roots.
+    if let Some(cutoff) = opts.keep_recent_after {
+        let cutoff = cutoff
+            .duration_since(UNIX_EPOCH)
+            .map_or(0, |d| i64::try_from(d.as_secs()).unwrap_or(i64::MAX));
+        let n_before = roots.len();
+        roots.extend(
+            graph
+                .nodes()
+                .filter(|&n| graph.registration_time(n) >= cutoff),
+        );
+        info!("{} recent paths kept", roots.len() - n_before);
+    }
+
+    roots.sort_unstable();
+    roots.dedup();
+    info!("found {} roots", roots.len());
+
+    info!("computing alive closure...");
+    let alive = graph.compute_closure(&roots);
+    let n_alive = alive.len();
+    info!("{} alive paths", n_alive);
+    info!("{} dead paths", graph.len() - n_alive);
+
+    // Find entries on disk that are not in the DB at all. Raw OsString
+    // names: a non-UTF-8 entry cannot be in the DB (it stores text), but
+    // it is still garbage that must be unlinked by its real bytes.
+    let mut unknown_on_disk: Vec<OsString> = Vec::new();
+    match fs::read_dir(store.layout.real_store_dir()) {
+        Err(e) => warn!(
+            "cannot list {}: {e}",
+            store.layout.real_store_dir().display()
+        ),
+        Ok(entries) => {
+            for entry in entries.flatten() {
+                let raw = entry.file_name();
+                if let Some(name) = raw.to_str() {
+                    if name == ".links" {
+                        continue;
+                    }
+                    // An entry belongs to an active build if its first 32
+                    // chars match a temp root's hash part.
+                    let hash_part_active = name.len() >= 32
+                        && name.is_char_boundary(32)
+                        && temp_root_hashes.contains(&name[..32]);
+                    if bidx.get_basename(name).is_some()
+                        || temp_root_basenames.contains(name)
+                        || hash_part_active
+                    {
+                        continue;
+                    }
+                }
+                unknown_on_disk.push(raw);
+            }
+        }
+    }
+    if !unknown_on_disk.is_empty() {
+        info!("{} unknown paths on disk not in DB", unknown_on_disk.len());
+    }
+
+    let dead_nodes: Vec<NodeIdx> = graph.nodes().filter(|&n| !alive.contains(n)).collect();
+
+    let max = max_freed.unwrap_or(u64::MAX);
+
+    if dry_run {
+        let mut estimated = 0u64;
+        let mut would_delete = Vec::new();
+        // Roots can arrive over the gc-socket while we run. A real GC
+        // would honor them, so the report must too.
+        let protected = live.protected_snapshot();
+        let protected_unknown = live.protected_unknown_snapshot();
+        for &node in &dead_nodes {
+            if estimated >= max {
+                break;
+            }
+            if protected[node.index()] {
+                continue;
+            }
+            would_delete.push(graph.path(node).to_owned());
+            estimated += graph.nar_size(node);
+        }
+        if estimated < max {
+            for name in &unknown_on_disk {
+                if name.to_str().is_some_and(|n| protected_unknown.contains(n)) {
+                    continue;
+                }
+                would_delete.push(format!("{store_prefix}{}", name.display()));
+            }
+        }
+        return Ok(GcReport {
+            bytes_freed: estimated,
+            paths_deleted: would_delete.len() as u64,
+            would_delete,
+        });
+    }
+
+    info!("deleting garbage...");
+
+    // Test sync point, so tests exercise the protect() path
+    // deterministically rather than racing the delete loop.
+    if let Ok(p) = env::var("_HARMONIA_GC_TEST_SYNC") {
+        let _ = fs::read(&p);
+    }
+
+    // Bulk-invalidate, then delete from disk in parallel. Safe to crash
+    // mid-delete: leftover dirs are picked up as unknown-on-disk next run.
+    let real_store_dir = store.layout.real_store_dir().to_path_buf();
+    let bytes_freed = AtomicU64::new(0);
+    let paths_deleted = AtomicU64::new(0);
+
+    let (order, acyclic_len) = deletion_order(&graph, &alive, &dead_nodes);
+
+    // Commit in bounded chunks, truncating the WAL after each, so disk
+    // use stays bounded and space is reclaimed incrementally.
+    let max_chunk = opts.chunk_size.max(1);
+    let mut cursor = 0usize;
+    while cursor < order.len() {
+        let freed_so_far = bytes_freed.load(Ordering::Relaxed);
+        if freed_so_far >= max {
+            info!("deleted more than {max} bytes, stopping");
+            break;
+        }
+        let remaining = max - freed_so_far;
+        let mut chunk: Vec<NodeIdx> = Vec::new();
+        // narSize over-reports hard-linked paths, so estimated only
+        // bounds the chunk. Actual freed bytes are re-checked above.
+        let mut estimated = 0u64;
+        // Take the cyclic tail (from acyclic_len on) whole and unsplit.
+        let take_all = cursor >= acyclic_len;
+        while cursor < order.len()
+            && (take_all
+                || (cursor < acyclic_len && estimated < remaining && chunk.len() < max_chunk))
+        {
+            let node = order[cursor];
+            cursor += 1;
+            estimated = estimated.saturating_add(graph.nar_size(node));
+            chunk.push(node);
+        }
+        if chunk.is_empty() {
+            break;
+        }
+        // Claim atomically with the protection check, *before*
+        // invalidating DB rows. A protect() arriving for a claimed node
+        // blocks until the unlink finished, so a builder is never acked
+        // while the row deletion is in flight.
+        let (mut claimed, skipped) = live.claim_nodes(&chunk);
+        // protect() marks closures atomically, but the claim is per node:
+        // it may have kept a reference whose referrer got protected a
+        // moment earlier. Drop the closures of skipped paths.
+        if !skipped.is_empty() {
+            let keep_out = graph.compute_closure(&skipped);
+            claimed.retain(|&n| {
+                if keep_out.contains(n) {
+                    live.end_delete_node(n);
+                    false
+                } else {
+                    true
+                }
+            });
+        }
+        // Invalidate rows before unlinking: builders trust isValidPath(),
+        // so a path must never look valid after its disk entry is gone.
+        store
+            .db
+            .invalidate_ids(claimed.iter().map(|&n| graph.db_id(n)))?;
+        claimed.par_iter().for_each(|&node| {
+            let path = graph.path(node);
+            let basename = path.strip_prefix(&store_prefix).unwrap_or(path);
+            let real_path = real_store_dir.join(basename);
+            debug!("deleting '{path}'");
+            match delete_store_path(&real_path) {
+                Ok(freed) => {
+                    bytes_freed.fetch_add(freed, Ordering::Relaxed);
+                    paths_deleted.fetch_add(1, Ordering::Relaxed);
+                }
+                // The row is already invalidated. The leftover is picked
+                // up as unknown-on-disk by the next run.
+                Err(e) => warn!("failed to delete {}: {e}", real_path.display()),
+            }
+            live.end_delete_node(node);
+        });
+        debug!(
+            "deleted {}/{} dead paths, {} bytes freed",
+            paths_deleted.load(Ordering::Relaxed),
+            order.len(),
+            bytes_freed.load(Ordering::Relaxed),
+        );
+    }
+
+    // Unknown-on-disk paths, also in parallel. tmp-* dirs hold flock
+    // through deletion to avoid a TOCTOU race with a builder.
+    if bytes_freed.load(Ordering::Relaxed) < max {
+        // A builder may have registered a scanned path after our graph
+        // snapshot and then exited, leaving its temp root file stale.
+        // Unlinking such a path would orphan its ValidPaths row, so
+        // re-check the DB first. Once is enough: any registration from
+        // here on goes through the gc-socket and protected_unknown.
+        let mut unknown_on_disk = unknown_on_disk;
+        unknown_on_disk.retain(|name| {
+            // A non-UTF-8 name cannot be a DB path (the DB stores text).
+            let Some(name) = name.to_str() else {
+                return true;
+            };
+            match is_valid_path(store, &format!("{store_prefix}{name}")) {
+                Ok(valid) => !valid,
+                Err(e) => {
+                    warn!("skipping {store_prefix}{name}: validity check failed: {e}");
+                    false
+                }
+            }
+        });
+        unknown_on_disk.par_iter().for_each(|raw| {
+            // The liveset key is textual. Non-UTF-8 names cannot collide
+            // with anything a builder protects.
+            let name = raw.to_string_lossy();
+            if !live.try_begin_delete_unknown(&name) {
+                return;
+            }
+            let real_path = real_store_dir.join(raw);
+            // Only a directory can be a build temp dir a builder still
+            // holds. A stray tmp-* FIFO would fail flock() on macOS and
+            // be kept forever.
+            let is_locked_candidate = name.starts_with("tmp-")
+                && real_path
+                    .symlink_metadata()
+                    .map(|m| m.is_dir())
+                    .unwrap_or(false);
+            let _tmp_lock = if is_locked_candidate {
+                match try_lock_dir(&real_path) {
+                    Some(f) => Some(f),
+                    None => {
+                        debug!("skipping locked tempdir {}", real_path.display());
+                        live.end_delete_unknown(&name);
+                        return;
+                    }
+                }
+            } else {
+                None
+            };
+            debug!("deleting '{store_prefix}{name}'");
+            match delete_store_path(&real_path) {
+                Ok(freed) => {
+                    bytes_freed.fetch_add(freed, Ordering::Relaxed);
+                    paths_deleted.fetch_add(1, Ordering::Relaxed);
+                }
+                Err(e) => warn!("failed to delete {}: {e}", real_path.display()),
+            }
+            live.end_delete_unknown(&name);
+        });
+    }
+
+    let bytes_freed = bytes_freed.into_inner();
+    let paths_deleted = paths_deleted.into_inner();
+
+    let bytes_freed = bytes_freed + clean_links(store.layout.links_dir())?;
+
+    // Reclaim db space freed by the row deletions, still under the
+    // exclusive gc.lock. Best effort: a failed vacuum leaves the db
+    // valid.
+    if opts.vacuum
+        && let Err(e) = store.db.maybe_vacuum()
+    {
+        warn!("vacuuming database failed: {e}");
+    }
+
+    Ok(GcReport {
+        bytes_freed,
+        paths_deleted,
+        would_delete: Vec::new(),
+    })
+}
+
+/// Check a raw path string against ValidPaths. Unknown-on-disk names are
+/// arbitrary bytes, so this cannot go through the typed StorePath API.
+/// Referrer-first deletion order (Kahn over the dead subgraph), so every
+/// prefix is safe to commit: still-valid paths never reference an
+/// already-deleted one. Returns the order and the length of its acyclic
+/// prefix; cyclic nodes never reach in-degree 0 and are appended as one
+/// trailing group that must not be split.
+fn deletion_order(
+    graph: &StoreGraph,
+    alive: &Closure,
+    dead_nodes: &[NodeIdx],
+) -> (Vec<NodeIdx>, usize) {
+    // in_degree counts a dead node's dead referrers.
+    let dead_ref = |node: NodeIdx, m: NodeIdx| m != node && !alive.contains(m);
+    let mut in_degree = vec![0u32; graph.len()];
+    for &node in dead_nodes {
+        for m in graph.refs(node).filter(|&m| dead_ref(node, m)) {
+            in_degree[m.index()] += 1;
+        }
+    }
+    let mut order: Vec<NodeIdx> = dead_nodes
+        .iter()
+        .copied()
+        .filter(|&m| in_degree[m.index()] == 0)
+        .collect();
+    let mut head = 0;
+    while head < order.len() {
+        let node = order[head];
+        head += 1;
+        for m in graph.refs(node).filter(|&m| dead_ref(node, m)) {
+            in_degree[m.index()] -= 1;
+            if in_degree[m.index()] == 0 {
+                order.push(m);
+            }
+        }
+    }
+    let acyclic_len = order.len();
+    if order.len() < dead_nodes.len() {
+        order.extend(
+            dead_nodes
+                .iter()
+                .copied()
+                .filter(|&m| in_degree[m.index()] != 0),
+        );
+    }
+    (order, acyclic_len)
+}
+
+fn is_valid_path(store: &GcStore, path: &str) -> Result<bool> {
+    // Cached: called once per unknown-on-disk entry, which can be many
+    // thousands after an interrupted nixos-install or nix copy.
+    let mut stmt = store
+        .db
+        .connection()
+        .prepare_cached("SELECT COUNT(*) FROM ValidPaths WHERE path = ?")
+        .map_err(harmonia_store_db::Error::from)?;
+    let n: i64 = stmt
+        .query_row([path], |r| r.get(0))
+        .map_err(harmonia_store_db::Error::from)?;
+    Ok(n > 0)
+}
+
+/// Remove hard links with link count 1 from the `.links` directory,
+/// returning bytes freed.
+///
+/// The dir can contain millions of entries. stat + unlink per entry is
+/// disk-bound, so process in parallel, and stream the entries instead of
+/// collecting them: a Vec of millions of DirEntries costs gigabytes.
+fn clean_links(links_dir: &Path) -> Result<u64> {
+    info!("deleting unused links...");
+    let entries = match fs::read_dir(links_dir) {
+        Ok(e) => e,
+        Err(e) if e.kind() == ErrorKind::NotFound => return Ok(0),
+        Err(e) => {
+            warn!("cannot read {}: {e}", links_dir.display());
+            return Ok(0);
+        }
+    };
+
+    // A link entry has one reference from .links plus one per store file.
+    // N references total mean hard linking saves (N-2)*size compared to
+    // independent copies.
+    let saved_bytes = AtomicU64::new(0);
+    let freed_bytes = AtomicU64::new(0);
+
+    entries.flatten().par_bridge().for_each(|entry| {
+        let path = entry.path();
+        let Ok(meta) = fs::symlink_metadata(&path) else {
+            return;
+        };
+        if meta.nlink() != 1 {
+            saved_bytes.fetch_add(
+                meta.nlink().saturating_sub(2) * meta.size(),
+                Ordering::Relaxed,
+            );
+            return;
+        }
+        if fs::remove_file(&path).is_ok() {
+            freed_bytes.fetch_add(meta.blocks() * 512, Ordering::Relaxed);
+        }
+    });
+
+    let saving = saved_bytes.into_inner();
+    if saving > 0 {
+        info!("hard linking is currently saving {saving} bytes");
+    }
+
+    Ok(freed_bytes.into_inner())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::testutil::graph;
+
+    #[test]
+    fn deletion_order_referrers_first_cycle_last() {
+        // app -> lib -> libc(alive);  a <-> b cycle;  leaf standalone.
+        let g = graph(&[
+            ("app", &[1]),
+            ("lib", &[2]),
+            ("libc", &[]),
+            ("a", &[4]),
+            ("b", &[3]),
+            ("leaf", &[]),
+        ]);
+        let n = |name: &str| {
+            g.nodes()
+                .find(|&n| g.path(n) == format!("/nix/store/{name}"))
+                .unwrap()
+        };
+        let alive = g.compute_closure(&[n("libc")]);
+        let dead: Vec<_> = g.nodes().filter(|&x| !alive.contains(x)).collect();
+
+        let (order, acyclic_len) = deletion_order(&g, &alive, &dead);
+
+        assert_eq!(order.len(), dead.len());
+        assert!(!order.contains(&n("libc")));
+        let pos = |x| order.iter().position(|&o| o == x).unwrap();
+        assert!(pos(n("app")) < pos(n("lib")), "referrer before reference");
+        assert_eq!(acyclic_len, 3, "app, lib, leaf are acyclic");
+        let mut tail: Vec<_> = order[acyclic_len..].to_vec();
+        tail.sort();
+        let mut cyc = vec![n("a"), n("b")];
+        cyc.sort();
+        assert_eq!(tail, cyc, "cycle forms the unsplit tail");
+    }
+
+    #[test]
+    fn delete_store_path_missing_is_zero() {
+        let tmp = tempfile::tempdir().unwrap();
+        assert_eq!(delete_store_path(&tmp.path().join("gone")).unwrap(), 0);
+    }
+
+    #[test]
+    fn delete_store_path_other_stat_errors_propagate() {
+        let tmp = tempfile::tempdir().unwrap();
+        let f = tmp.path().join("file");
+        fs::write(&f, b"x").unwrap();
+        // ENOTDIR, not ENOENT: must not be treated as "already gone".
+        assert!(delete_store_path(&f.join("sub")).is_err());
+    }
+
+    #[test]
+    fn delete_store_path_file_reports_disk_blocks() {
+        let tmp = tempfile::tempdir().unwrap();
+        let f = tmp.path().join("file");
+        fs::write(&f, vec![1u8; 5000]).unwrap();
+        let expected = fs::symlink_metadata(&f).unwrap().blocks() * 512;
+        assert!(expected > 0);
+        assert_eq!(delete_store_path(&f).unwrap(), expected);
+        assert!(!f.exists());
+    }
+
+    #[test]
+    fn delete_store_path_removes_readonly_tree() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("pkg");
+        fs::create_dir_all(dir.join("sub")).unwrap();
+        fs::write(dir.join("sub/file"), vec![1u8; 5000]).unwrap();
+        let mut expected = 0;
+        for e in walkdir::WalkDir::new(&dir) {
+            expected += e.unwrap().metadata().unwrap().blocks() * 512;
+        }
+        // Store paths are read-only on disk.
+        fs::set_permissions(dir.join("sub/file"), fs::Permissions::from_mode(0o444)).unwrap();
+        fs::set_permissions(dir.join("sub"), fs::Permissions::from_mode(0o555)).unwrap();
+        fs::set_permissions(&dir, fs::Permissions::from_mode(0o555)).unwrap();
+
+        assert_eq!(delete_store_path(&dir).unwrap(), expected);
+        assert!(!dir.exists());
+    }
+
+    #[test]
+    fn try_lock_dir_none_while_held() {
+        let tmp = tempfile::tempdir().unwrap();
+        let lock = try_lock_dir(tmp.path()).expect("unheld dir is lockable");
+        assert!(try_lock_dir(tmp.path()).is_none(), "held dir must not lock");
+        drop(lock);
+    }
+
+    #[test]
+    fn clean_links_removes_only_unreferenced() {
+        let tmp = tempfile::tempdir().unwrap();
+        let links = tmp.path().join(".links");
+        fs::create_dir_all(&links).unwrap();
+        let dead = links.join("dead");
+        fs::write(&dead, b"unreferenced").unwrap();
+        let shared = links.join("shared");
+        fs::write(&shared, b"referenced").unwrap();
+        fs::hard_link(&shared, tmp.path().join("user")).unwrap();
+
+        let dead_blocks = fs::symlink_metadata(&dead).unwrap().blocks() * 512;
+        let freed = clean_links(&links).unwrap();
+
+        assert!(!dead.exists());
+        assert!(shared.exists());
+        assert_eq!(freed, dead_blocks, "freed bytes of removed links");
+        // A missing .links dir is not an error.
+        assert_eq!(clean_links(&tmp.path().join("nope")).unwrap(), 0);
+    }
+}

--- a/harmonia-store-gc/src/gc.rs
+++ b/harmonia-store-gc/src/gc.rs
@@ -1,0 +1,736 @@
+// SPDX-FileCopyrightText: 2026 Jörg Thalheim
+// SPDX-License-Identifier: MIT
+
+//! Garbage collection: liveness computation and store path deletion.
+
+use std::fs;
+use std::io::Write;
+use std::os::unix::fs::{MetadataExt, OpenOptionsExt, PermissionsExt};
+use std::path::Path;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use harmonia_store_db::{BasenameIndex, GraphOptions, NodeIdx, StoreGraph};
+use nix::fcntl::{Flock, FlockArg};
+use rayon::prelude::*;
+use tracing::{debug, info, warn};
+
+use crate::error::{Error, Result};
+use crate::gc_socket::{GcSocketServer, LiveSet};
+use crate::roots::find_roots;
+use crate::store::GcStore;
+use crate::temp_roots::find_temp_roots;
+
+/// Delete a store path from disk, returning bytes freed.
+///
+/// Store paths are read-only on disk, so directories are made writable
+/// before removal, mirroring Nix's `deletePath`.
+fn delete_store_path(real_path: &Path) -> Result<u64> {
+    let meta = match fs::symlink_metadata(real_path) {
+        Ok(m) => m,
+        // Already gone: another process won the race.
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(0),
+        Err(source) => {
+            return Err(Error::Stat {
+                path: real_path.to_owned(),
+                source,
+            });
+        }
+    };
+
+    if !meta.file_type().is_dir() {
+        let bytes = meta.blocks() * 512;
+        fs::remove_file(real_path).map_err(|source| Error::Remove {
+            path: real_path.to_owned(),
+            source,
+        })?;
+        return Ok(bytes);
+    }
+
+    let mut bytes_freed = 0u64;
+    // chmod and retry on permission errors instead of aborting the GC.
+    for entry in walkdir::WalkDir::new(real_path).contents_first(true) {
+        let entry = match entry {
+            Ok(e) => e,
+            Err(e) => {
+                if let Some(parent) = e.path().and_then(Path::parent) {
+                    let _ = fs::set_permissions(parent, fs::Permissions::from_mode(0o755));
+                }
+                continue;
+            }
+        };
+        let p = entry.path();
+        if let Ok(m) = entry.metadata() {
+            bytes_freed += m.blocks() * 512;
+        }
+        if entry.file_type().is_dir() {
+            if fs::remove_dir(p).is_err() {
+                // rmdir needs write permission on the parent, not on p.
+                if let Some(parent) = p.parent() {
+                    let _ = fs::set_permissions(parent, fs::Permissions::from_mode(0o755));
+                }
+                let _ = fs::remove_dir(p);
+            }
+        } else if fs::remove_file(p).is_err() {
+            if let Some(parent) = p.parent() {
+                let _ = fs::set_permissions(parent, fs::Permissions::from_mode(0o755));
+            }
+            let _ = fs::remove_file(p);
+        }
+    }
+
+    Ok(bytes_freed)
+}
+
+/// Lock a `tmp-*` build dir before deleting. `None` means a builder
+/// still holds it. The caller keeps the fd through deletion to avoid a
+/// TOCTOU race.
+fn try_lock_dir(path: &Path) -> Option<Flock<fs::File>> {
+    // O_NONBLOCK: a stray FIFO named tmp-* must not block open() forever
+    // while we hold the exclusive gc.lock.
+    let f = match fs::OpenOptions::new()
+        .read(true)
+        .custom_flags(nix::libc::O_NONBLOCK)
+        .open(path)
+    {
+        Ok(f) => f,
+        Err(e) => {
+            if e.kind() != std::io::ErrorKind::NotFound {
+                warn!("cannot open {} for locking: {e}", path.display());
+            }
+            return None;
+        }
+    };
+    Flock::lock(f, FlockArg::LockExclusiveNonblock).ok()
+}
+
+/// Take the same lock Nix takes. Builders hold it shared while
+/// registering temp roots. We take it exclusive so the root set cannot
+/// change under us.
+fn acquire_gc_lock(state_dir: &Path) -> Result<Flock<fs::File>> {
+    let lock_path = state_dir.join("gc.lock");
+    let lock_err = |source| Error::GcLock {
+        path: lock_path.clone(),
+        source,
+    };
+    // 0600 like Nix: a world-readable lock would let any local user
+    // flock it and block GC and builders indefinitely.
+    let f = fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .mode(0o600)
+        .open(&lock_path)
+        .map_err(lock_err)?;
+
+    match Flock::lock(f, FlockArg::LockExclusiveNonblock) {
+        Ok(lock) => Ok(lock),
+        Err((f, _)) => {
+            info!("waiting for the big garbage collector lock...");
+            Flock::lock(f, FlockArg::LockExclusive).map_err(|(_, e)| lock_err(e.into()))
+        }
+    }
+}
+
+/// Tuning knobs for one garbage collection run.
+#[derive(Default)]
+pub struct GcOptions {
+    /// Which liveness edges the reference graph should include.
+    pub graph_options: GraphOptions,
+    /// Report what would be deleted without touching anything.
+    pub dry_run: bool,
+    /// Stop after freeing this many bytes.
+    pub max_freed: Option<u64>,
+    /// Keep paths registered at or after this Unix timestamp.
+    pub keep_recent_after: Option<i64>,
+    /// Skip the post-GC VACUUM. For busy builders, where concurrent
+    /// readers keep the VACUUM's database-sized WAL from being truncated.
+    pub no_vacuum: bool,
+    /// Max dead paths invalidated per database transaction. Smaller keeps
+    /// the WAL lower, larger means fewer checkpoints. `None` uses the
+    /// default.
+    pub chunk_size: Option<usize>,
+    /// Extra directories scanned for GC roots. Nix only scans its fixed
+    /// state dirs, so roots outside them would go uncounted.
+    pub extra_gc_roots_dirs: Vec<std::path::PathBuf>,
+}
+
+/// Result of a garbage collection run.
+///
+/// In a dry run `bytes_freed` is the estimated NAR size of the paths
+/// that would be deleted and `paths_deleted` counts them.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct GcReport {
+    /// Bytes freed on disk, including hard-link savings reclaimed from
+    /// `.links`.
+    pub bytes_freed: u64,
+    /// Number of store paths deleted.
+    pub paths_deleted: usize,
+}
+
+/// Collect garbage: find roots, compute the alive closure, delete dead
+/// paths.
+///
+/// Interoperates with running builds throughout: the exclusive `gc.lock`
+/// is held, temp roots are honored, and new roots arriving over the
+/// gc-socket are protected before their closure is touched.
+///
+/// The store directory must be writable. On NixOS, where /nix/store is
+/// bind-mounted read-only, the caller has to remount it first (see the
+/// harmonia-gc binary).
+pub fn collect_garbage(store: &GcStore, opts: &GcOptions) -> Result<GcReport> {
+    let dry_run = opts.dry_run;
+    let max_freed = opts.max_freed;
+
+    // Free the reserved space file first. On a 100% full disk the SQLite
+    // invalidation needs room to write before anything was unlinked.
+    if !dry_run {
+        let reserved = store.layout.state_dir().join("db/reserved");
+        match fs::remove_file(&reserved) {
+            Ok(()) => {}
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+            Err(e) => warn!("cannot remove {}: {e}", reserved.display()),
+        }
+    }
+
+    let _gc_lock = acquire_gc_lock(store.layout.state_dir())?;
+
+    // Serve the gc-socket immediately after taking the lock, like Nix:
+    // builders that lost the shared-lock race retry connecting every
+    // 100ms, so the socket must exist before the potentially long graph
+    // load, and during dry runs, which hold the lock too.
+    //
+    // Phase 1: no graph yet, so every received root is acked instantly
+    // and recorded by basename. That is sound because nothing can be
+    // deleted before the graph exists. The roots are replayed below.
+    let store_prefix = format!("{}/", store.layout.store_dir().to_str());
+    let early_live = Arc::new(LiveSet::new(0));
+    // A dry run on a read-only state dir can still report. Without the
+    // socket no builder can run anyway (they need temproots).
+    let start_socket = |live: Arc<LiveSet>, graph: Arc<StoreGraph>| -> Result<_> {
+        match GcSocketServer::start(store.layout.state_dir(), live, graph) {
+            Ok(s) => Ok(Some(s)),
+            Err(e) if dry_run => {
+                warn!("cannot serve gc-socket: {e}");
+                Ok(None)
+            }
+            Err(e) => Err(e),
+        }
+    };
+    let early_socket = start_socket(
+        Arc::clone(&early_live),
+        Arc::new(StoreGraph::empty(store_prefix.clone())),
+    )?;
+
+    // Test sync point: block until the named fifo is readable, so tests
+    // can deterministically exercise the early-socket window.
+    if let Ok(p) = std::env::var("_HARMONIA_GC_TEST_SYNC_EARLY") {
+        let _ = fs::read(&p);
+    }
+
+    info!("loading store graph...");
+    let graph = Arc::new(
+        store
+            .db
+            .load_graph(store.layout.store_dir(), &opts.graph_options)?,
+    );
+    info!("{} total valid paths", graph.len());
+
+    // Phase 2: swap to the real server. Builders whose connection drops
+    // during the swap reconnect (Nix's addTempRoot restart loop).
+    drop(early_socket);
+    let early_roots = early_live.protected_unknown_snapshot();
+    let live = Arc::new(LiveSet::new(graph.len()));
+    let _gc_socket = start_socket(Arc::clone(&live), Arc::clone(&graph))?;
+
+    let bidx = BasenameIndex::new(&graph);
+
+    // Replay phase-1 roots: known paths become ordinary GC roots (their
+    // closure stays alive), unknown basenames stay protected.
+    let mut early_root_nodes: Vec<NodeIdx> = Vec::new();
+    for b in &early_roots {
+        match bidx.get_basename(b) {
+            Some(n) => early_root_nodes.push(n),
+            None => live.protect_unknown_basename(b),
+        }
+    }
+
+    // A --store-dir that does not match the DB contents would make every
+    // root lookup miss and every DB path look dead, wiping the store.
+    if !graph.is_empty() && bidx.is_empty() {
+        let first = graph.nodes().next().expect("graph is non-empty");
+        return Err(Error::StoreDirMismatch {
+            store_dir: store.layout.store_dir().to_path().to_owned(),
+            example: graph.path(first).to_owned(),
+        });
+    }
+
+    info!("finding garbage collector roots...");
+    let mut roots = find_roots(&store.layout, &opts.extra_gc_roots_dirs, &bidx)?;
+    roots.extend(early_root_nodes);
+
+    // Add temp roots. Some may reference paths registered after our graph
+    // snapshot (a builder can register paths while we hold gc.lock as
+    // long as it wrote its temp root before we acquired it). Track those
+    // by basename so the unknown-on-disk scan won't delete them.
+    let mut temp_root_basenames: crate::HashSet<String> = crate::HashSet::default();
+    // Nix matches temp roots by hash part so that sibling files of an
+    // active build (`<path>.lock`, `<path>.chroot`, `<path>.check`) are
+    // protected too.
+    let mut temp_root_hashes: crate::HashSet<String> = crate::HashSet::default();
+    for tr in find_temp_roots(store.layout.state_dir())? {
+        if let Some(b) = tr.strip_prefix(&store_prefix) {
+            if b.len() > 32 && b.as_bytes()[32] == b'-' {
+                temp_root_hashes.insert(b[..32].to_owned());
+            }
+            if bidx.get_basename(b).is_none() {
+                temp_root_basenames.insert(b.to_owned());
+            }
+        }
+        if let Some(n) = bidx.get(&tr) {
+            roots.push(n);
+        }
+    }
+    // --keep-recent: treat recently registered paths as roots.
+    if let Some(cutoff) = opts.keep_recent_after {
+        let n_before = roots.len();
+        roots.extend(
+            graph
+                .nodes()
+                .filter(|&n| graph.registration_time(n) >= cutoff),
+        );
+        info!("{} recent paths kept", roots.len() - n_before);
+    }
+
+    roots.sort_unstable();
+    roots.dedup();
+    info!("found {} roots", roots.len());
+
+    info!("computing alive closure...");
+    let alive = graph.compute_closure(&roots);
+    let n_alive = alive.len();
+    info!("{} alive paths", n_alive);
+    info!("{} dead paths", graph.len() - n_alive);
+
+    // Find entries on disk that are not in the DB at all. Raw OsString
+    // names: a non-UTF-8 entry cannot be in the DB (it stores text), but
+    // it is still garbage that must be unlinked by its real bytes.
+    let mut unknown_on_disk: Vec<std::ffi::OsString> = Vec::new();
+    if let Ok(entries) = fs::read_dir(store.layout.real_store_dir()) {
+        for entry in entries.flatten() {
+            let raw = entry.file_name();
+            if let Some(name) = raw.to_str() {
+                if name == ".links" {
+                    continue;
+                }
+                // An entry belongs to an active build if its first 32
+                // chars match a temp root's hash part.
+                let hash_part_active = name.len() >= 32
+                    && name.is_char_boundary(32)
+                    && temp_root_hashes.contains(&name[..32]);
+                if bidx.get_basename(name).is_some()
+                    || temp_root_basenames.contains(name)
+                    || hash_part_active
+                {
+                    continue;
+                }
+            }
+            unknown_on_disk.push(raw);
+        }
+    }
+    if !unknown_on_disk.is_empty() {
+        info!("{} unknown paths on disk not in DB", unknown_on_disk.len());
+    }
+
+    let dead_nodes: Vec<NodeIdx> = graph.nodes().filter(|&n| !alive.contains(n)).collect();
+
+    let max = max_freed.unwrap_or(u64::MAX);
+
+    if dry_run {
+        let report_err = |source| Error::Report { source };
+        let mut stdout = std::io::BufWriter::new(std::io::stdout().lock());
+        let mut estimated = 0u64;
+        let mut count = 0usize;
+        // Roots can arrive over the gc-socket while we run. A real GC
+        // would honor them, so the report must too.
+        let protected = live.protected_snapshot();
+        let protected_unknown = live.protected_unknown_snapshot();
+        for &node in &dead_nodes {
+            if estimated >= max {
+                break;
+            }
+            if protected[node.index()] {
+                continue;
+            }
+            writeln!(stdout, "{}", graph.path(node)).map_err(report_err)?;
+            estimated += graph.nar_size(node);
+            count += 1;
+        }
+        for name in &unknown_on_disk {
+            if name.to_str().is_some_and(|n| protected_unknown.contains(n)) {
+                continue;
+            }
+            writeln!(stdout, "{store_prefix}{}", name.display()).map_err(report_err)?;
+            count += 1;
+        }
+        return Ok(GcReport {
+            bytes_freed: estimated,
+            paths_deleted: count,
+        });
+    }
+
+    info!("deleting garbage...");
+
+    // Test sync point, so tests exercise the protect() path
+    // deterministically rather than racing the delete loop.
+    if let Ok(p) = std::env::var("_HARMONIA_GC_TEST_SYNC") {
+        let _ = fs::read(&p);
+    }
+
+    // Bulk-invalidate, then delete from disk in parallel. Safe to crash
+    // mid-delete: leftover dirs are picked up as unknown-on-disk next run.
+    let real_store_dir = store.layout.real_store_dir().to_path_buf();
+    let bytes_freed = AtomicU64::new(0);
+    let paths_deleted = AtomicU64::new(0);
+
+    // Referrer-first deletion order (Kahn over the dead subgraph), so
+    // every prefix is safe to commit: still-valid paths never reference
+    // an already-deleted one. in_degree counts a dead node's dead
+    // referrers.
+    let dead_ref = |node: NodeIdx, m: NodeIdx| m != node && !alive.contains(m);
+    let mut in_degree = vec![0u32; graph.len()];
+    for &node in &dead_nodes {
+        for m in graph.refs(node).filter(|&m| dead_ref(node, m)) {
+            in_degree[m.index()] += 1;
+        }
+    }
+    let mut order: Vec<NodeIdx> = dead_nodes
+        .iter()
+        .copied()
+        .filter(|&m| in_degree[m.index()] == 0)
+        .collect();
+    let mut head = 0;
+    while head < order.len() {
+        let node = order[head];
+        head += 1;
+        for m in graph.refs(node).filter(|&m| dead_ref(node, m)) {
+            in_degree[m.index()] -= 1;
+            if in_degree[m.index()] == 0 {
+                order.push(m);
+            }
+        }
+    }
+    // Cyclic nodes never reach in-degree 0. They are mutually dependent,
+    // so they share one trailing chunk that is never split.
+    let acyclic_len = order.len();
+    if order.len() < dead_nodes.len() {
+        order.extend(
+            dead_nodes
+                .iter()
+                .copied()
+                .filter(|&m| in_degree[m.index()] != 0),
+        );
+    }
+
+    // Commit in bounded chunks, truncating the WAL after each, so disk
+    // use stays bounded and space is reclaimed incrementally.
+    let max_chunk = opts.chunk_size.unwrap_or(65_536).max(1);
+    let mut cursor = 0usize;
+    while cursor < order.len() {
+        let freed_so_far = bytes_freed.load(Ordering::Relaxed);
+        if freed_so_far >= max {
+            info!("deleted more than {max} bytes, stopping");
+            break;
+        }
+        let remaining = max - freed_so_far;
+        let mut chunk: Vec<NodeIdx> = Vec::new();
+        // narSize over-reports hard-linked paths, so estimated only
+        // bounds the chunk. Actual freed bytes are re-checked above.
+        let mut estimated = 0u64;
+        // Take the cyclic tail (from acyclic_len on) whole and unsplit.
+        let take_all = cursor >= acyclic_len;
+        while cursor < order.len()
+            && (take_all
+                || (cursor < acyclic_len && estimated < remaining && chunk.len() < max_chunk))
+        {
+            let node = order[cursor];
+            cursor += 1;
+            estimated = estimated.saturating_add(graph.nar_size(node));
+            chunk.push(node);
+        }
+        if chunk.is_empty() {
+            break;
+        }
+        // Claim atomically with the protection check, *before*
+        // invalidating DB rows. A protect() arriving for a claimed node
+        // blocks until the unlink finished, so a builder is never acked
+        // while the row deletion is in flight.
+        let (mut claimed, skipped) = live.claim_nodes(&chunk);
+        // protect() marks closures atomically, but the claim is per node:
+        // it may have kept a reference whose referrer got protected a
+        // moment earlier. Drop the closures of skipped paths.
+        if !skipped.is_empty() {
+            let keep_out = graph.compute_closure(&skipped);
+            claimed.retain(|&n| {
+                if keep_out.contains(n) {
+                    live.end_delete_node(n);
+                    false
+                } else {
+                    true
+                }
+            });
+        }
+        // Invalidate rows before unlinking: builders trust isValidPath(),
+        // so a path must never look valid after its disk entry is gone.
+        store
+            .db
+            .invalidate_ids(claimed.iter().map(|&n| graph.db_id(n)))?;
+        claimed.par_iter().for_each(|&node| {
+            let path = graph.path(node);
+            let basename = path.strip_prefix(&store_prefix).unwrap_or(path);
+            let real_path = real_store_dir.join(basename);
+            debug!("deleting '{path}'");
+            match delete_store_path(&real_path) {
+                Ok(freed) => {
+                    bytes_freed.fetch_add(freed, Ordering::Relaxed);
+                }
+                // The row is already invalidated. The leftover is picked
+                // up as unknown-on-disk by the next run.
+                Err(e) => warn!("failed to delete {}: {e}", real_path.display()),
+            }
+            live.end_delete_node(node);
+        });
+        let done =
+            paths_deleted.fetch_add(claimed.len() as u64, Ordering::Relaxed) + claimed.len() as u64;
+        debug!(
+            "deleted {done}/{} dead paths, {} bytes freed",
+            order.len(),
+            bytes_freed.load(Ordering::Relaxed),
+        );
+    }
+
+    // Unknown-on-disk paths, also in parallel. tmp-* dirs hold flock
+    // through deletion to avoid a TOCTOU race with a builder.
+    if bytes_freed.load(Ordering::Relaxed) < max {
+        // A builder may have registered a scanned path after our graph
+        // snapshot and then exited, leaving its temp root file stale.
+        // Unlinking such a path would orphan its ValidPaths row, so
+        // re-check the DB first. Once is enough: any registration from
+        // here on goes through the gc-socket and protected_unknown.
+        let mut unknown_on_disk = unknown_on_disk;
+        unknown_on_disk.retain(|name| {
+            // A non-UTF-8 name cannot be a DB path (the DB stores text).
+            let Some(name) = name.to_str() else {
+                return true;
+            };
+            match is_valid_path(store, &format!("{store_prefix}{name}")) {
+                Ok(valid) => !valid,
+                Err(e) => {
+                    warn!("skipping {store_prefix}{name}: validity check failed: {e}");
+                    false
+                }
+            }
+        });
+        unknown_on_disk.par_iter().for_each(|raw| {
+            // The liveset key is textual. Non-UTF-8 names cannot collide
+            // with anything a builder protects.
+            let name = raw.to_string_lossy();
+            if !live.try_begin_delete_unknown(&name) {
+                return;
+            }
+            let real_path = real_store_dir.join(raw);
+            // Only a directory can be a build temp dir a builder still
+            // holds. A stray tmp-* FIFO would fail flock() on macOS and
+            // be kept forever.
+            let is_locked_candidate = name.starts_with("tmp-")
+                && real_path
+                    .symlink_metadata()
+                    .map(|m| m.is_dir())
+                    .unwrap_or(false);
+            let _tmp_lock = if is_locked_candidate {
+                match try_lock_dir(&real_path) {
+                    Some(f) => Some(f),
+                    None => {
+                        debug!("skipping locked tempdir {}", real_path.display());
+                        live.end_delete_unknown(&name);
+                        return;
+                    }
+                }
+            } else {
+                None
+            };
+            debug!("deleting '{store_prefix}{name}'");
+            match delete_store_path(&real_path) {
+                Ok(freed) => {
+                    bytes_freed.fetch_add(freed, Ordering::Relaxed);
+                    paths_deleted.fetch_add(1, Ordering::Relaxed);
+                }
+                Err(e) => warn!("failed to delete {}: {e}", real_path.display()),
+            }
+            live.end_delete_unknown(&name);
+        });
+    }
+
+    let bytes_freed = bytes_freed.into_inner();
+    let paths_deleted = paths_deleted.into_inner() as usize;
+
+    let bytes_freed = bytes_freed + clean_links(store.layout.links_dir())?;
+
+    // Reclaim db space freed by the row deletions, still under the
+    // exclusive gc.lock. Best effort: a failed vacuum leaves the db
+    // valid.
+    if !opts.no_vacuum
+        && let Err(e) = store.db.maybe_vacuum()
+    {
+        warn!("vacuuming database failed: {e}");
+    }
+
+    Ok(GcReport {
+        bytes_freed,
+        paths_deleted,
+    })
+}
+
+/// Check a raw path string against ValidPaths. Unknown-on-disk names are
+/// arbitrary bytes, so this cannot go through the typed StorePath API.
+fn is_valid_path(store: &GcStore, path: &str) -> Result<bool> {
+    // Cached: called once per unknown-on-disk entry, which can be many
+    // thousands after an interrupted nixos-install or nix copy.
+    let mut stmt = store
+        .db
+        .connection()
+        .prepare_cached("SELECT COUNT(*) FROM ValidPaths WHERE path = ?")
+        .map_err(harmonia_store_db::Error::from)?;
+    let n: i64 = stmt
+        .query_row([path], |r| r.get(0))
+        .map_err(harmonia_store_db::Error::from)?;
+    Ok(n > 0)
+}
+
+/// Remove hard links with link count 1 from the `.links` directory,
+/// returning bytes freed.
+///
+/// The dir can contain millions of entries. stat + unlink per entry is
+/// disk-bound, so process in parallel, and stream the entries instead of
+/// collecting them: a Vec of millions of DirEntries costs gigabytes.
+fn clean_links(links_dir: &Path) -> Result<u64> {
+    info!("deleting unused links...");
+    let entries = match fs::read_dir(links_dir) {
+        Ok(e) => e,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(0),
+        Err(e) => {
+            warn!("cannot read {}: {e}", links_dir.display());
+            return Ok(0);
+        }
+    };
+
+    // A link entry has one reference from .links plus one per store file.
+    // N references total mean hard linking saves (N-2)*size compared to
+    // independent copies.
+    let saved_bytes = AtomicU64::new(0);
+    let freed_bytes = AtomicU64::new(0);
+
+    entries.flatten().par_bridge().for_each(|entry| {
+        let path = entry.path();
+        let Ok(meta) = fs::symlink_metadata(&path) else {
+            return;
+        };
+        if meta.nlink() != 1 {
+            saved_bytes.fetch_add(
+                meta.nlink().saturating_sub(2) * meta.size(),
+                Ordering::Relaxed,
+            );
+            return;
+        }
+        if fs::remove_file(&path).is_ok() {
+            freed_bytes.fetch_add(meta.blocks() * 512, Ordering::Relaxed);
+        }
+    });
+
+    let saving = saved_bytes.into_inner();
+    if saving > 0 {
+        info!("hard linking is currently saving {saving} bytes");
+    }
+
+    Ok(freed_bytes.into_inner())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn delete_store_path_missing_is_zero() {
+        let tmp = tempfile::tempdir().unwrap();
+        assert_eq!(delete_store_path(&tmp.path().join("gone")).unwrap(), 0);
+    }
+
+    #[test]
+    fn delete_store_path_other_stat_errors_propagate() {
+        let tmp = tempfile::tempdir().unwrap();
+        let f = tmp.path().join("file");
+        fs::write(&f, b"x").unwrap();
+        // ENOTDIR, not ENOENT: must not be treated as "already gone".
+        assert!(delete_store_path(&f.join("sub")).is_err());
+    }
+
+    #[test]
+    fn delete_store_path_file_reports_disk_blocks() {
+        let tmp = tempfile::tempdir().unwrap();
+        let f = tmp.path().join("file");
+        fs::write(&f, vec![1u8; 5000]).unwrap();
+        let expected = fs::symlink_metadata(&f).unwrap().blocks() * 512;
+        assert!(expected > 0);
+        assert_eq!(delete_store_path(&f).unwrap(), expected);
+        assert!(!f.exists());
+    }
+
+    #[test]
+    fn delete_store_path_removes_readonly_tree() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("pkg");
+        fs::create_dir_all(dir.join("sub")).unwrap();
+        fs::write(dir.join("sub/file"), vec![1u8; 5000]).unwrap();
+        let mut expected = 0;
+        for e in walkdir::WalkDir::new(&dir) {
+            expected += e.unwrap().metadata().unwrap().blocks() * 512;
+        }
+        // Store paths are read-only on disk.
+        fs::set_permissions(dir.join("sub/file"), fs::Permissions::from_mode(0o444)).unwrap();
+        fs::set_permissions(dir.join("sub"), fs::Permissions::from_mode(0o555)).unwrap();
+        fs::set_permissions(&dir, fs::Permissions::from_mode(0o555)).unwrap();
+
+        assert_eq!(delete_store_path(&dir).unwrap(), expected);
+        assert!(!dir.exists());
+    }
+
+    #[test]
+    fn try_lock_dir_none_while_held() {
+        let tmp = tempfile::tempdir().unwrap();
+        let lock = try_lock_dir(tmp.path()).expect("unheld dir is lockable");
+        assert!(try_lock_dir(tmp.path()).is_none(), "held dir must not lock");
+        drop(lock);
+    }
+
+    #[test]
+    fn clean_links_removes_only_unreferenced() {
+        let tmp = tempfile::tempdir().unwrap();
+        let links = tmp.path().join(".links");
+        fs::create_dir_all(&links).unwrap();
+        let dead = links.join("dead");
+        fs::write(&dead, b"unreferenced").unwrap();
+        let shared = links.join("shared");
+        fs::write(&shared, b"referenced").unwrap();
+        fs::hard_link(&shared, tmp.path().join("user")).unwrap();
+
+        let dead_blocks = fs::symlink_metadata(&dead).unwrap().blocks() * 512;
+        let freed = clean_links(&links).unwrap();
+
+        assert!(!dead.exists());
+        assert!(shared.exists());
+        assert_eq!(freed, dead_blocks, "freed bytes of removed links");
+        // A missing .links dir is not an error.
+        assert_eq!(clean_links(&tmp.path().join("nope")).unwrap(), 0);
+    }
+}

--- a/harmonia-store-gc/src/gc_socket.rs
+++ b/harmonia-store-gc/src/gc_socket.rs
@@ -1,0 +1,630 @@
+// SPDX-FileCopyrightText: 2026 Jörg Thalheim
+// SPDX-License-Identifier: MIT
+
+//! GC roots socket, protocol-compatible with `nix-store --gc`.
+//!
+//! Builders that fail to acquire a shared `gc.lock` connect to
+//! `state/gc-socket/socket`, send newline-terminated store paths, and
+//! wait for a single `'1'` ack per line. We mark the closure protected
+//! before acking so the builder cannot recreate a path we are still
+//! unlinking.
+
+use std::fs;
+use std::io::{BufRead, BufReader, ErrorKind, Read, Write};
+use std::net::Shutdown;
+use std::os::unix::fs::PermissionsExt;
+use std::os::unix::io::AsFd;
+use std::os::unix::net::{UnixListener, UnixStream};
+use std::path::{Path, PathBuf};
+use std::sync::{
+    Arc, Condvar, Mutex,
+    atomic::{AtomicBool, Ordering},
+};
+use std::thread::{self, JoinHandle};
+use std::time::Duration;
+
+use harmonia_store_db::{NodeIdx, StoreGraph};
+use nix::poll::{PollFd, PollFlags, PollTimeout, poll};
+use tracing::{debug, warn};
+
+use crate::error::{Error, Result};
+use crate::{HashMap, HashSet};
+
+/// Liveness state shared between the deletion loop and the socket server.
+///
+/// Roots from clients can only flip dead -> protected. `pending` tracks
+/// in-flight unlinks so `protect()` waits for them before acking.
+pub(crate) struct LiveSet {
+    inner: Mutex<LiveInner>,
+    cond: Condvar,
+}
+
+struct LiveInner {
+    /// GC teardown in progress. protect() must stop waiting.
+    cancelled: bool,
+    /// Per-node "do not delete" flag.
+    protected: Vec<bool>,
+    /// Protected basenames not (yet) in the graph, e.g. paths registered
+    /// after our database snapshot.
+    protected_unknown: HashSet<String>,
+    /// Graph nodes currently being deleted.
+    pending_nodes: HashSet<NodeIdx>,
+    /// Unknown-on-disk basenames currently being deleted.
+    pending_unknown: HashSet<String>,
+}
+
+impl LiveSet {
+    pub(crate) fn new(n_nodes: usize) -> Self {
+        LiveSet {
+            inner: Mutex::new(LiveInner {
+                cancelled: false,
+                protected: vec![false; n_nodes],
+                protected_unknown: HashSet::default(),
+                pending_nodes: HashSet::default(),
+                pending_unknown: HashSet::default(),
+            }),
+            cond: Condvar::new(),
+        }
+    }
+
+    pub(crate) fn end_delete_node(&self, node: NodeIdx) {
+        let mut g = self.inner.lock().unwrap();
+        g.pending_nodes.remove(&node);
+        drop(g);
+        self.cond.notify_all();
+    }
+
+    /// Snapshot of per-node protection flags (dry-run reporting).
+    pub(crate) fn protected_snapshot(&self) -> Vec<bool> {
+        self.inner.lock().unwrap().protected.clone()
+    }
+
+    /// Snapshot of protected basenames that are not in the graph.
+    pub(crate) fn protected_unknown_snapshot(&self) -> HashSet<String> {
+        self.inner.lock().unwrap().protected_unknown.clone()
+    }
+
+    /// Mark a basename outside the graph as protected. Used to carry
+    /// over roots received before the graph was loaded.
+    pub(crate) fn protect_unknown_basename(&self, basename: &str) {
+        self.inner
+            .lock()
+            .unwrap()
+            .protected_unknown
+            .insert(basename.to_owned());
+    }
+
+    /// Atomically partition `nodes` into (claimed, skipped). Skipped
+    /// nodes are protected. Claimed ones are marked pending, so a later
+    /// `protect()` blocks until their unlink finished. That is what keeps
+    /// a builder from being acked while the row deletion is in flight.
+    pub(crate) fn claim_nodes(&self, nodes: &[NodeIdx]) -> (Vec<NodeIdx>, Vec<NodeIdx>) {
+        let mut g = self.inner.lock().unwrap();
+        let mut claimed = Vec::with_capacity(nodes.len());
+        let mut skipped = Vec::new();
+        for &n in nodes {
+            if g.protected[n.index()] {
+                skipped.push(n);
+            } else {
+                g.pending_nodes.insert(n);
+                claimed.push(n);
+            }
+        }
+        (claimed, skipped)
+    }
+
+    /// Atomically check that the path is unprotected and mark it
+    /// pending, for paths not in the graph.
+    pub(crate) fn try_begin_delete_unknown(&self, basename: &str) -> bool {
+        let mut g = self.inner.lock().unwrap();
+        if g.protected_unknown.contains(basename) {
+            return false;
+        }
+        g.pending_unknown.insert(basename.to_owned());
+        true
+    }
+
+    pub(crate) fn end_delete_unknown(&self, basename: &str) {
+        let mut g = self.inner.lock().unwrap();
+        g.pending_unknown.remove(basename);
+        drop(g);
+        self.cond.notify_all();
+    }
+
+    /// Mark the closure of `basename` as protected and wait until none of
+    /// it is still being deleted.
+    /// Returns `false` if cancelled by GC teardown; the caller must not
+    /// ack then.
+    fn protect(&self, basename: &str, graph: &StoreGraph, idx: &HashMap<String, NodeIdx>) -> bool {
+        let mut g = self.inner.lock().unwrap();
+        // Wait for every pending closure node, including ones an earlier
+        // overlapping protect() already marked. Acking before their
+        // unlinks finish would let the client recreate a path mid-delete.
+        let mut wait_for: Vec<NodeIdx> = Vec::new();
+        if let Some(&root) = idx.get(basename) {
+            let mut stack = vec![root];
+            let mut seen: HashSet<NodeIdx> = HashSet::default();
+            while let Some(n) = stack.pop() {
+                if !seen.insert(n) {
+                    continue;
+                }
+                g.protected[n.index()] = true;
+                if g.pending_nodes.contains(&n) {
+                    wait_for.push(n);
+                }
+                stack.extend(graph.refs(n));
+            }
+        } else {
+            g.protected_unknown.insert(basename.to_owned());
+        }
+
+        let conflict = |g: &LiveInner| {
+            wait_for.iter().any(|n| g.pending_nodes.contains(n))
+                || g.pending_unknown.contains(basename)
+        };
+        while conflict(&g) && !g.cancelled {
+            debug!("synchronising with deletion of {basename}");
+            g = self.cond.wait(g).unwrap();
+        }
+        !g.cancelled
+    }
+
+    /// Unblock every waiting protect(). Used on GC teardown, where an
+    /// error path may leave pending nodes that will never finish.
+    fn cancel(&self) {
+        self.inner.lock().unwrap().cancelled = true;
+        self.cond.notify_all();
+    }
+}
+
+/// Client connections and their handler threads, owned by the server.
+type Conns = Arc<Mutex<Vec<(UnixStream, JoinHandle<()>)>>>;
+
+/// Running GC roots socket server.
+///
+/// Dropping it tears down the listener, removes the socket file, and
+/// joins the accept thread and every client handler.
+pub(crate) struct GcSocketServer {
+    socket_path: PathBuf,
+    shutdown: Arc<AtomicBool>,
+    handle: Option<JoinHandle<()>>,
+    live: Arc<LiveSet>,
+    /// Live client connections. Drop shuts them down and joins their
+    /// handler threads so no `protect()` is still running afterwards.
+    /// Callers snapshot the LiveSet right after dropping the server.
+    conns: Conns,
+}
+
+impl GcSocketServer {
+    /// Bind `state_dir/gc-socket/socket` and spawn the accept thread.
+    pub(crate) fn start(
+        state_dir: &Path,
+        live: Arc<LiveSet>,
+        graph: Arc<StoreGraph>,
+    ) -> Result<Self> {
+        let dir = state_dir.join("gc-socket");
+        fs::create_dir_all(&dir).map_err(|source| Error::GcSocketServe {
+            path: dir.clone(),
+            source,
+        })?;
+        let socket_path = dir.join("socket");
+        let serve_err = |source| Error::GcSocketServe {
+            path: socket_path.clone(),
+            source,
+        };
+        // A previous GC may have crashed without cleaning up.
+        let _ = fs::remove_file(&socket_path);
+        let listener = UnixListener::bind(&socket_path).map_err(serve_err)?;
+        // Builders may run as a different user. Mirror Nix's 0666.
+        fs::set_permissions(&socket_path, fs::Permissions::from_mode(0o666)).map_err(serve_err)?;
+
+        // Owned map: BasenameIndex borrows from the graph and cannot be
+        // sent across threads alongside an Arc<StoreGraph>.
+        let mut idx: HashMap<String, NodeIdx> = HashMap::default();
+        idx.reserve(graph.len());
+        for node in graph.nodes() {
+            if let Some(b) = graph.path(node).strip_prefix(graph.store_prefix()) {
+                idx.insert(b.to_owned(), node);
+            }
+        }
+        let idx = Arc::new(idx);
+        let store_prefix = graph.store_prefix().to_owned();
+        let live_for_drop = Arc::clone(&live);
+        let shutdown = Arc::new(AtomicBool::new(false));
+        let accept_shutdown = Arc::clone(&shutdown);
+        let conns: Conns = Arc::new(Mutex::new(Vec::new()));
+        let accept_conns = Arc::clone(&conns);
+
+        let handle = thread::Builder::new()
+            .name("gc-socket".into())
+            .spawn(move || {
+                accept_loop(
+                    listener,
+                    store_prefix,
+                    live,
+                    graph,
+                    idx,
+                    accept_shutdown,
+                    accept_conns,
+                )
+            })
+            .map_err(|source| Error::SpawnThread {
+                name: "gc-socket",
+                source,
+            })?;
+
+        Ok(GcSocketServer {
+            socket_path,
+            shutdown,
+            handle: Some(handle),
+            live: live_for_drop,
+            conns,
+        })
+    }
+}
+
+impl Drop for GcSocketServer {
+    fn drop(&mut self) {
+        let _ = fs::remove_file(&self.socket_path);
+        self.shutdown.store(true, Ordering::Release);
+        if let Some(h) = self.handle.take() {
+            let _ = h.join();
+        }
+        // Cancel first so a protect() stuck on abandoned pending nodes
+        // cannot deadlock the join below. Unacked clients reconnect via
+        // Nix's addTempRoot restart loop.
+        self.live.cancel();
+        let conns = std::mem::take(&mut *self.conns.lock().unwrap());
+        for (stream, handle) in conns {
+            let _ = stream.shutdown(Shutdown::Both);
+            let _ = handle.join();
+        }
+    }
+}
+
+fn accept_loop(
+    listener: UnixListener,
+    store_prefix: String,
+    live: Arc<LiveSet>,
+    graph: Arc<StoreGraph>,
+    idx: Arc<HashMap<String, NodeIdx>>,
+    shutdown: Arc<AtomicBool>,
+    conns: Conns,
+) {
+    while !shutdown.load(Ordering::Acquire) {
+        let pfd = PollFd::new(listener.as_fd(), PollFlags::POLLIN);
+        match poll(&mut [pfd], PollTimeout::from(10_u8)) {
+            Ok(0) => continue,
+            Err(e) => {
+                // Don't hot-spin if poll fails persistently.
+                debug!("gc-socket poll: {e}");
+                thread::sleep(Duration::from_millis(10));
+                continue;
+            }
+            _ => {}
+        }
+        match listener.accept() {
+            Ok((stream, _)) => {
+                let store_prefix = store_prefix.clone();
+                let live = Arc::clone(&live);
+                let graph = Arc::clone(&graph);
+                let idx = Arc::clone(&idx);
+                let Ok(stream2) = stream.try_clone() else {
+                    continue;
+                };
+                let spawned =
+                    thread::Builder::new()
+                        .name("gc-socket-conn".into())
+                        .spawn(move || {
+                            if let Err(e) =
+                                handle_client(stream, &store_prefix, &live, &graph, &idx)
+                            {
+                                debug!("gc-socket client: {e}");
+                            }
+                        });
+                if let Ok(handle) = spawned {
+                    let mut g = conns.lock().unwrap();
+                    // Keep the list from growing with finished handlers.
+                    g.retain(|(_, h)| !h.is_finished());
+                    g.push((stream2, handle));
+                }
+            }
+            Err(e) if e.kind() == ErrorKind::Interrupted => {}
+            Err(e) => {
+                // Transient failures (EMFILE/ECONNABORTED) must not kill
+                // the server. Back off briefly and keep accepting.
+                warn!("gc-socket accept: {e}");
+                thread::sleep(Duration::from_millis(100));
+            }
+        }
+    }
+}
+
+fn handle_client(
+    stream: UnixStream,
+    store_prefix: &str,
+    live: &LiveSet,
+    graph: &StoreGraph,
+    idx: &HashMap<String, NodeIdx>,
+) -> Result<()> {
+    // The socket is world-writable. A peer streaming data without a
+    // newline must not OOM the GC.
+    const MAX_LINE: u64 = 64 * 1024;
+    let client_err = |source| Error::ClientIo { source };
+    let mut writer = stream.try_clone().map_err(client_err)?;
+    let mut reader = BufReader::new(stream);
+    let mut line = String::new();
+    loop {
+        line.clear();
+        let n = reader
+            .by_ref()
+            .take(MAX_LINE)
+            .read_line(&mut line)
+            .map_err(client_err)?;
+        if n == 0 {
+            return Ok(());
+        }
+        if n as u64 == MAX_LINE && !line.ends_with('\n') {
+            return Err(Error::LineTooLong);
+        }
+        let path = line.trim_end_matches('\n');
+        if let Some(basename) = path.strip_prefix(store_prefix).filter(|b| !b.is_empty()) {
+            debug!("got new GC root '{path}'");
+            if !live.protect(basename, graph, idx) {
+                return Ok(());
+            }
+        } else {
+            warn!("gc-socket: received garbage instead of a root: {path:?}");
+        }
+        writer.write_all(b"1").map_err(client_err)?;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::mpsc;
+    use std::time::Duration;
+
+    use super::*;
+    use crate::testutil::graph;
+
+    /// Single-node claim, as the deleter does per chunk via claim_nodes.
+    fn claim(live: &LiveSet, n: NodeIdx) -> bool {
+        let (claimed, _) = live.claim_nodes(&[n]);
+        !claimed.is_empty()
+    }
+
+    fn node(g: &StoreGraph, name: &str) -> NodeIdx {
+        g.nodes()
+            .find(|&n| g.path(n) == format!("/nix/store/{name}"))
+            .unwrap()
+    }
+
+    #[test]
+    fn drop_returns_when_idle_accept_loop_is_waiting() {
+        let g = graph(&[]);
+        let live = Arc::new(LiveSet::new(0));
+        let dir = tempfile::tempdir().unwrap();
+        let server = GcSocketServer::start(dir.path(), live, g).unwrap();
+
+        let (tx, rx) = mpsc::channel();
+        let handle = std::thread::spawn(move || {
+            drop(server);
+            let _ = tx.send(());
+        });
+
+        rx.recv_timeout(Duration::from_secs(2))
+            .expect("GcSocketServer::drop did not finish");
+        handle.join().unwrap();
+    }
+
+    #[test]
+    fn protect_marks_closure_and_blocks_deletion() {
+        // a -> b -> c, d standalone
+        let g = graph(&[("a", &[1]), ("b", &[2]), ("c", &[]), ("d", &[])]);
+        let live = Arc::new(LiveSet::new(g.len()));
+        let dir = tempfile::tempdir().unwrap();
+        let server = GcSocketServer::start(dir.path(), Arc::clone(&live), Arc::clone(&g)).unwrap();
+        let sock = dir.path().join("gc-socket/socket");
+
+        let mut conn = UnixStream::connect(&sock).unwrap();
+        conn.write_all(b"/nix/store/a\n").unwrap();
+        let mut ack = [0u8; 1];
+        conn.read_exact(&mut ack).unwrap();
+        assert_eq!(ack, [b'1']);
+
+        // The closure of a (a, b, c) is protected. d is still deletable.
+        assert!(!claim(&live, node(&g, "a")));
+        assert!(!claim(&live, node(&g, "b")));
+        assert!(!claim(&live, node(&g, "c")));
+        assert!(claim(&live, node(&g, "d")));
+        live.end_delete_node(node(&g, "d"));
+
+        drop(server);
+        assert!(!sock.exists());
+    }
+
+    #[test]
+    fn protect_blocks_until_pending_delete_finishes() {
+        let g = graph(&[("x", &[])]);
+        let live = Arc::new(LiveSet::new(g.len()));
+        let dir = tempfile::tempdir().unwrap();
+        let _server = GcSocketServer::start(dir.path(), Arc::clone(&live), Arc::clone(&g)).unwrap();
+        let sock = dir.path().join("gc-socket/socket");
+
+        // Simulate the deleter claiming x.
+        let x = node(&g, "x");
+        assert!(claim(&live, x));
+
+        let mut conn = UnixStream::connect(&sock).unwrap();
+        conn.write_all(b"/nix/store/x\n").unwrap();
+        // The ack must not arrive until end_delete_node is called.
+        conn.set_read_timeout(Some(Duration::from_millis(50)))
+            .unwrap();
+        let mut ack = [0u8; 1];
+        assert!(conn.read_exact(&mut ack).is_err(), "ack arrived too early");
+
+        live.end_delete_node(x);
+        conn.set_read_timeout(None).unwrap();
+        conn.read_exact(&mut ack).unwrap();
+        assert_eq!(ack, [b'1']);
+        // After protection, a fresh delete attempt is refused.
+        assert!(!claim(&live, x));
+    }
+
+    #[test]
+    fn cancelled_protect_is_not_acked() {
+        let g = graph(&[("x", &[])]);
+        let live = Arc::new(LiveSet::new(g.len()));
+        let dir = tempfile::tempdir().unwrap();
+        let server = GcSocketServer::start(dir.path(), Arc::clone(&live), Arc::clone(&g)).unwrap();
+        let sock = dir.path().join("gc-socket/socket");
+
+        let x = node(&g, "x");
+        assert!(claim(&live, x));
+        let mut conn = UnixStream::connect(&sock).unwrap();
+        conn.write_all(b"/nix/store/x\n").unwrap();
+        conn.set_read_timeout(Some(Duration::from_millis(100)))
+            .unwrap();
+        let mut ack = [0u8; 1];
+        assert!(conn.read_exact(&mut ack).is_err(), "ack arrived too early");
+
+        // GC bails out with x still pending. Cancel with the server still
+        // up so the outcome does not race the connection shutdown.
+        live.cancel();
+        assert!(
+            conn.read_exact(&mut ack).is_err(),
+            "cancelled protect must not be acked"
+        );
+        drop(server);
+        let mut rest = Vec::new();
+        conn.read_to_end(&mut rest).unwrap();
+        assert!(rest.is_empty());
+    }
+
+    #[test]
+    fn protect_waits_for_already_protected_pending_node() {
+        // Two roots a -> c and b -> c share a leaf. While c is mid-unlink,
+        // protecting a marks c protected and waits. A second protect for b
+        // must also wait for c, not ack early just because c is already
+        // protected.
+        let g = graph(&[("a", &[2]), ("b", &[2]), ("c", &[])]);
+        let live = Arc::new(LiveSet::new(g.len()));
+        let dir = tempfile::tempdir().unwrap();
+        let _server = GcSocketServer::start(dir.path(), Arc::clone(&live), Arc::clone(&g)).unwrap();
+        let sock = dir.path().join("gc-socket/socket");
+
+        // c is in flight.
+        let c = node(&g, "c");
+        assert!(claim(&live, c));
+
+        let mut conn_a = UnixStream::connect(&sock).unwrap();
+        conn_a.write_all(b"/nix/store/a\n").unwrap();
+        conn_a
+            .set_read_timeout(Some(Duration::from_millis(50)))
+            .unwrap();
+        let mut ack = [0u8; 1];
+        assert!(conn_a.read_exact(&mut ack).is_err(), "a acked too early");
+
+        // c is now protected (by a's protect) but still pending. b's
+        // protect must not ack yet.
+        let mut conn_b = UnixStream::connect(&sock).unwrap();
+        conn_b.write_all(b"/nix/store/b\n").unwrap();
+        conn_b
+            .set_read_timeout(Some(Duration::from_millis(50)))
+            .unwrap();
+        assert!(conn_b.read_exact(&mut ack).is_err(), "b acked too early");
+
+        // c finishes, both unblock.
+        live.end_delete_node(c);
+        for conn in [&mut conn_a, &mut conn_b] {
+            conn.set_read_timeout(None).unwrap();
+            conn.read_exact(&mut ack).unwrap();
+            assert_eq!(ack, [b'1']);
+        }
+    }
+
+    #[test]
+    fn claim_nodes_partitions_and_blocks_protect() {
+        let g = graph(&[("a", &[]), ("b", &[])]);
+        let live = Arc::new(LiveSet::new(g.len()));
+        let dir = tempfile::tempdir().unwrap();
+        let _server = GcSocketServer::start(dir.path(), Arc::clone(&live), Arc::clone(&g)).unwrap();
+        let sock = dir.path().join("gc-socket/socket");
+
+        // Protect b up front. claim must skip it and claim a.
+        let mut conn = UnixStream::connect(&sock).unwrap();
+        conn.write_all(b"/nix/store/b\n").unwrap();
+        let mut ack = [0u8; 1];
+        conn.read_exact(&mut ack).unwrap();
+
+        let (a, b) = (node(&g, "a"), node(&g, "b"));
+        let (claimed, skipped) = live.claim_nodes(&[a, b]);
+        assert_eq!(claimed, vec![a]);
+        assert_eq!(skipped, vec![b]);
+
+        // A protect for the claimed node must block until its unlink is
+        // done. The DB row is already gone, so acking earlier would tell
+        // the builder a deleted row is protected.
+        conn.write_all(b"/nix/store/a\n").unwrap();
+        conn.set_read_timeout(Some(Duration::from_millis(50)))
+            .unwrap();
+        assert!(conn.read_exact(&mut ack).is_err(), "acked mid-deletion");
+
+        live.end_delete_node(a);
+        conn.set_read_timeout(None).unwrap();
+        conn.read_exact(&mut ack).unwrap();
+        assert_eq!(ack, [b'1']);
+    }
+
+    #[test]
+    fn drop_joins_handlers_and_snapshot_sees_acked_roots() {
+        // Every root acked before the server is dropped must be visible
+        // in the snapshot taken right after, even while the client
+        // connection is still open.
+        let g = graph(&[]);
+        let live = Arc::new(LiveSet::new(0));
+        let dir = tempfile::tempdir().unwrap();
+        let server = GcSocketServer::start(dir.path(), Arc::clone(&live), g).unwrap();
+        let sock = dir.path().join("gc-socket/socket");
+
+        let mut conn = UnixStream::connect(&sock).unwrap();
+        conn.write_all(b"/nix/store/early-root\n").unwrap();
+        let mut ack = [0u8; 1];
+        conn.read_exact(&mut ack).unwrap();
+        assert_eq!(ack, [b'1']);
+
+        // The handler is blocked in read_line. Drop must not hang.
+        let (tx, rx) = mpsc::channel();
+        let joiner = std::thread::spawn(move || {
+            drop(server);
+            let _ = tx.send(());
+        });
+        rx.recv_timeout(Duration::from_secs(2))
+            .expect("GcSocketServer::drop hung joining a live connection");
+        joiner.join().unwrap();
+
+        assert!(
+            live.protected_unknown_snapshot().contains("early-root"),
+            "acked root missing from post-drop snapshot"
+        );
+    }
+
+    #[test]
+    fn unknown_path_protected_by_basename() {
+        let g = graph(&[]);
+        let live = Arc::new(LiveSet::new(0));
+        let dir = tempfile::tempdir().unwrap();
+        let _server = GcSocketServer::start(dir.path(), Arc::clone(&live), Arc::clone(&g)).unwrap();
+        let sock = dir.path().join("gc-socket/socket");
+
+        let mut conn = UnixStream::connect(&sock).unwrap();
+        conn.write_all(b"/nix/store/zzz-fresh\n").unwrap();
+        let mut ack = [0u8; 1];
+        conn.read_exact(&mut ack).unwrap();
+
+        assert!(!live.try_begin_delete_unknown("zzz-fresh"));
+        assert!(live.try_begin_delete_unknown("other"));
+        live.end_delete_unknown("other");
+    }
+}

--- a/harmonia-store-gc/src/gc_socket.rs
+++ b/harmonia-store-gc/src/gc_socket.rs
@@ -1,0 +1,617 @@
+// SPDX-FileCopyrightText: 2026 Jörg Thalheim
+// SPDX-License-Identifier: MIT
+
+//! GC roots socket, protocol-compatible with `nix-store --gc`.
+//!
+//! Builders that fail to acquire a shared `gc.lock` connect to
+//! `state/gc-socket/socket`, send newline-terminated store paths, and
+//! wait for a single `'1'` ack per line. We mark the closure protected
+//! before acking so the builder cannot recreate a path we are still
+//! unlinking.
+
+use std::fs;
+use std::io::{BufRead, BufReader, ErrorKind, Read, Write};
+use std::os::unix::fs::PermissionsExt;
+use std::os::unix::io::AsFd;
+use std::os::unix::net::{UnixListener, UnixStream};
+use std::path::{Path, PathBuf};
+use std::sync::{
+    Arc, Condvar, Mutex,
+    atomic::{AtomicBool, Ordering},
+};
+use std::thread::JoinHandle;
+
+use harmonia_store_db::{NodeIdx, StoreGraph};
+use nix::poll::{PollFd, PollFlags, PollTimeout, poll};
+use tracing::{debug, warn};
+
+use crate::error::{Error, Result};
+use crate::{HashMap, HashSet};
+
+/// Liveness state shared between the deletion loop and the socket server.
+///
+/// Roots from clients can only flip dead -> protected. `pending` tracks
+/// in-flight unlinks so `protect()` waits for them before acking.
+pub struct LiveSet {
+    inner: Mutex<LiveInner>,
+    cond: Condvar,
+}
+
+struct LiveInner {
+    /// GC teardown in progress. protect() must stop waiting.
+    cancelled: bool,
+    /// Per-node "do not delete" flag.
+    protected: Vec<bool>,
+    /// Protected basenames not (yet) in the graph, e.g. paths registered
+    /// after our database snapshot.
+    protected_unknown: HashSet<String>,
+    /// Graph nodes currently being deleted.
+    pending_nodes: HashSet<NodeIdx>,
+    /// Unknown-on-disk basenames currently being deleted.
+    pending_unknown: HashSet<String>,
+}
+
+impl LiveSet {
+    pub fn new(n_nodes: usize) -> Self {
+        LiveSet {
+            inner: Mutex::new(LiveInner {
+                cancelled: false,
+                protected: vec![false; n_nodes],
+                protected_unknown: HashSet::default(),
+                pending_nodes: HashSet::default(),
+                pending_unknown: HashSet::default(),
+            }),
+            cond: Condvar::new(),
+        }
+    }
+
+    pub fn end_delete_node(&self, node: NodeIdx) {
+        let mut g = self.inner.lock().unwrap();
+        g.pending_nodes.remove(&node);
+        drop(g);
+        self.cond.notify_all();
+    }
+
+    /// Snapshot of per-node protection flags (dry-run reporting).
+    pub fn protected_snapshot(&self) -> Vec<bool> {
+        self.inner.lock().unwrap().protected.clone()
+    }
+
+    /// Snapshot of protected basenames that are not in the graph.
+    pub fn protected_unknown_snapshot(&self) -> HashSet<String> {
+        self.inner.lock().unwrap().protected_unknown.clone()
+    }
+
+    /// Mark a basename outside the graph as protected. Used to carry
+    /// over roots received before the graph was loaded.
+    pub fn protect_unknown_basename(&self, basename: &str) {
+        self.inner
+            .lock()
+            .unwrap()
+            .protected_unknown
+            .insert(basename.to_owned());
+    }
+
+    /// Atomically partition `nodes` into (claimed, skipped). Skipped
+    /// nodes are protected. Claimed ones are marked pending, so a later
+    /// `protect()` blocks until their unlink finished. That is what keeps
+    /// a builder from being acked while the row deletion is in flight.
+    pub fn claim_nodes(&self, nodes: &[NodeIdx]) -> (Vec<NodeIdx>, Vec<NodeIdx>) {
+        let mut g = self.inner.lock().unwrap();
+        let mut claimed = Vec::with_capacity(nodes.len());
+        let mut skipped = Vec::new();
+        for &n in nodes {
+            if g.protected[n.index()] {
+                skipped.push(n);
+            } else {
+                g.pending_nodes.insert(n);
+                claimed.push(n);
+            }
+        }
+        (claimed, skipped)
+    }
+
+    /// Atomically check that the path is unprotected and mark it
+    /// pending, for paths not in the graph.
+    pub fn try_begin_delete_unknown(&self, basename: &str) -> bool {
+        let mut g = self.inner.lock().unwrap();
+        if g.protected_unknown.contains(basename) {
+            return false;
+        }
+        g.pending_unknown.insert(basename.to_owned());
+        true
+    }
+
+    pub fn end_delete_unknown(&self, basename: &str) {
+        let mut g = self.inner.lock().unwrap();
+        g.pending_unknown.remove(basename);
+        drop(g);
+        self.cond.notify_all();
+    }
+
+    /// Mark the closure of `basename` as protected and wait until none of
+    /// it is still being deleted.
+    fn protect(&self, basename: &str, graph: &StoreGraph, idx: &HashMap<String, NodeIdx>) {
+        let mut g = self.inner.lock().unwrap();
+        // Wait for every pending closure node, including ones an earlier
+        // overlapping protect() already marked. Acking before their
+        // unlinks finish would let the client recreate a path mid-delete.
+        let mut wait_for: Vec<NodeIdx> = Vec::new();
+        if let Some(&root) = idx.get(basename) {
+            let mut stack = vec![root];
+            let mut seen: HashSet<NodeIdx> = HashSet::default();
+            while let Some(n) = stack.pop() {
+                if !seen.insert(n) {
+                    continue;
+                }
+                g.protected[n.index()] = true;
+                if g.pending_nodes.contains(&n) {
+                    wait_for.push(n);
+                }
+                stack.extend(graph.refs(n));
+            }
+        } else {
+            g.protected_unknown.insert(basename.to_owned());
+        }
+
+        let conflict = |g: &LiveInner| {
+            wait_for.iter().any(|n| g.pending_nodes.contains(n))
+                || g.pending_unknown.contains(basename)
+        };
+        while conflict(&g) && !g.cancelled {
+            debug!("synchronising with deletion of {basename}");
+            g = self.cond.wait(g).unwrap();
+        }
+    }
+
+    /// Unblock every waiting protect(). Used on GC teardown, where an
+    /// error path may leave pending nodes that will never finish.
+    fn cancel(&self) {
+        self.inner.lock().unwrap().cancelled = true;
+        self.cond.notify_all();
+    }
+}
+
+/// Client connections and their handler threads, owned by the server.
+type Conns = Arc<Mutex<Vec<(UnixStream, JoinHandle<()>)>>>;
+
+/// Running GC roots socket server.
+///
+/// Dropping it tears down the listener, removes the socket file, and
+/// joins the accept thread and every client handler.
+pub struct GcSocketServer {
+    socket_path: PathBuf,
+    shutdown: Arc<AtomicBool>,
+    handle: Option<JoinHandle<()>>,
+    live: Arc<LiveSet>,
+    /// Live client connections. Drop shuts them down and joins their
+    /// handler threads so no `protect()` is still running afterwards.
+    /// Callers snapshot the LiveSet right after dropping the server.
+    conns: Conns,
+}
+
+impl GcSocketServer {
+    /// Bind `state_dir/gc-socket/socket` and spawn the accept thread.
+    pub fn start(state_dir: &Path, live: Arc<LiveSet>, graph: Arc<StoreGraph>) -> Result<Self> {
+        let dir = state_dir.join("gc-socket");
+        fs::create_dir_all(&dir).map_err(|source| Error::GcSocketServe {
+            path: dir.clone(),
+            source,
+        })?;
+        let socket_path = dir.join("socket");
+        let serve_err = |source| Error::GcSocketServe {
+            path: socket_path.clone(),
+            source,
+        };
+        // A previous GC may have crashed without cleaning up.
+        let _ = fs::remove_file(&socket_path);
+        let listener = UnixListener::bind(&socket_path).map_err(serve_err)?;
+        // Builders may run as a different user. Mirror Nix's 0666.
+        fs::set_permissions(&socket_path, fs::Permissions::from_mode(0o666)).map_err(serve_err)?;
+
+        // Owned map: BasenameIndex borrows from the graph and cannot be
+        // sent across threads alongside an Arc<StoreGraph>.
+        let mut idx: HashMap<String, NodeIdx> = HashMap::default();
+        idx.reserve(graph.len());
+        for node in graph.nodes() {
+            if let Some(b) = graph.path(node).strip_prefix(graph.store_prefix()) {
+                idx.insert(b.to_owned(), node);
+            }
+        }
+        let idx = Arc::new(idx);
+        let store_prefix = graph.store_prefix().to_owned();
+        let live_for_drop = Arc::clone(&live);
+        let shutdown = Arc::new(AtomicBool::new(false));
+        let accept_shutdown = Arc::clone(&shutdown);
+        let conns: Conns = Arc::new(Mutex::new(Vec::new()));
+        let accept_conns = Arc::clone(&conns);
+
+        let handle = std::thread::Builder::new()
+            .name("gc-socket".into())
+            .spawn(move || {
+                accept_loop(
+                    listener,
+                    store_prefix,
+                    live,
+                    graph,
+                    idx,
+                    accept_shutdown,
+                    accept_conns,
+                )
+            })
+            .map_err(|source| Error::SpawnThread {
+                name: "gc-socket",
+                source,
+            })?;
+
+        Ok(GcSocketServer {
+            socket_path,
+            shutdown,
+            handle: Some(handle),
+            live: live_for_drop,
+            conns,
+        })
+    }
+}
+
+impl Drop for GcSocketServer {
+    fn drop(&mut self) {
+        let _ = fs::remove_file(&self.socket_path);
+        self.shutdown.store(true, Ordering::Release);
+        if let Some(h) = self.handle.take() {
+            let _ = h.join();
+        }
+        // Cancel first so a protect() stuck on abandoned pending nodes
+        // cannot deadlock the join below. Unacked clients reconnect via
+        // Nix's addTempRoot restart loop.
+        self.live.cancel();
+        let conns = std::mem::take(&mut *self.conns.lock().unwrap());
+        for (stream, handle) in conns {
+            let _ = stream.shutdown(std::net::Shutdown::Both);
+            let _ = handle.join();
+        }
+    }
+}
+
+fn accept_loop(
+    listener: UnixListener,
+    store_prefix: String,
+    live: Arc<LiveSet>,
+    graph: Arc<StoreGraph>,
+    idx: Arc<HashMap<String, NodeIdx>>,
+    shutdown: Arc<AtomicBool>,
+    conns: Conns,
+) {
+    while !shutdown.load(Ordering::Acquire) {
+        let pfd = PollFd::new(listener.as_fd(), PollFlags::POLLIN);
+        match poll(&mut [pfd], PollTimeout::from(10_u8)) {
+            Ok(0) => continue,
+            Err(e) => {
+                // Don't hot-spin if poll fails persistently.
+                debug!("gc-socket poll: {e}");
+                std::thread::sleep(std::time::Duration::from_millis(10));
+                continue;
+            }
+            _ => {}
+        }
+        match listener.accept() {
+            Ok((stream, _)) => {
+                let store_prefix = store_prefix.clone();
+                let live = Arc::clone(&live);
+                let graph = Arc::clone(&graph);
+                let idx = Arc::clone(&idx);
+                let Ok(stream2) = stream.try_clone() else {
+                    continue;
+                };
+                let spawned = std::thread::Builder::new()
+                    .name("gc-socket-conn".into())
+                    .spawn(move || {
+                        if let Err(e) = handle_client(stream, &store_prefix, &live, &graph, &idx) {
+                            debug!("gc-socket client: {e}");
+                        }
+                    });
+                if let Ok(handle) = spawned {
+                    let mut g = conns.lock().unwrap();
+                    // Keep the list from growing with finished handlers.
+                    g.retain(|(_, h)| !h.is_finished());
+                    g.push((stream2, handle));
+                }
+            }
+            Err(e) if e.kind() == ErrorKind::Interrupted => {}
+            Err(e) => {
+                // Transient failures (EMFILE/ECONNABORTED) must not kill
+                // the server. Back off briefly and keep accepting.
+                warn!("gc-socket accept: {e}");
+                std::thread::sleep(std::time::Duration::from_millis(100));
+            }
+        }
+    }
+}
+
+fn handle_client(
+    stream: UnixStream,
+    store_prefix: &str,
+    live: &LiveSet,
+    graph: &StoreGraph,
+    idx: &HashMap<String, NodeIdx>,
+) -> Result<()> {
+    // The socket is world-writable. A peer streaming data without a
+    // newline must not OOM the GC.
+    const MAX_LINE: u64 = 64 * 1024;
+    let client_err = |source| Error::ClientIo { source };
+    let mut writer = stream.try_clone().map_err(client_err)?;
+    let mut reader = BufReader::new(stream);
+    let mut line = String::new();
+    loop {
+        line.clear();
+        let n = reader
+            .by_ref()
+            .take(MAX_LINE)
+            .read_line(&mut line)
+            .map_err(client_err)?;
+        if n == 0 {
+            return Ok(());
+        }
+        if n as u64 == MAX_LINE && !line.ends_with('\n') {
+            return Err(Error::LineTooLong);
+        }
+        let path = line.trim_end_matches('\n');
+        if let Some(basename) = path.strip_prefix(store_prefix).filter(|b| !b.is_empty()) {
+            debug!("got new GC root '{path}'");
+            live.protect(basename, graph, idx);
+        } else {
+            warn!("gc-socket: received garbage instead of a root: {path:?}");
+        }
+        writer.write_all(b"1").map_err(client_err)?;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use harmonia_store_db::{GraphOptions, StoreDb};
+    use harmonia_store_path::StoreDir;
+    use std::io::Read;
+
+    /// Load a graph with the given nodes and edges. `refs` are indices
+    /// into `paths`.
+    fn graph(paths: &[(&str, &[usize])]) -> Arc<StoreGraph> {
+        let db = StoreDb::open_memory().unwrap();
+        let mut ids = Vec::new();
+        for (name, _) in paths {
+            db.connection()
+                .execute(
+                    "INSERT INTO ValidPaths (path, hash, registrationTime) \
+                     VALUES (?, 'sha256:x', 1)",
+                    [format!("/nix/store/{name}")],
+                )
+                .unwrap();
+            ids.push(db.connection().last_insert_rowid());
+        }
+        for (i, (_, refs)) in paths.iter().enumerate() {
+            for &r in refs.iter() {
+                db.connection()
+                    .execute(
+                        "INSERT INTO Refs (referrer, reference) VALUES (?, ?)",
+                        [ids[i], ids[r]],
+                    )
+                    .unwrap();
+            }
+        }
+        let options = GraphOptions {
+            keep_derivations: false,
+            keep_outputs: false,
+        };
+        Arc::new(db.load_graph(&StoreDir::default(), &options).unwrap())
+    }
+
+    /// Single-node claim, as the deleter does per chunk via claim_nodes.
+    fn claim(live: &LiveSet, n: NodeIdx) -> bool {
+        let (claimed, _) = live.claim_nodes(&[n]);
+        !claimed.is_empty()
+    }
+
+    fn node(g: &StoreGraph, name: &str) -> NodeIdx {
+        g.nodes()
+            .find(|&n| g.path(n) == format!("/nix/store/{name}"))
+            .unwrap()
+    }
+
+    #[test]
+    fn drop_returns_when_idle_accept_loop_is_waiting() {
+        let g = graph(&[]);
+        let live = Arc::new(LiveSet::new(0));
+        let dir = tempfile::tempdir().unwrap();
+        let server = GcSocketServer::start(dir.path(), live, g).unwrap();
+
+        let (tx, rx) = std::sync::mpsc::channel();
+        let handle = std::thread::spawn(move || {
+            drop(server);
+            let _ = tx.send(());
+        });
+
+        rx.recv_timeout(std::time::Duration::from_secs(2))
+            .expect("GcSocketServer::drop did not finish");
+        handle.join().unwrap();
+    }
+
+    #[test]
+    fn protect_marks_closure_and_blocks_deletion() {
+        // a -> b -> c, d standalone
+        let g = graph(&[("a", &[1]), ("b", &[2]), ("c", &[]), ("d", &[])]);
+        let live = Arc::new(LiveSet::new(g.len()));
+        let dir = tempfile::tempdir().unwrap();
+        let server = GcSocketServer::start(dir.path(), Arc::clone(&live), Arc::clone(&g)).unwrap();
+        let sock = dir.path().join("gc-socket/socket");
+
+        let mut conn = UnixStream::connect(&sock).unwrap();
+        conn.write_all(b"/nix/store/a\n").unwrap();
+        let mut ack = [0u8; 1];
+        conn.read_exact(&mut ack).unwrap();
+        assert_eq!(ack, [b'1']);
+
+        // The closure of a (a, b, c) is protected. d is still deletable.
+        assert!(!claim(&live, node(&g, "a")));
+        assert!(!claim(&live, node(&g, "b")));
+        assert!(!claim(&live, node(&g, "c")));
+        assert!(claim(&live, node(&g, "d")));
+        live.end_delete_node(node(&g, "d"));
+
+        drop(server);
+        assert!(!sock.exists());
+    }
+
+    #[test]
+    fn protect_blocks_until_pending_delete_finishes() {
+        let g = graph(&[("x", &[])]);
+        let live = Arc::new(LiveSet::new(g.len()));
+        let dir = tempfile::tempdir().unwrap();
+        let _server = GcSocketServer::start(dir.path(), Arc::clone(&live), Arc::clone(&g)).unwrap();
+        let sock = dir.path().join("gc-socket/socket");
+
+        // Simulate the deleter claiming x.
+        let x = node(&g, "x");
+        assert!(claim(&live, x));
+
+        let mut conn = UnixStream::connect(&sock).unwrap();
+        conn.write_all(b"/nix/store/x\n").unwrap();
+        // The ack must not arrive until end_delete_node is called.
+        conn.set_read_timeout(Some(std::time::Duration::from_millis(50)))
+            .unwrap();
+        let mut ack = [0u8; 1];
+        assert!(conn.read_exact(&mut ack).is_err(), "ack arrived too early");
+
+        live.end_delete_node(x);
+        conn.set_read_timeout(None).unwrap();
+        conn.read_exact(&mut ack).unwrap();
+        assert_eq!(ack, [b'1']);
+        // After protection, a fresh delete attempt is refused.
+        assert!(!claim(&live, x));
+    }
+
+    #[test]
+    fn protect_waits_for_already_protected_pending_node() {
+        // Two roots a -> c and b -> c share a leaf. While c is mid-unlink,
+        // protecting a marks c protected and waits. A second protect for b
+        // must also wait for c, not ack early just because c is already
+        // protected.
+        let g = graph(&[("a", &[2]), ("b", &[2]), ("c", &[])]);
+        let live = Arc::new(LiveSet::new(g.len()));
+        let dir = tempfile::tempdir().unwrap();
+        let _server = GcSocketServer::start(dir.path(), Arc::clone(&live), Arc::clone(&g)).unwrap();
+        let sock = dir.path().join("gc-socket/socket");
+
+        // c is in flight.
+        let c = node(&g, "c");
+        assert!(claim(&live, c));
+
+        let mut conn_a = UnixStream::connect(&sock).unwrap();
+        conn_a.write_all(b"/nix/store/a\n").unwrap();
+        conn_a
+            .set_read_timeout(Some(std::time::Duration::from_millis(50)))
+            .unwrap();
+        let mut ack = [0u8; 1];
+        assert!(conn_a.read_exact(&mut ack).is_err(), "a acked too early");
+
+        // c is now protected (by a's protect) but still pending. b's
+        // protect must not ack yet.
+        let mut conn_b = UnixStream::connect(&sock).unwrap();
+        conn_b.write_all(b"/nix/store/b\n").unwrap();
+        conn_b
+            .set_read_timeout(Some(std::time::Duration::from_millis(50)))
+            .unwrap();
+        assert!(conn_b.read_exact(&mut ack).is_err(), "b acked too early");
+
+        // c finishes, both unblock.
+        live.end_delete_node(c);
+        for conn in [&mut conn_a, &mut conn_b] {
+            conn.set_read_timeout(None).unwrap();
+            conn.read_exact(&mut ack).unwrap();
+            assert_eq!(ack, [b'1']);
+        }
+    }
+
+    #[test]
+    fn claim_nodes_partitions_and_blocks_protect() {
+        let g = graph(&[("a", &[]), ("b", &[])]);
+        let live = Arc::new(LiveSet::new(g.len()));
+        let dir = tempfile::tempdir().unwrap();
+        let _server = GcSocketServer::start(dir.path(), Arc::clone(&live), Arc::clone(&g)).unwrap();
+        let sock = dir.path().join("gc-socket/socket");
+
+        // Protect b up front. claim must skip it and claim a.
+        let mut conn = UnixStream::connect(&sock).unwrap();
+        conn.write_all(b"/nix/store/b\n").unwrap();
+        let mut ack = [0u8; 1];
+        conn.read_exact(&mut ack).unwrap();
+
+        let (a, b) = (node(&g, "a"), node(&g, "b"));
+        let (claimed, skipped) = live.claim_nodes(&[a, b]);
+        assert_eq!(claimed, vec![a]);
+        assert_eq!(skipped, vec![b]);
+
+        // A protect for the claimed node must block until its unlink is
+        // done. The DB row is already gone, so acking earlier would tell
+        // the builder a deleted row is protected.
+        conn.write_all(b"/nix/store/a\n").unwrap();
+        conn.set_read_timeout(Some(std::time::Duration::from_millis(50)))
+            .unwrap();
+        assert!(conn.read_exact(&mut ack).is_err(), "acked mid-deletion");
+
+        live.end_delete_node(a);
+        conn.set_read_timeout(None).unwrap();
+        conn.read_exact(&mut ack).unwrap();
+        assert_eq!(ack, [b'1']);
+    }
+
+    #[test]
+    fn drop_joins_handlers_and_snapshot_sees_acked_roots() {
+        // Every root acked before the server is dropped must be visible
+        // in the snapshot taken right after, even while the client
+        // connection is still open.
+        let g = graph(&[]);
+        let live = Arc::new(LiveSet::new(0));
+        let dir = tempfile::tempdir().unwrap();
+        let server = GcSocketServer::start(dir.path(), Arc::clone(&live), g).unwrap();
+        let sock = dir.path().join("gc-socket/socket");
+
+        let mut conn = UnixStream::connect(&sock).unwrap();
+        conn.write_all(b"/nix/store/early-root\n").unwrap();
+        let mut ack = [0u8; 1];
+        conn.read_exact(&mut ack).unwrap();
+        assert_eq!(ack, [b'1']);
+
+        // The handler is blocked in read_line. Drop must not hang.
+        let (tx, rx) = std::sync::mpsc::channel();
+        let joiner = std::thread::spawn(move || {
+            drop(server);
+            let _ = tx.send(());
+        });
+        rx.recv_timeout(std::time::Duration::from_secs(2))
+            .expect("GcSocketServer::drop hung joining a live connection");
+        joiner.join().unwrap();
+
+        assert!(
+            live.protected_unknown_snapshot().contains("early-root"),
+            "acked root missing from post-drop snapshot"
+        );
+    }
+
+    #[test]
+    fn unknown_path_protected_by_basename() {
+        let g = graph(&[]);
+        let live = Arc::new(LiveSet::new(0));
+        let dir = tempfile::tempdir().unwrap();
+        let _server = GcSocketServer::start(dir.path(), Arc::clone(&live), Arc::clone(&g)).unwrap();
+        let sock = dir.path().join("gc-socket/socket");
+
+        let mut conn = UnixStream::connect(&sock).unwrap();
+        conn.write_all(b"/nix/store/zzz-fresh\n").unwrap();
+        let mut ack = [0u8; 1];
+        conn.read_exact(&mut ack).unwrap();
+
+        assert!(!live.try_begin_delete_unknown("zzz-fresh"));
+        assert!(live.try_begin_delete_unknown("other"));
+        live.end_delete_unknown("other");
+    }
+}

--- a/harmonia-store-gc/src/lib.rs
+++ b/harmonia-store-gc/src/lib.rs
@@ -17,7 +17,9 @@
 //! Entry point: [`gc::collect_garbage`] with a [`store::GcStore`].
 
 mod error;
-pub mod roots;
+pub mod gc;
+pub mod gc_socket;
+pub(crate) mod roots;
 pub mod store;
 pub mod temp_roots;
 
@@ -27,6 +29,6 @@ pub use error::{Error, Result};
 ///
 /// SipHash showed up in GC profiles when hashing millions of ~50-char
 /// store paths, so foldhash is used instead.
-pub type HashMap<K, V> = std::collections::HashMap<K, V, foldhash::fast::RandomState>;
+pub(crate) type HashMap<K, V> = std::collections::HashMap<K, V, foldhash::fast::RandomState>;
 /// Hash set counterpart of [`HashMap`].
 pub(crate) type HashSet<K> = std::collections::HashSet<K, foldhash::fast::RandomState>;

--- a/harmonia-store-gc/src/lib.rs
+++ b/harmonia-store-gc/src/lib.rs
@@ -14,19 +14,46 @@
 //! paths while a collection is in progress. Running it next to a busy
 //! nix-daemon is safe.
 //!
-//! Entry point: [`gc::collect_garbage`] with a [`store::GcStore`].
+//! ```no_run
+//! # fn main() -> harmonia_store_gc::Result<()> {
+//! use std::path::Path;
+//! use harmonia_store_gc::{GcOptions, GcStore, collect_garbage};
+//!
+//! let store = GcStore::open(Path::new("/nix/store"), Path::new("/nix/var/nix"))?;
+//! let report = collect_garbage(
+//!     &store,
+//!     &GcOptions {
+//!         dry_run: true,
+//!         ..Default::default()
+//!     },
+//! )?;
+//! for path in &report.would_delete {
+//!     println!("{path}");
+//! }
+//! println!("~{} bytes in {} paths", report.bytes_freed, report.paths_deleted);
+//! # Ok(())
+//! # }
+//! ```
 
 mod error;
-pub mod roots;
-pub mod store;
-pub mod temp_roots;
+mod gc;
+mod gc_socket;
+mod roots;
+mod store;
+mod temp_roots;
+#[cfg(test)]
+mod testutil;
 
 pub use error::{Error, Result};
+pub use gc::{GcOptions, GcReport, collect_garbage};
+pub use harmonia_store_db::GraphOptions;
+pub use store::GcStore;
+pub use temp_roots::TempRoots;
 
 /// Hash map keyed by store path strings.
 ///
 /// SipHash showed up in GC profiles when hashing millions of ~50-char
 /// store paths, so foldhash is used instead.
-pub type HashMap<K, V> = std::collections::HashMap<K, V, foldhash::fast::RandomState>;
+pub(crate) type HashMap<K, V> = std::collections::HashMap<K, V, foldhash::fast::RandomState>;
 /// Hash set counterpart of [`HashMap`].
 pub(crate) type HashSet<K> = std::collections::HashSet<K, foldhash::fast::RandomState>;

--- a/harmonia-store-gc/src/roots.rs
+++ b/harmonia-store-gc/src/roots.rs
@@ -24,7 +24,7 @@ use crate::error::{Error, Result};
 /// Returned nodes belong to the graph behind `idx`. Runtime-scan
 /// candidates that are not in the database are dropped, mirroring Nix's
 /// `findRuntimeRoots`.
-pub fn find_roots(
+pub(crate) fn find_roots(
     layout: &StoreLayout,
     extra_dirs: &[PathBuf],
     idx: &BasenameIndex,

--- a/harmonia-store-gc/src/store.rs
+++ b/harmonia-store-gc/src/store.rs
@@ -20,20 +20,23 @@ use crate::error::Result;
 /// ```no_run
 /// # fn main() -> harmonia_store_gc::Result<()> {
 /// use std::path::Path;
-/// use harmonia_store_gc::store::GcStore;
+/// use harmonia_store_gc::GcStore;
 ///
 /// let store = GcStore::open(Path::new("/nix/store"), Path::new("/nix/var/nix"))?;
 /// # Ok(())
 /// # }
 /// ```
 pub struct GcStore {
-    /// The store database at `state_dir/db/db.sqlite`.
-    pub db: StoreDb,
-    /// Where the store lives on disk.
-    pub layout: StoreLayout,
+    pub(crate) db: StoreDb,
+    pub(crate) layout: StoreLayout,
 }
 
 impl GcStore {
+    /// Where the store lives on disk.
+    pub fn layout(&self) -> &StoreLayout {
+        &self.layout
+    }
+
     /// Open the store database read-write, as needed for an actual
     /// collection.
     pub fn open(store_dir: &Path, state_dir: &Path) -> Result<Self> {

--- a/harmonia-store-gc/src/temp_roots.rs
+++ b/harmonia-store-gc/src/temp_roots.rs
@@ -43,7 +43,7 @@ fn flock_retry(mut f: fs::File, arg: FlockArg) -> std::io::Result<Flock<fs::File
 /// ```no_run
 /// # fn main() -> harmonia_store_gc::Result<()> {
 /// use std::path::Path;
-/// use harmonia_store_gc::temp_roots::TempRoots;
+/// use harmonia_store_gc::TempRoots;
 ///
 /// let mut roots = TempRoots::create(Path::new("/nix/var/nix"))?;
 /// roots.add("/nix/store/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-example")?;
@@ -240,7 +240,7 @@ impl TempRoots {
 /// stale: we can acquire a write lock on it because the owner held one.
 /// Stale files are removed and their roots ignored, mirroring Nix's
 /// `findTempRoots`.
-pub fn find_temp_roots(state_dir: &Path) -> Result<std::collections::HashSet<String>> {
+pub(crate) fn find_temp_roots(state_dir: &Path) -> Result<std::collections::HashSet<String>> {
     let mut roots = std::collections::HashSet::new();
     let temp_dir = state_dir.join("temproots");
 

--- a/harmonia-store-gc/src/testutil.rs
+++ b/harmonia-store-gc/src/testutil.rs
@@ -1,0 +1,36 @@
+use std::sync::Arc;
+
+use harmonia_store_db::{GraphOptions, StoreDb, StoreGraph};
+use harmonia_store_path::StoreDir;
+
+/// Load a graph with the given nodes and edges. `refs` are indices
+/// into `paths`.
+pub(crate) fn graph(paths: &[(&str, &[usize])]) -> Arc<StoreGraph> {
+    let db = StoreDb::open_memory().unwrap();
+    let mut ids = Vec::new();
+    for (name, _) in paths {
+        db.connection()
+            .execute(
+                "INSERT INTO ValidPaths (path, hash, registrationTime) \
+                 VALUES (?, 'sha256:x', 1)",
+                [format!("/nix/store/{name}")],
+            )
+            .unwrap();
+        ids.push(db.connection().last_insert_rowid());
+    }
+    for (i, (_, refs)) in paths.iter().enumerate() {
+        for &r in refs.iter() {
+            db.connection()
+                .execute(
+                    "INSERT INTO Refs (referrer, reference) VALUES (?, ?)",
+                    [ids[i], ids[r]],
+                )
+                .unwrap();
+        }
+    }
+    let options = GraphOptions {
+        keep_derivations: false,
+        keep_outputs: false,
+    };
+    Arc::new(db.load_graph(&StoreDir::default(), &options).unwrap())
+}


### PR DESCRIPTION
collect_garbage takes the exclusive gc.lock, loads the reference
graph, computes the alive closure from the roots, and deletes dead
paths in parallel.

The gc-socket is served from the moment the lock is held, even before
the graph is loaded, since builders retry connecting every 100ms.
Roots received in that window are acked immediately and replayed once
the graph exists. The LiveSet ensures a protect() request is never
acked while the path is still being deleted.

Deletion is referrer-first in bounded chunks. Database rows are
invalidated before the disk entry goes away, so a path never looks
valid without its files. Crashing mid-run is safe: leftovers are
collected as unknown-on-disk entries by the next run.