### PR TITLE
store-gc: add profile cleanup and the harmonia-gc CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -459,6 +459,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
+ "clap_derive",
 ]
 
 [[package]]
@@ -469,6 +470,19 @@ checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
  "anstyle",
  "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1186,6 +1200,7 @@ dependencies = [
 name = "harmonia-store-gc"
 version = "3.2.0"
 dependencies = [
+ "clap",
  "foldhash",
  "harmonia-store-db",
  "harmonia-store-fs",
@@ -1392,6 +1407,12 @@ checksum = "a5081f264ed7adee96ea4b4778b6bb9da0a7228b084587aa3bd3ff05da7c5a3b"
 dependencies = [
  "hashbrown 0.17.0",
 ]
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hex-literal"
@@ -2420,6 +2441,12 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "subtle"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -452,6 +452,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
+ "clap_derive",
 ]
 
 [[package]]
@@ -462,6 +463,19 @@ checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
  "anstyle",
  "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1179,6 +1193,7 @@ dependencies = [
 name = "harmonia-store-gc"
 version = "3.2.0"
 dependencies = [
+ "clap",
  "foldhash",
  "harmonia-store-db",
  "harmonia-store-fs",
@@ -1385,6 +1400,12 @@ checksum = "a5081f264ed7adee96ea4b4778b6bb9da0a7228b084587aa3bd3ff05da7c5a3b"
 dependencies = [
  "hashbrown 0.17.0",
 ]
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hex-literal"
@@ -2413,6 +2434,12 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "subtle"

--- a/harmonia-store-gc/Cargo.toml
+++ b/harmonia-store-gc/Cargo.toml
@@ -11,7 +11,12 @@ homepage.workspace   = true
 repository.workspace = true
 description          = "Garbage collection for the Nix store"
 
+[[bin]]
+name = "harmonia-gc"
+path = "src/bin/harmonia-gc.rs"
+
 [dependencies]
+clap                = { workspace = true }
 foldhash            = { workspace = true }
 harmonia-store-db   = { workspace = true }
 harmonia-store-fs   = { workspace = true }

--- a/harmonia-store-gc/Cargo.toml
+++ b/harmonia-store-gc/Cargo.toml
@@ -12,11 +12,15 @@ repository.workspace = true
 description          = "Garbage collection for the Nix store"
 
 [[bin]]
-name = "harmonia-gc"
-path = "src/bin/harmonia-gc.rs"
+name              = "harmonia-gc"
+path              = "src/bin/harmonia-gc.rs"
+required-features = [ "cli" ]
+
+[features]
+cli = [ "dep:clap", "dep:tracing-subscriber" ]
 
 [dependencies]
-clap                = { workspace = true }
+clap                = { workspace = true, optional = true }
 foldhash            = { workspace = true }
 harmonia-store-db   = { workspace = true }
 harmonia-store-fs   = { workspace = true }
@@ -26,7 +30,7 @@ nix                 = { workspace = true }
 rayon               = { workspace = true }
 thiserror           = { workspace = true }
 tracing             = { workspace = true }
-tracing-subscriber  = { workspace = true }
+tracing-subscriber  = { workspace = true, optional = true }
 walkdir             = { workspace = true }
 
 [dev-dependencies]

--- a/harmonia-store-gc/src/bin/harmonia-gc.rs
+++ b/harmonia-store-gc/src/bin/harmonia-gc.rs
@@ -1,0 +1,444 @@
+// SPDX-FileCopyrightText: 2026 Jörg Thalheim
+// SPDX-License-Identifier: MIT
+
+//! `harmonia-gc`: a faster `nix-collect-garbage`.
+
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+use clap::Parser;
+use harmonia_store_fs::{make_store_writable, unshare_mount_namespace};
+use harmonia_store_gc::{GcOptions, GcStore, collect_garbage, profiles};
+use rayon::prelude::*;
+use tracing::{debug, warn};
+
+type MainResult<T> = Result<T, Box<dyn std::error::Error>>;
+
+/// A faster nix-collect-garbage.
+#[derive(Parser)]
+#[command(version)]
+struct Args {
+    /// Remove old profile generations
+    #[arg(short, long)]
+    delete_old: bool,
+
+    /// Delete generations older than SPEC (e.g. 30d). Implies --delete-old
+    #[arg(long, value_name = "SPEC")]
+    delete_older_than: Option<String>,
+
+    /// Show what would be done without doing it
+    #[arg(long)]
+    dry_run: bool,
+
+    /// Free until SIZE is available (e.g. 50G or 20%). Pinned paths are
+    /// never freed
+    #[arg(long, value_name = "SIZE", value_parser = parse_ensure_free)]
+    ensure_free: Option<EnsureFree>,
+
+    /// Keep paths registered within SPEC (e.g. 7d)
+    #[arg(long, value_name = "SPEC")]
+    keep_recent: Option<String>,
+
+    /// Skip the database VACUUM after deletion
+    #[arg(long)]
+    no_vacuum: bool,
+
+    /// Dead paths per delete transaction
+    #[arg(long, value_name = "N")]
+    chunk_size: Option<usize>,
+
+    /// Override the keep-outputs nix.conf setting
+    #[arg(long, value_name = "BOOL")]
+    keep_outputs: Option<bool>,
+
+    /// Override the keep-derivations nix.conf setting
+    #[arg(long, value_name = "BOOL")]
+    keep_derivations: Option<bool>,
+
+    /// Extra directory to scan for GC roots (repeatable)
+    #[arg(long = "gc-roots-dir", value_name = "PATH")]
+    gc_roots_dirs: Vec<PathBuf>,
+
+    /// Nix store directory
+    #[arg(long, value_name = "PATH", default_value = "/nix/store")]
+    store_dir: PathBuf,
+
+    /// Nix state directory
+    #[arg(long, value_name = "PATH", default_value = "/nix/var/nix")]
+    state_dir: PathBuf,
+}
+
+/// `--ensure-free` target: absolute bytes or a percentage of the store's
+/// filesystem.
+#[derive(Debug, Clone, Copy, PartialEq)]
+enum EnsureFree {
+    Bytes(u64),
+    Percent(f64),
+}
+
+impl EnsureFree {
+    fn target_bytes(self, total: u64) -> u64 {
+        match self {
+            EnsureFree::Bytes(b) => b,
+            EnsureFree::Percent(p) => (total as f64 * p / 100.0) as u64,
+        }
+    }
+}
+
+/// Format a byte count for human-readable output.
+fn format_size(bytes: u64) -> String {
+    const KIB: f64 = 1024.0;
+    const MIB: f64 = KIB * 1024.0;
+    const GIB: f64 = MIB * 1024.0;
+    let b = bytes as f64;
+    if b >= GIB {
+        format!("{:.2} GiB", b / GIB)
+    } else if b >= MIB {
+        format!("{:.2} MiB", b / MIB)
+    } else if b >= KIB {
+        format!("{:.2} KiB", b / KIB)
+    } else {
+        format!("{bytes} bytes")
+    }
+}
+
+/// `nix config show <key>` parsed as a bool. Returns `default` if `nix`
+/// is not in PATH, the key is unknown, or the value is not a bool.
+/// Reusing Nix's own config resolution avoids reimplementing the
+/// multi-file nix.conf parser.
+fn bool_setting(key: &str, default: bool) -> bool {
+    // `nix config show` is gated on nix-command. Pass the flag so this
+    // works without it in nix.conf.
+    let out = std::process::Command::new("nix")
+        .args([
+            "--extra-experimental-features",
+            "nix-command",
+            "config",
+            "show",
+            key,
+        ])
+        .output();
+    let out = match out {
+        Ok(o) if o.status.success() => o.stdout,
+        // Don't fall back silently: a user who set e.g. keep-outputs=true
+        // in nix.conf should learn why it is being ignored.
+        Ok(o) => {
+            warn!(
+                "`nix config show {key}` failed ({}). Using default {default}",
+                o.status
+            );
+            return default;
+        }
+        Err(e) => {
+            warn!("cannot run `nix config show {key}`: {e}. Using default {default}");
+            return default;
+        }
+    };
+    parse_bool(&out).unwrap_or(default)
+}
+
+fn parse_bool(s: &[u8]) -> Option<bool> {
+    match std::str::from_utf8(s).ok()?.trim() {
+        "true" => Some(true),
+        "false" => Some(false),
+        _ => None,
+    }
+}
+
+/// Parse a size like "50G" or a percentage like "20%".
+fn parse_ensure_free(s: &str) -> Result<EnsureFree, String> {
+    let s = s.trim();
+    if let Some(num) = s.strip_suffix('%') {
+        let p: f64 = num
+            .trim()
+            .parse()
+            .map_err(|e| format!("invalid percentage '{s}': {e}"))?;
+        if !p.is_finite() || !(0.0..=100.0).contains(&p) {
+            return Err(format!("percentage '{s}' must be between 0 and 100"));
+        }
+        Ok(EnsureFree::Percent(p))
+    } else {
+        Ok(EnsureFree::Bytes(parse_size(s)?))
+    }
+}
+
+/// Parse a size like "50G", "512M", "1024K", or plain bytes.
+fn parse_size(s: &str) -> Result<u64, String> {
+    let s = s.trim();
+    let (num, mult) = match s.chars().last() {
+        Some('K' | 'k') => (&s[..s.len() - 1], 1024u64),
+        Some('M' | 'm') => (&s[..s.len() - 1], 1024 * 1024),
+        Some('G' | 'g') => (&s[..s.len() - 1], 1024 * 1024 * 1024),
+        Some('T' | 't') => (&s[..s.len() - 1], 1024u64.pow(4)),
+        _ => (s, 1),
+    };
+    let n: f64 = num
+        .parse()
+        .map_err(|e| format!("invalid size '{s}': {e}"))?;
+    if !n.is_finite() || n < 0.0 || n * mult as f64 > u64::MAX as f64 {
+        return Err(format!("size '{s}' is out of range"));
+    }
+    Ok((n * mult as f64) as u64)
+}
+
+/// Free and total bytes on the filesystem containing `path`.
+fn filesystem_bytes(path: &Path) -> MainResult<(u64, u64)> {
+    let st =
+        nix::sys::statvfs::statvfs(path).map_err(|e| format!("statvfs {}: {e}", path.display()))?;
+    // statvfs field types differ between Linux (u64) and macOS (u32).
+    let frag = st.fragment_size() as u64;
+    let avail = st.blocks_available() as u64 * frag;
+    let total = st.blocks() as u64 * frag;
+    Ok((avail, total))
+}
+
+/// Initialize the rayon global pool up front so thread creation failures
+/// (e.g. EAGAIN under a sandbox thread limit) fall back to a single
+/// thread instead of panicking on the first `par_iter`.
+fn init_rayon() {
+    if let Err(e) = rayon::ThreadPoolBuilder::new().build_global() {
+        warn!("failed to start rayon thread pool ({e}), falling back to a single thread");
+        let _ = rayon::ThreadPoolBuilder::new()
+            .num_threads(1)
+            .build_global();
+    }
+}
+
+fn main() -> MainResult<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),
+        )
+        .with_writer(std::io::stderr)
+        .init();
+
+    let args = Args::parse();
+    let delete_old = args.delete_old || args.delete_older_than.is_some();
+
+    // Must happen before rayon spawns its worker threads: only the
+    // calling thread joins the new mount namespace.
+    if !args.dry_run
+        && let Err(e) = unshare_mount_namespace()
+    {
+        // EPERM is normal in containers. The remount below then affects
+        // the host namespace, like legacy nix-store.
+        warn!("no private mount namespace: {e}");
+    }
+    init_rayon();
+
+    if args.ensure_free.is_some() && args.dry_run {
+        return Err("--ensure-free cannot be combined with --dry-run".into());
+    }
+
+    // Validate every time spec before any destructive work. A bad
+    // --keep-recent must not surface only after generations were deleted.
+    let delete_older_cutoff = args
+        .delete_older_than
+        .as_deref()
+        .map(profiles::parse_older_than)
+        .transpose()?;
+    let keep_recent_after = args
+        .keep_recent
+        .as_deref()
+        .map(profiles::parse_older_than)
+        .transpose()?;
+
+    if delete_old {
+        profiles::profile_dirs(&args.state_dir)
+            .par_iter()
+            .try_for_each(|dir| {
+                profiles::remove_old_generations(dir, delete_older_cutoff, args.dry_run)
+            })?;
+    }
+
+    let max_freed = if let Some(ensure_free) = args.ensure_free {
+        let (avail, total) = filesystem_bytes(&args.store_dir)?;
+        let target = ensure_free.target_bytes(total);
+        if avail >= target {
+            println!("{} already free, nothing to do", format_size(avail));
+            return Ok(());
+        }
+        let need = target - avail;
+        tracing::info!(
+            "freeing at least {} to reach {} free",
+            format_size(need),
+            format_size(target)
+        );
+        Some(need)
+    } else {
+        None
+    };
+    let ensure_free_need = max_freed;
+
+    let store = if args.dry_run {
+        // No DB writes happen in a dry run, so don't take write locks or
+        // flip the journal mode. A WAL database without its -shm/-wal
+        // sidecars cannot be opened read-only. Fall back to read-write.
+        GcStore::open_read_only(&args.store_dir, &args.state_dir).or_else(|e| {
+            debug!("read-only open failed ({e}), retrying read-write");
+            GcStore::open(&args.store_dir, &args.state_dir)
+        })?
+    } else {
+        GcStore::open(&args.store_dir, &args.state_dir)?
+    };
+    let defaults = harmonia_store_gc::GraphOptions::default();
+    let graph_options = harmonia_store_gc::GraphOptions {
+        keep_outputs: args
+            .keep_outputs
+            .unwrap_or_else(|| bool_setting("keep-outputs", defaults.keep_outputs)),
+        keep_derivations: args
+            .keep_derivations
+            .unwrap_or_else(|| bool_setting("keep-derivations", defaults.keep_derivations)),
+    };
+    if !args.dry_run {
+        make_store_writable(store.layout().real_store_dir())?;
+    }
+    let mut opts = GcOptions {
+        graph_options,
+        dry_run: args.dry_run,
+        max_freed,
+        keep_recent_after,
+        vacuum: !args.no_vacuum,
+        extra_gc_roots_dirs: args.gc_roots_dirs,
+        ..Default::default()
+    };
+    if let Some(n) = args.chunk_size {
+        opts.chunk_size = n;
+    }
+    let report = collect_garbage(&store, &opts)?;
+    {
+        let mut out = std::io::BufWriter::new(std::io::stdout().lock());
+        for p in &report.would_delete {
+            writeln!(out, "{p}")?;
+        }
+    }
+    let (bytes_freed, paths_deleted) = (report.bytes_freed, report.paths_deleted);
+
+    if let Some(need) = ensure_free_need
+        && bytes_freed < need
+    {
+        let hint = if keep_recent_after.is_some() {
+            " (reachable from GC roots or pinned by --keep-recent)"
+        } else {
+            " (reachable from GC roots)"
+        };
+        warn!(
+            "only freed {}, {} short of --ensure-free target. \
+             The remaining paths are alive{hint}",
+            format_size(bytes_freed),
+            format_size(need - bytes_freed)
+        );
+    }
+
+    if args.dry_run {
+        println!(
+            "{paths_deleted} store paths would be deleted (~{})",
+            format_size(bytes_freed)
+        );
+    } else {
+        println!(
+            "{paths_deleted} store paths deleted, {} freed",
+            format_size(bytes_freed)
+        );
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        Args, EnsureFree, bool_setting, format_size, parse_bool, parse_ensure_free, parse_size,
+    };
+    use clap::Parser;
+
+    fn try_parse(list: &[&str]) -> Result<Args, clap::Error> {
+        Args::try_parse_from(std::iter::once(&"harmonia-gc").chain(list))
+    }
+
+    #[test]
+    fn rejects_unknown_arguments() {
+        // A typo'd flag must not silently run a destructive GC.
+        assert!(try_parse(&["--dry-rnu"]).is_err());
+        assert!(try_parse(&["--keep-resent", "2d"]).is_err());
+        assert!(try_parse(&["--dry-run", "extra"]).is_err());
+        let parsed = try_parse(&["--dry-run"]).unwrap();
+        assert!(parsed.dry_run);
+    }
+
+    #[test]
+    fn repeatable_and_default_args() {
+        let parsed = try_parse(&["--gc-roots-dir", "/a", "--gc-roots-dir", "/b"]).unwrap();
+        assert_eq!(parsed.gc_roots_dirs.len(), 2);
+        assert_eq!(parsed.store_dir.to_str(), Some("/nix/store"));
+        assert_eq!(parsed.state_dir.to_str(), Some("/nix/var/nix"));
+        assert!(!parsed.delete_old);
+        let parsed = try_parse(&["--delete-older-than", "30d"]).unwrap();
+        assert_eq!(parsed.delete_older_than.as_deref(), Some("30d"));
+    }
+
+    #[test]
+    fn format_size_units() {
+        assert_eq!(format_size(0), "0 bytes");
+        assert_eq!(format_size(1023), "1023 bytes");
+        assert_eq!(format_size(1536), "1.50 KiB");
+        assert_eq!(format_size(5 * 1024 * 1024 + 512 * 1024), "5.50 MiB");
+        assert_eq!(format_size(3 * 1024 * 1024 * 1024 / 2), "1.50 GiB");
+    }
+
+    #[test]
+    fn parse_bool_values() {
+        assert_eq!(parse_bool(b"true\n"), Some(true));
+        assert_eq!(parse_bool(b"false\n"), Some(false));
+        assert_eq!(parse_bool(b"42\n"), None);
+        assert_eq!(parse_bool(b""), None);
+    }
+
+    #[test]
+    fn unknown_setting_falls_back_to_default() {
+        assert!(bool_setting("this-setting-does-not-exist", true));
+        assert!(!bool_setting("this-setting-does-not-exist", false));
+    }
+
+    #[test]
+    fn parse_size_units() {
+        assert_eq!(parse_size("0").unwrap(), 0);
+        assert_eq!(parse_size("123").unwrap(), 123);
+        assert_eq!(parse_size("1K").unwrap(), 1024);
+        assert_eq!(parse_size("2k").unwrap(), 2048);
+        assert_eq!(parse_size("1M").unwrap(), 1024 * 1024);
+        assert_eq!(parse_size("3m").unwrap(), 3 * 1024 * 1024);
+        assert_eq!(parse_size("1G").unwrap(), 1024 * 1024 * 1024);
+        assert_eq!(parse_size("2g").unwrap(), 2 * 1024 * 1024 * 1024);
+        assert_eq!(parse_size("1T").unwrap(), 1024u64.pow(4));
+        assert_eq!(parse_size("1.5K").unwrap(), 1536);
+        assert_eq!(parse_size(" 4M ").unwrap(), 4 * 1024 * 1024);
+        assert!(parse_size("abc").is_err());
+        assert!(parse_size("-5G").is_err());
+        assert!(parse_size("inf").is_err());
+        assert!(parse_size("NaN").is_err());
+        assert!(parse_size("99999999999999999999G").is_err());
+    }
+
+    #[test]
+    fn parse_ensure_free_values() {
+        assert_eq!(
+            parse_ensure_free("50G").unwrap(),
+            EnsureFree::Bytes(50 * 1024u64.pow(3))
+        );
+        assert_eq!(parse_ensure_free("1024").unwrap(), EnsureFree::Bytes(1024));
+        assert_eq!(parse_ensure_free("20%").unwrap(), EnsureFree::Percent(20.0));
+        assert_eq!(
+            parse_ensure_free(" 12.5 % ").unwrap(),
+            EnsureFree::Percent(12.5)
+        );
+        assert_eq!(
+            parse_ensure_free("100%").unwrap(),
+            EnsureFree::Percent(100.0)
+        );
+        assert!(parse_ensure_free("101%").is_err());
+        assert!(parse_ensure_free("-5%").is_err());
+        assert!(parse_ensure_free("abc%").is_err());
+    }
+}

--- a/harmonia-store-gc/src/bin/harmonia-gc.rs
+++ b/harmonia-store-gc/src/bin/harmonia-gc.rs
@@ -1,0 +1,440 @@
+// SPDX-FileCopyrightText: 2026 Jörg Thalheim
+// SPDX-License-Identifier: MIT
+
+//! `harmonia-gc`: a faster `nix-collect-garbage`.
+
+use std::path::{Path, PathBuf};
+
+use clap::Parser;
+use harmonia_store_fs::{make_store_writable, unshare_mount_namespace};
+use harmonia_store_gc::store::GcStore;
+use harmonia_store_gc::{gc, profiles};
+use rayon::prelude::*;
+use tracing::{debug, warn};
+
+type MainResult<T> = Result<T, Box<dyn std::error::Error>>;
+
+/// A faster nix-collect-garbage.
+#[derive(Parser)]
+#[command(version)]
+struct Args {
+    /// Remove old profile generations
+    #[arg(short, long)]
+    delete_old: bool,
+
+    /// Delete generations older than SPEC (e.g. 30d). Implies --delete-old
+    #[arg(long, value_name = "SPEC")]
+    delete_older_than: Option<String>,
+
+    /// Show what would be done without doing it
+    #[arg(long)]
+    dry_run: bool,
+
+    /// Free until SIZE is available (e.g. 50G or 20%). Pinned paths are
+    /// never freed
+    #[arg(long, value_name = "SIZE", value_parser = parse_ensure_free)]
+    ensure_free: Option<EnsureFree>,
+
+    /// Keep paths registered within SPEC (e.g. 7d)
+    #[arg(long, value_name = "SPEC")]
+    keep_recent: Option<String>,
+
+    /// Skip the database VACUUM after deletion
+    #[arg(long)]
+    no_vacuum: bool,
+
+    /// Dead paths per delete transaction
+    #[arg(long, value_name = "N")]
+    chunk_size: Option<usize>,
+
+    /// Override the keep-outputs nix.conf setting
+    #[arg(long, value_name = "BOOL")]
+    keep_outputs: Option<bool>,
+
+    /// Override the keep-derivations nix.conf setting
+    #[arg(long, value_name = "BOOL")]
+    keep_derivations: Option<bool>,
+
+    /// Extra directory to scan for GC roots (repeatable)
+    #[arg(long = "gc-roots-dir", value_name = "PATH")]
+    gc_roots_dirs: Vec<PathBuf>,
+
+    /// Nix store directory
+    #[arg(long, value_name = "PATH", default_value = "/nix/store")]
+    store_dir: PathBuf,
+
+    /// Nix state directory
+    #[arg(long, value_name = "PATH", default_value = "/nix/var/nix")]
+    state_dir: PathBuf,
+}
+
+/// `--ensure-free` target: absolute bytes or a percentage of the store's
+/// filesystem.
+#[derive(Debug, Clone, Copy, PartialEq)]
+enum EnsureFree {
+    Bytes(u64),
+    Percent(f64),
+}
+
+impl EnsureFree {
+    fn target_bytes(self, total: u64) -> u64 {
+        match self {
+            EnsureFree::Bytes(b) => b,
+            EnsureFree::Percent(p) => (total as f64 * p / 100.0) as u64,
+        }
+    }
+}
+
+/// Format a byte count for human-readable output.
+fn format_size(bytes: u64) -> String {
+    const KIB: f64 = 1024.0;
+    const MIB: f64 = KIB * 1024.0;
+    const GIB: f64 = MIB * 1024.0;
+    let b = bytes as f64;
+    if b >= GIB {
+        format!("{:.2} GiB", b / GIB)
+    } else if b >= MIB {
+        format!("{:.2} MiB", b / MIB)
+    } else if b >= KIB {
+        format!("{:.2} KiB", b / KIB)
+    } else {
+        format!("{bytes} bytes")
+    }
+}
+
+/// `nix config show <key>` parsed as a bool. Returns `default` if `nix`
+/// is not in PATH, the key is unknown, or the value is not a bool.
+/// Reusing Nix's own config resolution avoids reimplementing the
+/// multi-file nix.conf parser.
+fn bool_setting(key: &str, default: bool) -> bool {
+    // `nix config show` is gated on nix-command. Pass the flag so this
+    // works without it in nix.conf.
+    let out = std::process::Command::new("nix")
+        .args([
+            "--extra-experimental-features",
+            "nix-command",
+            "config",
+            "show",
+            key,
+        ])
+        .output();
+    let out = match out {
+        Ok(o) if o.status.success() => o.stdout,
+        // Don't fall back silently: a user who set e.g. keep-outputs=true
+        // in nix.conf should learn why it is being ignored.
+        Ok(o) => {
+            warn!(
+                "`nix config show {key}` failed ({}). Using default {default}",
+                o.status
+            );
+            return default;
+        }
+        Err(e) => {
+            warn!("cannot run `nix config show {key}`: {e}. Using default {default}");
+            return default;
+        }
+    };
+    parse_bool(&out).unwrap_or(default)
+}
+
+fn parse_bool(s: &[u8]) -> Option<bool> {
+    match std::str::from_utf8(s).ok()?.trim() {
+        "true" => Some(true),
+        "false" => Some(false),
+        _ => None,
+    }
+}
+
+/// Parse a size like "50G" or a percentage like "20%".
+fn parse_ensure_free(s: &str) -> Result<EnsureFree, String> {
+    let s = s.trim();
+    if let Some(num) = s.strip_suffix('%') {
+        let p: f64 = num
+            .trim()
+            .parse()
+            .map_err(|e| format!("invalid percentage '{s}': {e}"))?;
+        if !p.is_finite() || !(0.0..=100.0).contains(&p) {
+            return Err(format!("percentage '{s}' must be between 0 and 100"));
+        }
+        Ok(EnsureFree::Percent(p))
+    } else {
+        Ok(EnsureFree::Bytes(parse_size(s)?))
+    }
+}
+
+/// Parse a size like "50G", "512M", "1024K", or plain bytes.
+fn parse_size(s: &str) -> Result<u64, String> {
+    let s = s.trim();
+    let (num, mult) = match s.chars().last() {
+        Some('K' | 'k') => (&s[..s.len() - 1], 1024u64),
+        Some('M' | 'm') => (&s[..s.len() - 1], 1024 * 1024),
+        Some('G' | 'g') => (&s[..s.len() - 1], 1024 * 1024 * 1024),
+        Some('T' | 't') => (&s[..s.len() - 1], 1024u64.pow(4)),
+        _ => (s, 1),
+    };
+    let n: f64 = num
+        .parse()
+        .map_err(|e| format!("invalid size '{s}': {e}"))?;
+    if !n.is_finite() || n < 0.0 || n * mult as f64 > u64::MAX as f64 {
+        return Err(format!("size '{s}' is out of range"));
+    }
+    Ok((n * mult as f64) as u64)
+}
+
+/// Free and total bytes on the filesystem containing `path`.
+fn filesystem_bytes(path: &Path) -> MainResult<(u64, u64)> {
+    let st =
+        nix::sys::statvfs::statvfs(path).map_err(|e| format!("statvfs {}: {e}", path.display()))?;
+    // statvfs field types differ between Linux (u64) and macOS (u32).
+    let frag = st.fragment_size() as u64;
+    let avail = st.blocks_available() as u64 * frag;
+    let total = st.blocks() as u64 * frag;
+    Ok((avail, total))
+}
+
+/// Initialize the rayon global pool up front so thread creation failures
+/// (e.g. EAGAIN under a sandbox thread limit) fall back to a single
+/// thread instead of panicking on the first `par_iter`.
+fn init_rayon() {
+    if let Err(e) = rayon::ThreadPoolBuilder::new().build_global() {
+        warn!("failed to start rayon thread pool ({e}), falling back to a single thread");
+        let _ = rayon::ThreadPoolBuilder::new()
+            .num_threads(1)
+            .build_global();
+    }
+}
+
+fn main() -> MainResult<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),
+        )
+        .with_writer(std::io::stderr)
+        .init();
+
+    let args = Args::parse();
+    let delete_old = args.delete_old || args.delete_older_than.is_some();
+
+    // Must happen before rayon spawns its worker threads: only the
+    // calling thread joins the new mount namespace.
+    if !args.dry_run
+        && let Err(e) = unshare_mount_namespace()
+    {
+        // EPERM is normal in containers. The remount below then affects
+        // the host namespace, like legacy nix-store.
+        warn!("no private mount namespace: {e}");
+    }
+    init_rayon();
+
+    if args.ensure_free.is_some() && args.dry_run {
+        return Err("--ensure-free cannot be combined with --dry-run".into());
+    }
+
+    // Validate every time spec before any destructive work. A bad
+    // --keep-recent must not surface only after generations were deleted.
+    let delete_older_cutoff = args
+        .delete_older_than
+        .as_deref()
+        .map(profiles::parse_older_than)
+        .transpose()?;
+    let keep_recent_after = args
+        .keep_recent
+        .as_deref()
+        .map(profiles::parse_older_than)
+        .transpose()?
+        .map(|t| {
+            t.duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_secs() as i64)
+                .unwrap_or(0)
+        });
+
+    if delete_old {
+        profiles::profile_dirs(&args.state_dir)
+            .par_iter()
+            .try_for_each(|dir| {
+                profiles::remove_old_generations(dir, delete_older_cutoff, args.dry_run)
+            })?;
+    }
+
+    let max_freed = if let Some(ensure_free) = args.ensure_free {
+        let (avail, total) = filesystem_bytes(&args.store_dir)?;
+        let target = ensure_free.target_bytes(total);
+        if avail >= target {
+            println!("{} already free, nothing to do", format_size(avail));
+            return Ok(());
+        }
+        let need = target - avail;
+        tracing::info!(
+            "freeing at least {} to reach {} free",
+            format_size(need),
+            format_size(target)
+        );
+        Some(need)
+    } else {
+        None
+    };
+    let ensure_free_need = max_freed;
+
+    let store = if args.dry_run {
+        // No DB writes happen in a dry run, so don't take write locks or
+        // flip the journal mode. A WAL database without its -shm/-wal
+        // sidecars cannot be opened read-only. Fall back to read-write.
+        GcStore::open_read_only(&args.store_dir, &args.state_dir).or_else(|e| {
+            debug!("read-only open failed ({e}), retrying read-write");
+            GcStore::open(&args.store_dir, &args.state_dir)
+        })?
+    } else {
+        GcStore::open(&args.store_dir, &args.state_dir)?
+    };
+    let defaults = harmonia_store_db::GraphOptions::default();
+    let graph_options = harmonia_store_db::GraphOptions {
+        keep_outputs: args
+            .keep_outputs
+            .unwrap_or_else(|| bool_setting("keep-outputs", defaults.keep_outputs)),
+        keep_derivations: args
+            .keep_derivations
+            .unwrap_or_else(|| bool_setting("keep-derivations", defaults.keep_derivations)),
+    };
+    if !args.dry_run {
+        make_store_writable(store.layout.real_store_dir())?;
+    }
+    let opts = gc::GcOptions {
+        graph_options,
+        dry_run: args.dry_run,
+        max_freed,
+        keep_recent_after,
+        no_vacuum: args.no_vacuum,
+        chunk_size: args.chunk_size,
+        extra_gc_roots_dirs: args.gc_roots_dirs,
+    };
+    let report = gc::collect_garbage(&store, &opts)?;
+    let (bytes_freed, paths_deleted) = (report.bytes_freed, report.paths_deleted);
+
+    if let Some(need) = ensure_free_need
+        && bytes_freed < need
+    {
+        let hint = if keep_recent_after.is_some() {
+            " (reachable from GC roots or pinned by --keep-recent)"
+        } else {
+            " (reachable from GC roots)"
+        };
+        warn!(
+            "only freed {}, {} short of --ensure-free target. \
+             The remaining paths are alive{hint}",
+            format_size(bytes_freed),
+            format_size(need - bytes_freed)
+        );
+    }
+
+    if args.dry_run {
+        println!(
+            "{paths_deleted} store paths would be deleted (~{})",
+            format_size(bytes_freed)
+        );
+    } else {
+        println!(
+            "{paths_deleted} store paths deleted, {} freed",
+            format_size(bytes_freed)
+        );
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        Args, EnsureFree, bool_setting, format_size, parse_bool, parse_ensure_free, parse_size,
+    };
+    use clap::Parser;
+
+    fn try_parse(list: &[&str]) -> Result<Args, clap::Error> {
+        Args::try_parse_from(std::iter::once(&"harmonia-gc").chain(list))
+    }
+
+    #[test]
+    fn rejects_unknown_arguments() {
+        // A typo'd flag must not silently run a destructive GC.
+        assert!(try_parse(&["--dry-rnu"]).is_err());
+        assert!(try_parse(&["--keep-resent", "2d"]).is_err());
+        assert!(try_parse(&["--dry-run", "extra"]).is_err());
+        let parsed = try_parse(&["--dry-run"]).unwrap();
+        assert!(parsed.dry_run);
+    }
+
+    #[test]
+    fn repeatable_and_default_args() {
+        let parsed = try_parse(&["--gc-roots-dir", "/a", "--gc-roots-dir", "/b"]).unwrap();
+        assert_eq!(parsed.gc_roots_dirs.len(), 2);
+        assert_eq!(parsed.store_dir.to_str(), Some("/nix/store"));
+        assert_eq!(parsed.state_dir.to_str(), Some("/nix/var/nix"));
+        assert!(!parsed.delete_old);
+        let parsed = try_parse(&["--delete-older-than", "30d"]).unwrap();
+        assert_eq!(parsed.delete_older_than.as_deref(), Some("30d"));
+    }
+
+    #[test]
+    fn format_size_units() {
+        assert_eq!(format_size(0), "0 bytes");
+        assert_eq!(format_size(1023), "1023 bytes");
+        assert_eq!(format_size(1536), "1.50 KiB");
+        assert_eq!(format_size(5 * 1024 * 1024 + 512 * 1024), "5.50 MiB");
+        assert_eq!(format_size(3 * 1024 * 1024 * 1024 / 2), "1.50 GiB");
+    }
+
+    #[test]
+    fn parse_bool_values() {
+        assert_eq!(parse_bool(b"true\n"), Some(true));
+        assert_eq!(parse_bool(b"false\n"), Some(false));
+        assert_eq!(parse_bool(b"42\n"), None);
+        assert_eq!(parse_bool(b""), None);
+    }
+
+    #[test]
+    fn unknown_setting_falls_back_to_default() {
+        assert!(bool_setting("this-setting-does-not-exist", true));
+        assert!(!bool_setting("this-setting-does-not-exist", false));
+    }
+
+    #[test]
+    fn parse_size_units() {
+        assert_eq!(parse_size("0").unwrap(), 0);
+        assert_eq!(parse_size("123").unwrap(), 123);
+        assert_eq!(parse_size("1K").unwrap(), 1024);
+        assert_eq!(parse_size("2k").unwrap(), 2048);
+        assert_eq!(parse_size("1M").unwrap(), 1024 * 1024);
+        assert_eq!(parse_size("3m").unwrap(), 3 * 1024 * 1024);
+        assert_eq!(parse_size("1G").unwrap(), 1024 * 1024 * 1024);
+        assert_eq!(parse_size("2g").unwrap(), 2 * 1024 * 1024 * 1024);
+        assert_eq!(parse_size("1T").unwrap(), 1024u64.pow(4));
+        assert_eq!(parse_size("1.5K").unwrap(), 1536);
+        assert_eq!(parse_size(" 4M ").unwrap(), 4 * 1024 * 1024);
+        assert!(parse_size("abc").is_err());
+        assert!(parse_size("-5G").is_err());
+        assert!(parse_size("inf").is_err());
+        assert!(parse_size("NaN").is_err());
+        assert!(parse_size("99999999999999999999G").is_err());
+    }
+
+    #[test]
+    fn parse_ensure_free_values() {
+        assert_eq!(
+            parse_ensure_free("50G").unwrap(),
+            EnsureFree::Bytes(50 * 1024u64.pow(3))
+        );
+        assert_eq!(parse_ensure_free("1024").unwrap(), EnsureFree::Bytes(1024));
+        assert_eq!(parse_ensure_free("20%").unwrap(), EnsureFree::Percent(20.0));
+        assert_eq!(
+            parse_ensure_free(" 12.5 % ").unwrap(),
+            EnsureFree::Percent(12.5)
+        );
+        assert_eq!(
+            parse_ensure_free("100%").unwrap(),
+            EnsureFree::Percent(100.0)
+        );
+        assert!(parse_ensure_free("101%").is_err());
+        assert!(parse_ensure_free("-5%").is_err());
+        assert!(parse_ensure_free("abc%").is_err());
+    }
+}

--- a/harmonia-store-gc/src/lib.rs
+++ b/harmonia-store-gc/src/lib.rs
@@ -38,6 +38,7 @@
 mod error;
 mod gc;
 mod gc_socket;
+pub mod profiles;
 mod roots;
 mod store;
 mod temp_roots;

--- a/harmonia-store-gc/src/lib.rs
+++ b/harmonia-store-gc/src/lib.rs
@@ -19,6 +19,7 @@
 mod error;
 pub mod gc;
 pub mod gc_socket;
+pub mod profiles;
 pub(crate) mod roots;
 pub mod store;
 pub mod temp_roots;

--- a/harmonia-store-gc/src/profiles.rs
+++ b/harmonia-store-gc/src/profiles.rs
@@ -265,6 +265,12 @@ pub fn remove_old_generations(
     };
 
     let can_write = nix::unistd::access(dir, nix::unistd::AccessFlags::W_OK).is_ok();
+    if !can_write {
+        warn!(
+            "no write permission on {}, skipping its profiles",
+            dir.display()
+        );
+    }
 
     entries.par_iter().try_for_each(|entry| -> Result<()> {
         let path = entry.path();

--- a/harmonia-store-gc/src/profiles.rs
+++ b/harmonia-store-gc/src/profiles.rs
@@ -166,10 +166,10 @@ impl ProfileLock {
 
 impl Drop for ProfileLock {
     fn drop(&mut self) {
-        // Nix's deleteLockFile: write the deletion marker, then unlink.
-        // The flock itself is released when the fd closes.
-        let _ = self.file.write_all(b"d");
+        // Same order as Nix's deleteLockFile: a crash in between must not
+        // leave a linked non-empty file, which waiters retry on forever.
         let _ = fs::remove_file(&self.lock_path);
+        let _ = self.file.write_all(b"d");
     }
 }
 

--- a/harmonia-store-gc/src/profiles.rs
+++ b/harmonia-store-gc/src/profiles.rs
@@ -1,0 +1,552 @@
+// SPDX-FileCopyrightText: 2026 Jörg Thalheim
+// SPDX-License-Identifier: MIT
+
+//! Profile generation cleanup (`--delete-old` / `--delete-older-than`).
+//!
+//! A profile is a symlink like `system` pointing at its current
+//! generation link `system-42-link`. Removing old generation links is
+//! what allows their store paths to become garbage.
+
+use std::collections::BTreeSet;
+use std::fs;
+use std::io::Write;
+use std::os::unix::fs::OpenOptionsExt;
+use std::path::{Path, PathBuf};
+use std::time::{Duration, SystemTime};
+
+use nix::errno::Errno;
+use nix::fcntl::{Flock, FlockArg};
+use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
+use tracing::{info, warn};
+
+use crate::error::{Error, Result};
+
+/// Parse a Nix-style time spec into a point in the past.
+///
+/// ```
+/// use harmonia_store_gc::profiles::parse_older_than;
+///
+/// assert!(parse_older_than("30d").is_ok());
+/// assert!(parse_older_than("4h").is_ok());
+/// assert!(parse_older_than("banana").is_err());
+/// ```
+pub fn parse_older_than(spec: &str) -> Result<SystemTime> {
+    let invalid = |reason: &str| Error::TimeSpec {
+        spec: spec.to_owned(),
+        reason: reason.to_owned(),
+    };
+    // Take the last *character*. A byte-based split_at would panic on
+    // multi-byte input like "30日".
+    let Some((idx, unit)) = spec.char_indices().last() else {
+        return Err(invalid("expected e.g. '30d'"));
+    };
+    let num_str = &spec[..idx];
+    if num_str.is_empty() {
+        return Err(invalid("expected e.g. '30d'"));
+    }
+    let num: u64 = num_str
+        .parse()
+        .map_err(|e| invalid(&format!("invalid number: {e}")))?;
+    let unit_secs = match unit {
+        'h' => 3600,
+        'd' => 86400,
+        'w' => 7 * 86400,
+        'm' => 30 * 86400,
+        _ => return Err(invalid(&format!("unknown time unit '{unit}', use h/d/w/m"))),
+    };
+    let secs = num
+        .checked_mul(unit_secs)
+        .ok_or_else(|| invalid("out of range"))?;
+    SystemTime::now()
+        .checked_sub(Duration::from_secs(secs))
+        .ok_or_else(|| invalid("out of range"))
+}
+
+fn find_generation_links(profile: &Path) -> Result<Vec<(PathBuf, u64)>> {
+    let parent = profile.parent().unwrap_or(Path::new("."));
+    let profile_name = profile
+        .file_name()
+        .unwrap_or_default()
+        .to_string_lossy()
+        .to_string();
+
+    let mut gens = Vec::new();
+    let entries = match fs::read_dir(parent) {
+        Ok(e) => e,
+        Err(_) => return Ok(gens),
+    };
+
+    for entry in entries.flatten() {
+        let name = entry.file_name().to_string_lossy().to_string();
+        if let Some(rest) = name.strip_prefix(&format!("{profile_name}-"))
+            && let Some(num_str) = rest.strip_suffix("-link")
+            && let Ok(r#gen) = num_str.parse::<u64>()
+        {
+            gens.push((entry.path(), r#gen));
+        }
+    }
+    gens.sort_by_key(|(_, g)| *g);
+    Ok(gens)
+}
+
+fn current_generation(profile: &Path) -> Result<Option<u64>> {
+    let target = match fs::read_link(profile) {
+        Ok(t) => t,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(source) => {
+            return Err(Error::ReadLink {
+                path: profile.to_owned(),
+                source,
+            });
+        }
+    };
+    let name = target
+        .file_name()
+        .unwrap_or_default()
+        .to_string_lossy()
+        .to_string();
+    let profile_name = profile
+        .file_name()
+        .unwrap_or_default()
+        .to_string_lossy()
+        .to_string();
+
+    if let Some(rest) = name.strip_prefix(&format!("{profile_name}-"))
+        && let Some(num_str) = rest.strip_suffix("-link")
+        && let Ok(r#gen) = num_str.parse::<u64>()
+    {
+        return Ok(Some(r#gen));
+    }
+    Ok(None)
+}
+
+/// Lock held while mutating a profile's generations, interoperable with
+/// Nix's PathLocks protocol: flock(2) on `<profile>.lock`, stale
+/// detection via a non-empty file, deletion marker on release.
+struct ProfileLock {
+    lock_path: PathBuf,
+    file: nix::fcntl::Flock<fs::File>,
+}
+
+impl ProfileLock {
+    fn acquire(profile: &Path) -> Result<ProfileLock> {
+        let mut name = profile.file_name().unwrap_or_default().to_os_string();
+        name.push(".lock");
+        let lock_path = profile.with_file_name(name);
+        let lock_err = |source| Error::ProfileLock {
+            path: lock_path.clone(),
+            source,
+        };
+        loop {
+            let mut file = fs::OpenOptions::new()
+                .read(true)
+                .write(true)
+                .create(true)
+                .truncate(false)
+                .mode(0o600)
+                .open(&lock_path)
+                .map_err(lock_err)?;
+            let file = loop {
+                match Flock::lock(file, FlockArg::LockExclusive) {
+                    Ok(lock) => break lock,
+                    // Flock does not retry EINTR itself.
+                    Err((f, Errno::EINTR)) => file = f,
+                    Err((_, errno)) => return Err(lock_err(errno.into())),
+                }
+            };
+            // Stale check (Nix protocol): a non-empty lock file was marked
+            // and unlinked by its previous holder. Retry on a fresh inode.
+            if file.metadata().map_err(lock_err)?.len() != 0 {
+                continue;
+            }
+            return Ok(ProfileLock { lock_path, file });
+        }
+    }
+}
+
+impl Drop for ProfileLock {
+    fn drop(&mut self) {
+        // Nix's deleteLockFile: write the deletion marker, then unlink.
+        // The flock itself is released when the fd closes.
+        let _ = self.file.write_all(b"d");
+        let _ = fs::remove_file(&self.lock_path);
+    }
+}
+
+fn delete_old_generations(profile: &Path, dry_run: bool) -> Result<()> {
+    // Serialize against nix-env/nixos-rebuild generation switches, which
+    // take the same lock.
+    let _lock = ProfileLock::acquire(profile)?;
+    // Fail closed: without a known active generation, "delete all but
+    // current" would delete the active system too.
+    let Some(current) = current_generation(profile)? else {
+        warn!(
+            "cannot determine current generation of {}, skipping",
+            profile.display()
+        );
+        return Ok(());
+    };
+    let gens = find_generation_links(profile)?;
+
+    for (path, r#gen) in &gens {
+        if *r#gen == current {
+            continue;
+        }
+        if dry_run {
+            info!("would remove: {}", path.display());
+        } else {
+            info!("removing: {}", path.display());
+            if let Err(e) = fs::remove_file(path) {
+                warn!("cannot remove {}: {e}", path.display());
+            }
+        }
+    }
+    Ok(())
+}
+
+fn delete_generations_older_than(profile: &Path, cutoff: SystemTime, dry_run: bool) -> Result<()> {
+    let _lock = ProfileLock::acquire(profile)?;
+    // Same fail-closed rule as delete_old_generations.
+    let Some(current) = current_generation(profile)? else {
+        warn!(
+            "cannot determine current generation of {}, skipping",
+            profile.display()
+        );
+        return Ok(());
+    };
+    let gens = find_generation_links(profile)?;
+
+    let mtime_of = |path: &Path| -> Option<SystemTime> {
+        let meta = fs::symlink_metadata(path).ok()?;
+        Some(meta.modified().unwrap_or(SystemTime::UNIX_EPOCH))
+    };
+
+    // Like Nix, keep the newest generation older than the cutoff: it was
+    // active at that point in time and stays available for rollback.
+    let newest_older = gens
+        .iter()
+        .rev()
+        .find(|(path, _)| mtime_of(path).is_some_and(|t| t < cutoff))
+        .map(|(_, g)| *g);
+
+    for (path, r#gen) in &gens {
+        if *r#gen == current || Some(*r#gen) == newest_older {
+            continue;
+        }
+        let Some(mtime) = mtime_of(path) else {
+            continue;
+        };
+        if mtime < cutoff {
+            if dry_run {
+                info!("would remove (old): {}", path.display());
+            } else {
+                info!("removing (old): {}", path.display());
+                if let Err(e) = fs::remove_file(path) {
+                    warn!("cannot remove {}: {e}", path.display());
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Remove old generations of every profile found under `dir`,
+/// recursively. With `delete_older_than` set, only generations older
+/// than that point go. Without it, everything but the current
+/// generation goes.
+pub fn remove_old_generations(
+    dir: &Path,
+    delete_older_than: Option<SystemTime>,
+    dry_run: bool,
+) -> Result<()> {
+    let entries: Vec<_> = match fs::read_dir(dir) {
+        Ok(rd) => rd.flatten().collect(),
+        Err(_) => return Ok(()),
+    };
+
+    let can_write = nix::unistd::access(dir, nix::unistd::AccessFlags::W_OK).is_ok();
+
+    entries.par_iter().try_for_each(|entry| -> Result<()> {
+        let path = entry.path();
+        let ft = match fs::symlink_metadata(&path) {
+            Ok(m) => m.file_type(),
+            Err(_) => return Ok(()),
+        };
+
+        if ft.is_symlink() && can_write {
+            let link_target = match fs::read_link(&path) {
+                Ok(t) => t,
+                Err(_) => return Ok(()),
+            };
+            if link_target.to_string_lossy().contains("link") {
+                info!("removing old generations of profile {}", path.display());
+                if let Some(cutoff) = delete_older_than {
+                    delete_generations_older_than(&path, cutoff, dry_run)?;
+                } else {
+                    delete_old_generations(&path, dry_run)?;
+                }
+            }
+        } else if ft.is_dir() {
+            remove_old_generations(&path, delete_older_than, dry_run)?;
+        }
+        Ok(())
+    })?;
+
+    Ok(())
+}
+
+/// Directories scanned for profiles, mirroring `nix-collect-garbage`:
+/// the system profiles dir (recursed, so per-user is covered) and the
+/// invoking user's XDG state profiles dir. Never the home directory
+/// itself — [`remove_old_generations`] recurses, and treating arbitrary
+/// `*-N-link` symlinks under `$HOME` as generations would delete user
+/// data.
+pub fn profile_dirs(state_dir: &Path) -> BTreeSet<PathBuf> {
+    let mut dirs = BTreeSet::new();
+
+    dirs.insert(state_dir.join("profiles"));
+
+    let xdg_state = std::env::var("XDG_STATE_HOME")
+        .map(PathBuf::from)
+        .ok()
+        .filter(|p| p.is_absolute())
+        .or_else(|| {
+            std::env::var("HOME")
+                .ok()
+                .map(|h| PathBuf::from(h).join(".local/state"))
+        });
+    if let Some(state_home) = xdg_state {
+        dirs.insert(state_home.join("nix/profiles"));
+    }
+
+    dirs
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::os::unix::fs::symlink;
+    use std::time::{Duration, SystemTime};
+
+    fn approx_secs_ago(t: SystemTime, secs: u64) {
+        let elapsed = SystemTime::now().duration_since(t).unwrap();
+        let want = Duration::from_secs(secs);
+        let diff = elapsed.abs_diff(want);
+        assert!(
+            diff < Duration::from_secs(5),
+            "expected ~{secs}s ago, got {elapsed:?}"
+        );
+    }
+
+    #[test]
+    fn parse_older_than_units() {
+        approx_secs_ago(parse_older_than("2h").unwrap(), 2 * 3600);
+        approx_secs_ago(parse_older_than("3d").unwrap(), 3 * 86400);
+        approx_secs_ago(parse_older_than("2w").unwrap(), 2 * 7 * 86400);
+        approx_secs_ago(parse_older_than("2m").unwrap(), 2 * 30 * 86400);
+    }
+
+    #[test]
+    fn parse_older_than_rejects_invalid() {
+        assert!(parse_older_than("").is_err());
+        assert!(parse_older_than("d").is_err());
+        assert!(parse_older_than("5x").is_err());
+        assert!(parse_older_than("xd").is_err());
+        // Multi-byte unit must error, not panic on a char boundary.
+        assert!(parse_older_than("30日").is_err());
+        assert!(parse_older_than("日").is_err());
+        // Overflowing multiplication must error, not wrap.
+        assert!(parse_older_than("99999999999999999999d").is_err());
+        assert!(parse_older_than("9999999999999999999d").is_err());
+        // Fits in u64 after multiplication but reaches the edge of
+        // SystemTime's range. Must not panic.
+        let _ = parse_older_than("106751991167300d");
+    }
+
+    #[test]
+    fn generation_links_and_current() {
+        let dir = tempfile::tempdir().unwrap();
+        let profile = dir.path().join("system");
+
+        // Generation links plus noise that must be ignored.
+        for n in [3u64, 1, 2] {
+            let link = dir.path().join(format!("system-{n}-link"));
+            symlink(format!("/nix/store/fake-{n}"), &link).unwrap();
+        }
+        symlink("/nix/store/x", dir.path().join("other-1-link")).unwrap();
+        symlink("/nix/store/x", dir.path().join("system-foo-link")).unwrap();
+
+        symlink(dir.path().join("system-2-link"), &profile).unwrap();
+
+        let gens = find_generation_links(&profile).unwrap();
+        let nums: Vec<u64> = gens.iter().map(|(_, g)| *g).collect();
+        assert_eq!(nums, vec![1, 2, 3]);
+        assert_eq!(gens[0].0, dir.path().join("system-1-link"));
+
+        assert_eq!(current_generation(&profile).unwrap(), Some(2));
+    }
+
+    /// Build a temp profile dir with generations 1..=n and a `system`
+    /// symlink pointing at `system-{current}-link`.
+    fn setup_profile(n: u64, current: u64) -> (tempfile::TempDir, PathBuf) {
+        let dir = tempfile::tempdir().unwrap();
+        for i in 1..=n {
+            let link = dir.path().join(format!("system-{i}-link"));
+            symlink(format!("/nix/store/fake-{i}"), &link).unwrap();
+        }
+        let profile = dir.path().join("system");
+        symlink(dir.path().join(format!("system-{current}-link")), &profile).unwrap();
+        (dir, profile)
+    }
+
+    fn existing_gens(dir: &Path) -> Vec<u64> {
+        find_generation_links(&dir.join("system"))
+            .unwrap()
+            .into_iter()
+            .map(|(_, g)| g)
+            .collect()
+    }
+
+    fn set_link_mtime(path: &Path, t: SystemTime) {
+        use nix::sys::stat::{UtimensatFlags, utimensat};
+        use nix::sys::time::TimeSpec;
+        let d = t.duration_since(SystemTime::UNIX_EPOCH).unwrap();
+        let ts = TimeSpec::new(d.as_secs() as i64, d.subsec_nanos() as i64);
+        utimensat(
+            nix::fcntl::AT_FDCWD,
+            path,
+            &ts,
+            &ts,
+            UtimensatFlags::NoFollowSymlink,
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn delete_old_generations_keeps_only_current() {
+        let (dir, profile) = setup_profile(3, 2);
+
+        // Dry run leaves everything in place.
+        delete_old_generations(&profile, true).unwrap();
+        assert_eq!(existing_gens(dir.path()), vec![1, 2, 3]);
+
+        delete_old_generations(&profile, false).unwrap();
+        assert_eq!(existing_gens(dir.path()), vec![2]);
+    }
+
+    #[test]
+    fn delete_generations_older_than_cutoff() {
+        let (dir, profile) = setup_profile(4, 4);
+        let base = SystemTime::UNIX_EPOCH + Duration::from_secs(1_000_000);
+        // gen i has mtime base + i*100s
+        for i in 1u64..=4 {
+            set_link_mtime(
+                &dir.path().join(format!("system-{i}-link")),
+                base + Duration::from_secs(i * 100),
+            );
+        }
+
+        // Cutoff at gen 2's mtime: only gen 1 is older, and it is kept
+        // for rollback (active at the cutoff). Nothing goes.
+        let cutoff = base + Duration::from_secs(200);
+        delete_generations_older_than(&profile, cutoff, true).unwrap();
+        assert_eq!(existing_gens(dir.path()), vec![1, 2, 3, 4]);
+        delete_generations_older_than(&profile, cutoff, false).unwrap();
+        assert_eq!(existing_gens(dir.path()), vec![1, 2, 3, 4]);
+
+        // Cutoff between gen 3 and 4: gens 1-3 are older, gen 3 was
+        // active at the cutoff and is kept. Generations 1 and 2 go.
+        let cutoff = base + Duration::from_secs(350);
+        delete_generations_older_than(&profile, cutoff, false).unwrap();
+        assert_eq!(existing_gens(dir.path()), vec![3, 4]);
+
+        // Cutoff after all gens: the newest older one is the current
+        // generation itself, so everything else goes.
+        delete_generations_older_than(&profile, base + Duration::from_secs(10_000), false).unwrap();
+        assert_eq!(existing_gens(dir.path()), vec![4]);
+    }
+
+    #[test]
+    fn remove_old_generations_recurses_and_skips_non_link_targets() {
+        let outer = tempfile::tempdir().unwrap();
+        let nested = outer.path().join("per-user").join("alice");
+        fs::create_dir_all(&nested).unwrap();
+        for i in 1u64..=3 {
+            symlink(
+                format!("/nix/store/fake-{i}"),
+                nested.join(format!("prof-{i}-link")),
+            )
+            .unwrap();
+        }
+        symlink(nested.join("prof-3-link"), nested.join("prof")).unwrap();
+        // Symlink whose target does not contain "link" must be left alone.
+        symlink("/nix/store/zzz", outer.path().join("plain")).unwrap();
+
+        remove_old_generations(outer.path(), None, false).unwrap();
+
+        let gens: Vec<u64> = find_generation_links(&nested.join("prof"))
+            .unwrap()
+            .into_iter()
+            .map(|(_, g)| g)
+            .collect();
+        assert_eq!(gens, vec![3]);
+        assert!(outer.path().join("plain").symlink_metadata().is_ok());
+    }
+
+    #[test]
+    fn profile_dirs_includes_state_and_xdg_paths_but_not_home() {
+        let state = Path::new("/var/state");
+        let dirs = profile_dirs(state);
+        assert!(dirs.contains(&state.join("profiles")));
+        if let Ok(home) = std::env::var("HOME") {
+            // $HOME itself must never be scanned recursively.
+            assert!(!dirs.contains(&PathBuf::from(&home)));
+            if std::env::var("XDG_STATE_HOME").is_err() {
+                assert!(dirs.contains(&PathBuf::from(home).join(".local/state/nix/profiles")));
+            }
+        }
+    }
+
+    #[test]
+    fn profile_lock_acquire_release_cleans_up() {
+        let dir = tempfile::tempdir().unwrap();
+        let profile = dir.path().join("system");
+        let lock_path = dir.path().join("system.lock");
+        {
+            let _lock = ProfileLock::acquire(&profile).unwrap();
+            assert!(lock_path.exists());
+        }
+        // Released locks are unlinked (Nix deleteLockFile protocol).
+        assert!(!lock_path.exists());
+        let _lock = ProfileLock::acquire(&profile).unwrap();
+    }
+
+    #[test]
+    fn unparseable_current_generation_deletes_nothing() {
+        // Profile pointing at a non-generation target: refusing to guess
+        // protects the active generation from "delete all but current".
+        let (dir, profile) = setup_profile(3, 2);
+        fs::remove_file(&profile).unwrap();
+        symlink("/nix/store/custom-env", &profile).unwrap();
+
+        delete_old_generations(&profile, false).unwrap();
+        assert_eq!(existing_gens(dir.path()), vec![1, 2, 3]);
+
+        delete_generations_older_than(&profile, SystemTime::now(), false).unwrap();
+        assert_eq!(existing_gens(dir.path()), vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn current_generation_none_when_missing() {
+        let dir = tempfile::tempdir().unwrap();
+        assert_eq!(current_generation(&dir.path().join("nope")).unwrap(), None);
+
+        // Profile exists but does not point at a -link target.
+        let profile = dir.path().join("system");
+        symlink("/nix/store/whatever", &profile).unwrap();
+        assert_eq!(current_generation(&profile).unwrap(), None);
+
+        // No matching generation links anywhere.
+        assert_eq!(find_generation_links(&profile).unwrap(), vec![]);
+    }
+}

--- a/nix/checks.nix
+++ b/nix/checks.nix
@@ -55,7 +55,7 @@
     ]
   );
 }
-// lib.optionalAttrs pkgs.stdenv.isLinux (
+// lib.optionalAttrs pkgs.stdenv.hostPlatform.isLinux (
   lib.mapAttrs' (
     name: _:
     lib.nameValuePair (lib.removeSuffix ".nix" name) (

--- a/nix/packages.nix
+++ b/nix/packages.nix
@@ -127,7 +127,7 @@ let
         export NIX_UPSTREAM_SRC=${nix-src}
         export LLVM_COV=${llvmPackages.bintools-unwrapped}/bin/llvm-cov
         export LLVM_PROFDATA=${llvmPackages.bintools-unwrapped}/bin/llvm-profdata
-        ${lib.optionalString stdenv.isDarwin ''
+        ${lib.optionalString stdenv.hostPlatform.isDarwin ''
           export _NIX_TEST_NO_SANDBOX="1"
         ''}
 

--- a/nix/packages.nix
+++ b/nix/packages.nix
@@ -76,6 +76,7 @@ let
     commonArgs
     // {
       inherit cargoArtifacts;
+      cargoExtraArgs = "--features harmonia-store-gc/cli";
 
       # Add runtime dependencies
       nativeBuildInputs = [ makeWrapper ];


### PR DESCRIPTION
Removing old profile generations, with the same profile locking that
nix-env uses, so a concurrent nixos-rebuild cannot race us.

The binary also carries the policy the library leaves to its caller:
keep-outputs and keep-derivations are read via 'nix config show'
unless overridden on the command line, and a read-only /nix/store is
remounted writable inside a private mount namespace before deletion.