### PR TITLE
store-gc: add integration and socket concurrency tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -459,6 +459,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
+ "clap_derive",
 ]
 
 [[package]]
@@ -469,6 +470,19 @@ checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
  "anstyle",
  "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1176,6 +1190,7 @@ dependencies = [
 name = "harmonia-store-gc"
 version = "3.2.0"
 dependencies = [
+ "clap",
  "foldhash",
  "harmonia-store-db",
  "harmonia-store-path",
@@ -1380,6 +1395,12 @@ checksum = "a5081f264ed7adee96ea4b4778b6bb9da0a7228b084587aa3bd3ff05da7c5a3b"
 dependencies = [
  "hashbrown 0.17.0",
 ]
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hex-literal"
@@ -2408,6 +2429,12 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "subtle"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1173,6 +1173,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "harmonia-store-gc"
+version = "3.2.0"
+dependencies = [
+ "foldhash",
+ "harmonia-store-db",
+ "harmonia-store-path",
+ "nix",
+ "rusqlite",
+ "tempfile",
+ "thiserror",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "harmonia-store-nar-info"
 version = "3.2.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1195,6 +1195,7 @@ dependencies = [
  "harmonia-store-db",
  "harmonia-store-path",
  "nix",
+ "rand",
  "rayon",
  "rusqlite",
  "tempfile",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1180,11 +1180,13 @@ dependencies = [
  "harmonia-store-db",
  "harmonia-store-path",
  "nix",
+ "rayon",
  "rusqlite",
  "tempfile",
  "thiserror",
  "tracing",
  "tracing-subscriber",
+ "walkdir",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ members = [
     "harmonia-store-derivation",
     "harmonia-store-ref-scan",
     "harmonia-store-db",
+    "harmonia-store-gc",
     "harmonia-store-path",
     "harmonia-utils-signature",
     "harmonia-store-nar-info",
@@ -45,6 +46,14 @@ async-stream = "0.3"
 blake3 = "1.8"
 bstr = "1.11"
 bytes = "1.11"
+clap = { version = "4", default-features = false, features = [
+    "std",
+    "help",
+    "usage",
+    "error-context",
+    "suggestions",
+    "derive",
+] }
 data-encoding = "2.11"
 derive_more = { version = "2.1", features = [ "display" ] }
 ed25519-dalek = "3.0.0-rc.0"
@@ -56,10 +65,22 @@ getrandom = "0.4"
 libc = "0.2"
 md5 = "0.8"
 memchr = "2"
-nix = { version = "0.31", features = [ "signal", "mman" ] }
+nix = { version = "0.31", features = [
+    "signal",
+    "mman",
+    "fs",
+    "user",
+    "dir",
+    "mount",
+    "sched",
+    "socket",
+    "poll",
+] }
 num_enum = "0.7"
+pico-args = "0.5"
 pin-project-lite = "0.2"
 prometheus = { version = "0.14", default-features = false }
+rayon = "1"
 rusqlite = { version = "0.40", features = [ "bundled" ] }
 serde = { version = "1.0", features = [ "derive" ] }
 serde_json = "1.0"
@@ -83,6 +104,7 @@ tokio-util = "0.7"
 toml = "1.1"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = [ "env-filter" ] }
+walkdir = "2"
 
 # Proc-macro toolkit (harmonia-protocol-derive)
 proc-macro2 = "1.0"
@@ -107,6 +129,7 @@ harmonia-store-build-result    = { path = "harmonia-store-build-result" }
 harmonia-store-content-address = { path = "harmonia-store-content-address" }
 harmonia-store-db              = { path = "harmonia-store-db" }
 harmonia-store-derivation      = { path = "harmonia-store-derivation" }
+harmonia-store-gc              = { path = "harmonia-store-gc" }
 harmonia-store-nar-info        = { path = "harmonia-store-nar-info" }
 harmonia-store-path            = { path = "harmonia-store-path" }
 harmonia-store-path-info       = { path = "harmonia-store-path-info" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,6 +80,7 @@ num_enum = "0.7"
 pico-args = "0.5"
 pin-project-lite = "0.2"
 prometheus = { version = "0.14", default-features = false }
+rand = "0.9"
 rayon = "1"
 rusqlite = { version = "0.40", features = [ "bundled" ] }
 serde = { version = "1.0", features = [ "derive" ] }

--- a/harmonia-store-gc/Cargo.toml
+++ b/harmonia-store-gc/Cargo.toml
@@ -16,9 +16,11 @@ foldhash            = { workspace = true }
 harmonia-store-db   = { workspace = true }
 harmonia-store-path = { workspace = true }
 nix                 = { workspace = true }
+rayon               = { workspace = true }
 thiserror           = { workspace = true }
 tracing             = { workspace = true }
 tracing-subscriber  = { workspace = true }
+walkdir             = { workspace = true }
 
 [dev-dependencies]
 rusqlite = { workspace = true }

--- a/harmonia-store-gc/Cargo.toml
+++ b/harmonia-store-gc/Cargo.toml
@@ -11,7 +11,12 @@ homepage.workspace   = true
 repository.workspace = true
 description          = "Garbage collection for the Nix store"
 
+[[bin]]
+name = "harmonia-gc"
+path = "src/bin/harmonia-gc.rs"
+
 [dependencies]
+clap                = { workspace = true }
 foldhash            = { workspace = true }
 harmonia-store-db   = { workspace = true }
 harmonia-store-path = { workspace = true }

--- a/harmonia-store-gc/Cargo.toml
+++ b/harmonia-store-gc/Cargo.toml
@@ -28,6 +28,7 @@ tracing-subscriber  = { workspace = true }
 walkdir             = { workspace = true }
 
 [dev-dependencies]
+rand     = { workspace = true }
 rusqlite = { workspace = true }
 tempfile = { workspace = true }
 

--- a/harmonia-store-gc/Cargo.toml
+++ b/harmonia-store-gc/Cargo.toml
@@ -1,0 +1,28 @@
+# SPDX-FileCopyrightText: 2025 Jörg Thalheim
+# SPDX-License-Identifier: MIT
+
+[package]
+name                 = "harmonia-store-gc"
+version.workspace    = true
+authors.workspace    = true
+edition.workspace    = true
+license.workspace    = true
+homepage.workspace   = true
+repository.workspace = true
+description          = "Garbage collection for the Nix store"
+
+[dependencies]
+foldhash            = { workspace = true }
+harmonia-store-db   = { workspace = true }
+harmonia-store-path = { workspace = true }
+nix                 = { workspace = true }
+thiserror           = { workspace = true }
+tracing             = { workspace = true }
+tracing-subscriber  = { workspace = true }
+
+[dev-dependencies]
+rusqlite = { workspace = true }
+tempfile = { workspace = true }
+
+[lints]
+workspace = true

--- a/harmonia-store-gc/src/bin/harmonia-gc.rs
+++ b/harmonia-store-gc/src/bin/harmonia-gc.rs
@@ -1,0 +1,342 @@
+// SPDX-FileCopyrightText: 2025 Jörg Thalheim
+// SPDX-License-Identifier: MIT
+
+//! `harmonia-gc`: a faster `nix-collect-garbage`.
+
+use std::path::{Path, PathBuf};
+
+use clap::Parser;
+use harmonia_store_gc::store::GcStore;
+use harmonia_store_gc::{format_size, gc, profiles, unshare_mount_namespace};
+use rayon::prelude::*;
+use tracing::{debug, warn};
+
+type MainResult<T> = Result<T, Box<dyn std::error::Error>>;
+
+/// A faster nix-collect-garbage.
+#[derive(Parser)]
+#[command(version)]
+struct Args {
+    /// Remove old profile generations
+    #[arg(short, long)]
+    delete_old: bool,
+
+    /// Delete generations older than SPEC (e.g. 30d). Implies --delete-old
+    #[arg(long, value_name = "SPEC")]
+    delete_older_than: Option<String>,
+
+    /// Show what would be done without doing it
+    #[arg(long)]
+    dry_run: bool,
+
+    /// Free until SIZE is available (e.g. 50G or 20%). Pinned paths are
+    /// never freed
+    #[arg(long, value_name = "SIZE", value_parser = parse_ensure_free)]
+    ensure_free: Option<EnsureFree>,
+
+    /// Keep paths registered within SPEC (e.g. 7d)
+    #[arg(long, value_name = "SPEC")]
+    keep_recent: Option<String>,
+
+    /// Skip the database VACUUM after deletion
+    #[arg(long)]
+    no_vacuum: bool,
+
+    /// Dead paths per delete transaction
+    #[arg(long, value_name = "N")]
+    chunk_size: Option<usize>,
+
+    /// Override the keep-outputs nix.conf setting
+    #[arg(long, value_name = "BOOL")]
+    keep_outputs: Option<bool>,
+
+    /// Override the keep-derivations nix.conf setting
+    #[arg(long, value_name = "BOOL")]
+    keep_derivations: Option<bool>,
+
+    /// Extra directory to scan for GC roots (repeatable)
+    #[arg(long = "gc-roots-dir", value_name = "PATH")]
+    gc_roots_dirs: Vec<PathBuf>,
+
+    /// Nix store directory
+    #[arg(long, value_name = "PATH", default_value = "/nix/store")]
+    store_dir: PathBuf,
+
+    /// Nix state directory
+    #[arg(long, value_name = "PATH", default_value = "/nix/var/nix")]
+    state_dir: PathBuf,
+}
+
+/// `--ensure-free` target: absolute bytes or a percentage of the store's
+/// filesystem.
+#[derive(Debug, Clone, Copy, PartialEq)]
+enum EnsureFree {
+    Bytes(u64),
+    Percent(f64),
+}
+
+impl EnsureFree {
+    fn target_bytes(self, total: u64) -> u64 {
+        match self {
+            EnsureFree::Bytes(b) => b,
+            EnsureFree::Percent(p) => (total as f64 * p / 100.0) as u64,
+        }
+    }
+}
+
+/// Parse a size like "50G" or a percentage like "20%".
+fn parse_ensure_free(s: &str) -> Result<EnsureFree, String> {
+    let s = s.trim();
+    if let Some(num) = s.strip_suffix('%') {
+        let p: f64 = num
+            .trim()
+            .parse()
+            .map_err(|e| format!("invalid percentage '{s}': {e}"))?;
+        if !p.is_finite() || !(0.0..=100.0).contains(&p) {
+            return Err(format!("percentage '{s}' must be between 0 and 100"));
+        }
+        Ok(EnsureFree::Percent(p))
+    } else {
+        Ok(EnsureFree::Bytes(parse_size(s)?))
+    }
+}
+
+/// Parse a size like "50G", "512M", "1024K", or plain bytes.
+fn parse_size(s: &str) -> Result<u64, String> {
+    let s = s.trim();
+    let (num, mult) = match s.chars().last() {
+        Some('K' | 'k') => (&s[..s.len() - 1], 1024u64),
+        Some('M' | 'm') => (&s[..s.len() - 1], 1024 * 1024),
+        Some('G' | 'g') => (&s[..s.len() - 1], 1024 * 1024 * 1024),
+        Some('T' | 't') => (&s[..s.len() - 1], 1024u64.pow(4)),
+        _ => (s, 1),
+    };
+    let n: f64 = num
+        .parse()
+        .map_err(|e| format!("invalid size '{s}': {e}"))?;
+    if !n.is_finite() || n < 0.0 || n * mult as f64 > u64::MAX as f64 {
+        return Err(format!("size '{s}' is out of range"));
+    }
+    Ok((n * mult as f64) as u64)
+}
+
+/// Free and total bytes on the filesystem containing `path`.
+fn filesystem_bytes(path: &Path) -> MainResult<(u64, u64)> {
+    let st =
+        nix::sys::statvfs::statvfs(path).map_err(|e| format!("statvfs {}: {e}", path.display()))?;
+    // statvfs field types differ between Linux (u64) and macOS (u32).
+    let frag = st.fragment_size() as u64;
+    let avail = st.blocks_available() as u64 * frag;
+    let total = st.blocks() as u64 * frag;
+    Ok((avail, total))
+}
+
+/// Initialize the rayon global pool up front so thread creation failures
+/// (e.g. EAGAIN under a sandbox thread limit) fall back to a single
+/// thread instead of panicking on the first `par_iter`.
+fn init_rayon() {
+    if let Err(e) = rayon::ThreadPoolBuilder::new().build_global() {
+        warn!("failed to start rayon thread pool ({e}), falling back to a single thread");
+        let _ = rayon::ThreadPoolBuilder::new()
+            .num_threads(1)
+            .build_global();
+    }
+}
+
+fn main() -> MainResult<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),
+        )
+        .with_writer(std::io::stderr)
+        .init();
+
+    let args = Args::parse();
+    let delete_old = args.delete_old || args.delete_older_than.is_some();
+
+    // Must happen before rayon spawns its worker threads: only the
+    // calling thread joins the new mount namespace.
+    if !args.dry_run {
+        unshare_mount_namespace();
+    }
+    init_rayon();
+
+    if args.ensure_free.is_some() && args.dry_run {
+        return Err("--ensure-free cannot be combined with --dry-run".into());
+    }
+
+    // Validate every time spec before any destructive work. A bad
+    // --keep-recent must not surface only after generations were deleted.
+    let delete_older_cutoff = args
+        .delete_older_than
+        .as_deref()
+        .map(profiles::parse_older_than)
+        .transpose()?;
+    let keep_recent_after = args
+        .keep_recent
+        .as_deref()
+        .map(profiles::parse_older_than)
+        .transpose()?
+        .map(|t| {
+            t.duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_secs() as i64)
+                .unwrap_or(0)
+        });
+
+    if delete_old {
+        profiles::profile_dirs(&args.state_dir)
+            .par_iter()
+            .try_for_each(|dir| {
+                profiles::remove_old_generations(dir, delete_older_cutoff, args.dry_run)
+            })?;
+    }
+
+    let max_freed = if let Some(ensure_free) = args.ensure_free {
+        let (avail, total) = filesystem_bytes(&args.store_dir)?;
+        let target = ensure_free.target_bytes(total);
+        if avail >= target {
+            println!("{} already free, nothing to do", format_size(avail));
+            return Ok(());
+        }
+        let need = target - avail;
+        tracing::info!(
+            "freeing at least {} to reach {} free",
+            format_size(need),
+            format_size(target)
+        );
+        Some(need)
+    } else {
+        None
+    };
+    let ensure_free_need = max_freed;
+
+    let mut store = if args.dry_run {
+        // No DB writes happen in a dry run, so don't take write locks or
+        // flip the journal mode. A WAL database without its -shm/-wal
+        // sidecars cannot be opened read-only. Fall back to read-write.
+        GcStore::open_read_only(&args.store_dir, &args.state_dir).or_else(|e| {
+            debug!("read-only open failed ({e}), retrying read-write");
+            GcStore::open(&args.store_dir, &args.state_dir)
+        })?
+    } else {
+        GcStore::open(&args.store_dir, &args.state_dir)?
+    };
+    if let Some(v) = args.keep_outputs {
+        store.graph_options.keep_outputs = v;
+    }
+    if let Some(v) = args.keep_derivations {
+        store.graph_options.keep_derivations = v;
+    }
+    let opts = gc::GcOptions {
+        dry_run: args.dry_run,
+        max_freed,
+        keep_recent_after,
+        no_vacuum: args.no_vacuum,
+        chunk_size: args.chunk_size,
+        extra_gc_roots_dirs: args.gc_roots_dirs,
+    };
+    let (bytes_freed, paths_deleted) = gc::collect_garbage(&store, &opts)?;
+
+    if let Some(need) = ensure_free_need
+        && bytes_freed < need
+    {
+        let hint = if keep_recent_after.is_some() {
+            " (reachable from GC roots or pinned by --keep-recent)"
+        } else {
+            " (reachable from GC roots)"
+        };
+        warn!(
+            "only freed {}, {} short of --ensure-free target. \
+             The remaining paths are alive{hint}",
+            format_size(bytes_freed),
+            format_size(need - bytes_freed)
+        );
+    }
+
+    if args.dry_run {
+        println!(
+            "{paths_deleted} store paths would be deleted (~{})",
+            format_size(bytes_freed)
+        );
+    } else {
+        println!(
+            "{paths_deleted} store paths deleted, {} freed",
+            format_size(bytes_freed)
+        );
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Args, EnsureFree, parse_ensure_free, parse_size};
+    use clap::Parser;
+
+    fn try_parse(list: &[&str]) -> Result<Args, clap::Error> {
+        Args::try_parse_from(std::iter::once(&"harmonia-gc").chain(list))
+    }
+
+    #[test]
+    fn rejects_unknown_arguments() {
+        // A typo'd flag must not silently run a destructive GC.
+        assert!(try_parse(&["--dry-rnu"]).is_err());
+        assert!(try_parse(&["--keep-resent", "2d"]).is_err());
+        assert!(try_parse(&["--dry-run", "extra"]).is_err());
+        let parsed = try_parse(&["--dry-run"]).unwrap();
+        assert!(parsed.dry_run);
+    }
+
+    #[test]
+    fn repeatable_and_default_args() {
+        let parsed = try_parse(&["--gc-roots-dir", "/a", "--gc-roots-dir", "/b"]).unwrap();
+        assert_eq!(parsed.gc_roots_dirs.len(), 2);
+        assert_eq!(parsed.store_dir.to_str(), Some("/nix/store"));
+        assert_eq!(parsed.state_dir.to_str(), Some("/nix/var/nix"));
+        assert!(!parsed.delete_old);
+        let parsed = try_parse(&["--delete-older-than", "30d"]).unwrap();
+        assert_eq!(parsed.delete_older_than.as_deref(), Some("30d"));
+    }
+
+    #[test]
+    fn parse_size_units() {
+        assert_eq!(parse_size("0").unwrap(), 0);
+        assert_eq!(parse_size("123").unwrap(), 123);
+        assert_eq!(parse_size("1K").unwrap(), 1024);
+        assert_eq!(parse_size("2k").unwrap(), 2048);
+        assert_eq!(parse_size("1M").unwrap(), 1024 * 1024);
+        assert_eq!(parse_size("3m").unwrap(), 3 * 1024 * 1024);
+        assert_eq!(parse_size("1G").unwrap(), 1024 * 1024 * 1024);
+        assert_eq!(parse_size("2g").unwrap(), 2 * 1024 * 1024 * 1024);
+        assert_eq!(parse_size("1T").unwrap(), 1024u64.pow(4));
+        assert_eq!(parse_size("1.5K").unwrap(), 1536);
+        assert_eq!(parse_size(" 4M ").unwrap(), 4 * 1024 * 1024);
+        assert!(parse_size("abc").is_err());
+        assert!(parse_size("-5G").is_err());
+        assert!(parse_size("inf").is_err());
+        assert!(parse_size("NaN").is_err());
+        assert!(parse_size("99999999999999999999G").is_err());
+    }
+
+    #[test]
+    fn parse_ensure_free_values() {
+        assert_eq!(
+            parse_ensure_free("50G").unwrap(),
+            EnsureFree::Bytes(50 * 1024u64.pow(3))
+        );
+        assert_eq!(parse_ensure_free("1024").unwrap(), EnsureFree::Bytes(1024));
+        assert_eq!(parse_ensure_free("20%").unwrap(), EnsureFree::Percent(20.0));
+        assert_eq!(
+            parse_ensure_free(" 12.5 % ").unwrap(),
+            EnsureFree::Percent(12.5)
+        );
+        assert_eq!(
+            parse_ensure_free("100%").unwrap(),
+            EnsureFree::Percent(100.0)
+        );
+        assert!(parse_ensure_free("101%").is_err());
+        assert!(parse_ensure_free("-5%").is_err());
+        assert!(parse_ensure_free("abc%").is_err());
+    }
+}

--- a/harmonia-store-gc/src/config.rs
+++ b/harmonia-store-gc/src/config.rs
@@ -1,0 +1,76 @@
+// SPDX-FileCopyrightText: 2025 Jörg Thalheim
+// SPDX-License-Identifier: MIT
+
+//! Read resolved nix.conf settings via `nix config show`. Reusing Nix's
+//! own config resolution avoids reimplementing the multi-file parser.
+
+use std::process::Command;
+
+use tracing::warn;
+
+/// `nix config show <key>` parsed as a bool. Returns `default` if `nix`
+/// is not in PATH, the key is unknown, or the value is not a bool.
+///
+/// ```no_run
+/// use harmonia_store_gc::config::bool_setting;
+///
+/// // Falls back to the default when the setting does not exist.
+/// assert!(bool_setting("no-such-setting", true));
+/// ```
+pub fn bool_setting(key: &str, default: bool) -> bool {
+    // `nix config show` is gated on nix-command. Pass the flag so this
+    // works without it in nix.conf.
+    let out = Command::new("nix")
+        .args([
+            "--extra-experimental-features",
+            "nix-command",
+            "config",
+            "show",
+            key,
+        ])
+        .output();
+    let out = match out {
+        Ok(o) if o.status.success() => o.stdout,
+        // Don't fall back silently: a user who set e.g. keep-outputs=true
+        // in nix.conf should learn why it is being ignored.
+        Ok(o) => {
+            warn!(
+                "`nix config show {key}` failed ({}). Using default {default}",
+                o.status
+            );
+            return default;
+        }
+        Err(e) => {
+            warn!("cannot run `nix config show {key}`: {e}. Using default {default}");
+            return default;
+        }
+    };
+    parse_bool(&out).unwrap_or(default)
+}
+
+fn parse_bool(s: &[u8]) -> Option<bool> {
+    match std::str::from_utf8(s).ok()?.trim() {
+        "true" => Some(true),
+        "false" => Some(false),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse() {
+        assert_eq!(parse_bool(b"true\n"), Some(true));
+        assert_eq!(parse_bool(b"false\n"), Some(false));
+        assert_eq!(parse_bool(b"42\n"), None);
+        assert_eq!(parse_bool(b""), None);
+    }
+
+    #[test]
+    fn unknown_key_falls_back_to_default() {
+        assert!(bool_setting("this-setting-does-not-exist", true));
+        assert!(!bool_setting("this-setting-does-not-exist", false));
+    }
+}

--- a/harmonia-store-gc/src/error.rs
+++ b/harmonia-store-gc/src/error.rs
@@ -1,0 +1,142 @@
+// SPDX-FileCopyrightText: 2025 Jörg Thalheim
+// SPDX-License-Identifier: MIT
+
+//! Error types for store garbage collection.
+
+use std::path::PathBuf;
+
+use thiserror::Error;
+
+/// Result type for store garbage collection.
+pub type Result<T> = std::result::Result<T, Error>;
+
+/// Errors that can occur during garbage collection.
+#[derive(Debug, Error)]
+pub enum Error {
+    /// Store database operation failed
+    #[error(transparent)]
+    Db(#[from] harmonia_store_db::Error),
+
+    /// Store directory path is not valid UTF-8
+    #[error(transparent)]
+    InvalidStoreDir(#[from] harmonia_store_path::StoreDirError),
+
+    /// The configured store dir matches nothing in the database.
+    /// Proceeding would make every path look dead and wipe the store.
+    #[error(
+        "store dir {store_dir} does not match any path in the Nix database \
+         (e.g. {example}), refusing to collect garbage"
+    )]
+    StoreDirMismatch { store_dir: PathBuf, example: String },
+
+    /// Opening or acquiring the exclusive `gc.lock` failed. This is the
+    /// lock Nix and this crate use to serialize garbage collections
+    /// against each other and against builders registering roots.
+    #[error("GC lock {path}: {source}")]
+    GcLock {
+        path: PathBuf,
+        source: std::io::Error,
+    },
+
+    /// Querying mount information for the store failed
+    #[error("getting mount info for {path}: {source}")]
+    MountInfo { path: PathBuf, source: nix::Error },
+
+    /// Remounting the store read-write failed
+    #[error("remounting {path} writable: {source}")]
+    Remount { path: PathBuf, source: nix::Error },
+
+    /// Scanning a GC roots directory failed. Skipping it could hide
+    /// live roots and delete paths that are still in use.
+    #[error("scanning roots in {dir}: {source}")]
+    ScanRoots {
+        dir: PathBuf,
+        #[source]
+        source: Box<Error>,
+    },
+
+    /// Reading a directory failed
+    #[error("reading directory {path}: {source}")]
+    ReadDir {
+        path: PathBuf,
+        source: std::io::Error,
+    },
+
+    /// stat() on a path failed
+    #[error("stat {path}: {source}")]
+    Stat {
+        path: PathBuf,
+        source: std::io::Error,
+    },
+
+    /// readlink() on a path failed
+    #[error("readlink {path}: {source}")]
+    ReadLink {
+        path: PathBuf,
+        source: std::io::Error,
+    },
+
+    /// Opening or reading a temp roots file failed
+    #[error("temp roots file {path}: {source}")]
+    TempRootFile {
+        path: PathBuf,
+        source: std::io::Error,
+    },
+
+    /// Writing to this process's own temp roots file failed
+    #[error("writing temp root: {source}")]
+    TempRootWrite { source: std::io::Error },
+
+    /// Connecting or talking to a running GC's socket failed
+    #[error("gc-socket {path}: {source}")]
+    GcSocketClient {
+        path: PathBuf,
+        source: std::io::Error,
+    },
+
+    /// Creating the gc-socket directory or socket failed
+    #[error("serving gc-socket at {path}: {source}")]
+    GcSocketServe {
+        path: PathBuf,
+        source: std::io::Error,
+    },
+
+    /// Spawning a GC worker thread failed
+    #[error("spawning {name} thread: {source}")]
+    SpawnThread {
+        name: &'static str,
+        source: std::io::Error,
+    },
+
+    /// A gc-socket client sent an over-long line. Store paths are short,
+    /// and the socket is world-writable like Nix's, so an unbounded line
+    /// could only be an attempt to exhaust the collector's memory.
+    #[error("gc-socket: line too long")]
+    LineTooLong,
+
+    /// Reading from or writing to a gc-socket client failed
+    #[error("gc-socket client: {source}")]
+    ClientIo { source: std::io::Error },
+
+    /// Opening or acquiring a profile lock failed
+    #[error("profile lock {path}: {source}")]
+    ProfileLock {
+        path: PathBuf,
+        source: std::io::Error,
+    },
+
+    /// A time spec like "30d" could not be parsed
+    #[error("invalid time spec '{spec}': {reason}")]
+    TimeSpec { spec: String, reason: String },
+
+    /// Writing the dry-run report to stdout failed
+    #[error("writing report: {source}")]
+    Report { source: std::io::Error },
+
+    /// Deleting a store path failed
+    #[error("removing {path}: {source}")]
+    Remove {
+        path: PathBuf,
+        source: std::io::Error,
+    },
+}

--- a/harmonia-store-gc/src/gc.rs
+++ b/harmonia-store-gc/src/gc.rs
@@ -1,0 +1,725 @@
+// SPDX-FileCopyrightText: 2025 Jörg Thalheim
+// SPDX-License-Identifier: MIT
+
+//! Garbage collection: liveness computation and store path deletion.
+
+use std::fs;
+use std::os::unix::fs::MetadataExt;
+use std::path::Path;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use harmonia_store_db::{BasenameIndex, NodeIdx, StoreGraph};
+use nix::fcntl::{Flock, FlockArg};
+use rayon::prelude::*;
+use tracing::{debug, info, warn};
+
+use crate::error::{Error, Result};
+use crate::gc_socket::{GcSocketServer, LiveSet};
+use crate::roots::{find_roots, find_temp_roots};
+use crate::store::GcStore;
+use crate::{format_size, make_store_writable};
+
+/// Delete a store path from disk, returning bytes freed.
+///
+/// Store paths are read-only on disk, so directories are made writable
+/// before removal, mirroring Nix's `deletePath`.
+fn delete_store_path(real_path: &Path) -> Result<u64> {
+    use std::os::unix::fs::PermissionsExt;
+
+    let meta = match fs::symlink_metadata(real_path) {
+        Ok(m) => m,
+        // Already gone: another process won the race.
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(0),
+        Err(source) => {
+            return Err(Error::Stat {
+                path: real_path.to_owned(),
+                source,
+            });
+        }
+    };
+
+    if !meta.file_type().is_dir() {
+        let bytes = meta.blocks() * 512;
+        fs::remove_file(real_path).map_err(|source| Error::Remove {
+            path: real_path.to_owned(),
+            source,
+        })?;
+        return Ok(bytes);
+    }
+
+    let mut bytes_freed = 0u64;
+    // chmod and retry on permission errors instead of aborting the GC.
+    for entry in walkdir::WalkDir::new(real_path).contents_first(true) {
+        let entry = match entry {
+            Ok(e) => e,
+            Err(e) => {
+                if let Some(parent) = e.path().and_then(Path::parent) {
+                    let _ = fs::set_permissions(parent, fs::Permissions::from_mode(0o755));
+                }
+                continue;
+            }
+        };
+        let p = entry.path();
+        if let Ok(m) = entry.metadata() {
+            bytes_freed += m.blocks() * 512;
+        }
+        if entry.file_type().is_dir() {
+            if fs::remove_dir(p).is_err() {
+                // rmdir needs write permission on the parent, not on p.
+                if let Some(parent) = p.parent() {
+                    let _ = fs::set_permissions(parent, fs::Permissions::from_mode(0o755));
+                }
+                let _ = fs::remove_dir(p);
+            }
+        } else if fs::remove_file(p).is_err() {
+            if let Some(parent) = p.parent() {
+                let _ = fs::set_permissions(parent, fs::Permissions::from_mode(0o755));
+            }
+            let _ = fs::remove_file(p);
+        }
+    }
+
+    Ok(bytes_freed)
+}
+
+/// Lock a `tmp-*` build dir before deleting. `None` means a builder
+/// still holds it. The caller keeps the fd through deletion to avoid a
+/// TOCTOU race.
+fn try_lock_dir(path: &Path) -> Option<Flock<fs::File>> {
+    use std::os::unix::fs::OpenOptionsExt;
+    // O_NONBLOCK: a stray FIFO named tmp-* must not block open() forever
+    // while we hold the exclusive gc.lock.
+    let f = match fs::OpenOptions::new()
+        .read(true)
+        .custom_flags(nix::libc::O_NONBLOCK)
+        .open(path)
+    {
+        Ok(f) => f,
+        Err(e) => {
+            if e.kind() != std::io::ErrorKind::NotFound {
+                warn!("cannot open {} for locking: {e}", path.display());
+            }
+            return None;
+        }
+    };
+    Flock::lock(f, FlockArg::LockExclusiveNonblock).ok()
+}
+
+/// Take the same lock Nix takes. Builders hold it shared while
+/// registering temp roots. We take it exclusive so the root set cannot
+/// change under us.
+fn acquire_gc_lock(state_dir: &Path) -> Result<Flock<fs::File>> {
+    use std::os::unix::fs::OpenOptionsExt;
+    let lock_path = state_dir.join("gc.lock");
+    let lock_err = |source| Error::GcLock {
+        path: lock_path.clone(),
+        source,
+    };
+    // 0600 like Nix: a world-readable lock would let any local user
+    // flock it and block GC and builders indefinitely.
+    let f = fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .mode(0o600)
+        .open(&lock_path)
+        .map_err(lock_err)?;
+
+    match Flock::lock(f, FlockArg::LockExclusiveNonblock) {
+        Ok(lock) => Ok(lock),
+        Err((f, _)) => {
+            info!("waiting for the big garbage collector lock...");
+            Flock::lock(f, FlockArg::LockExclusive).map_err(|(_, e)| lock_err(e.into()))
+        }
+    }
+}
+
+/// Tuning knobs for one garbage collection run.
+#[derive(Default)]
+pub struct GcOptions {
+    /// Report what would be deleted without touching anything.
+    pub dry_run: bool,
+    /// Stop after freeing this many bytes.
+    pub max_freed: Option<u64>,
+    /// Keep paths registered at or after this Unix timestamp.
+    pub keep_recent_after: Option<i64>,
+    /// Skip the post-GC VACUUM. For busy builders, where concurrent
+    /// readers keep the VACUUM's database-sized WAL from being truncated.
+    pub no_vacuum: bool,
+    /// Max dead paths invalidated per database transaction. Smaller keeps
+    /// the WAL lower, larger means fewer checkpoints. `None` uses the
+    /// default.
+    pub chunk_size: Option<usize>,
+    /// Extra directories scanned for GC roots. Nix only scans its fixed
+    /// state dirs, so roots outside them would go uncounted.
+    pub extra_gc_roots_dirs: Vec<std::path::PathBuf>,
+}
+
+/// Collect garbage: find roots, compute the alive closure, delete dead
+/// paths. Returns `(bytes_freed, paths_deleted)`.
+///
+/// Interoperates with running builds throughout: the exclusive `gc.lock`
+/// is held, temp roots are honored, and new roots arriving over the
+/// gc-socket are protected before their closure is touched.
+pub fn collect_garbage(store: &GcStore, opts: &GcOptions) -> Result<(u64, usize)> {
+    let dry_run = opts.dry_run;
+    let max_freed = opts.max_freed;
+
+    // Free the reserved space file first. On a 100% full disk the SQLite
+    // invalidation needs room to write before anything was unlinked.
+    if !dry_run {
+        let reserved = store.state_dir.join("db/reserved");
+        match fs::remove_file(&reserved) {
+            Ok(()) => {}
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+            Err(e) => warn!("cannot remove {}: {e}", reserved.display()),
+        }
+    }
+
+    let _gc_lock = acquire_gc_lock(&store.state_dir)?;
+
+    if !dry_run {
+        make_store_writable(&store.real_store_dir)?;
+    }
+
+    // Serve the gc-socket immediately after taking the lock, like Nix:
+    // builders that lost the shared-lock race retry connecting every
+    // 100ms, so the socket must exist before the potentially long graph
+    // load, and during dry runs, which hold the lock too.
+    //
+    // Phase 1: no graph yet, so every received root is acked instantly
+    // and recorded by basename. That is sound because nothing can be
+    // deleted before the graph exists. The roots are replayed below.
+    let store_prefix = format!("{}/", store.store_dir.to_str());
+    let early_live = Arc::new(LiveSet::new(0));
+    // A dry run on a read-only state dir can still report. Without the
+    // socket no builder can run anyway (they need temproots).
+    let start_socket = |live: Arc<LiveSet>, graph: Arc<StoreGraph>| -> Result<_> {
+        match GcSocketServer::start(&store.state_dir, live, graph) {
+            Ok(s) => Ok(Some(s)),
+            Err(e) if dry_run => {
+                warn!("cannot serve gc-socket: {e}");
+                Ok(None)
+            }
+            Err(e) => Err(e),
+        }
+    };
+    let early_socket = start_socket(
+        Arc::clone(&early_live),
+        Arc::new(StoreGraph::empty(store_prefix.clone())),
+    )?;
+
+    // Test sync point: block until the named fifo is readable, so tests
+    // can deterministically exercise the early-socket window.
+    if let Ok(p) = std::env::var("_HARMONIA_GC_TEST_SYNC_EARLY") {
+        let _ = fs::read(&p);
+    }
+
+    info!("loading store graph...");
+    let graph = Arc::new(
+        store
+            .db
+            .load_graph(&store.store_dir, &store.graph_options)?,
+    );
+    info!("{} total valid paths", graph.len());
+
+    // Phase 2: swap to the real server. Builders whose connection drops
+    // during the swap reconnect (Nix's addTempRoot restart loop).
+    drop(early_socket);
+    let early_roots = early_live.protected_unknown_snapshot();
+    let live = Arc::new(LiveSet::new(graph.len()));
+    let _gc_socket = start_socket(Arc::clone(&live), Arc::clone(&graph))?;
+
+    let bidx = BasenameIndex::new(&graph);
+
+    // Replay phase-1 roots: known paths become ordinary GC roots (their
+    // closure stays alive), unknown basenames stay protected.
+    let mut early_root_nodes: Vec<NodeIdx> = Vec::new();
+    for b in &early_roots {
+        match bidx.get_basename(b) {
+            Some(n) => early_root_nodes.push(n),
+            None => live.protect_unknown_basename(b),
+        }
+    }
+
+    // A --store-dir that does not match the DB contents would make every
+    // root lookup miss and every DB path look dead, wiping the store.
+    if !graph.is_empty() && bidx.is_empty() {
+        let first = graph.nodes().next().expect("graph is non-empty");
+        return Err(Error::StoreDirMismatch {
+            store_dir: store.store_dir.to_path().to_owned(),
+            example: graph.path(first).to_owned(),
+        });
+    }
+
+    info!("finding garbage collector roots...");
+    let mut roots = find_roots(
+        &store.state_dir,
+        store.store_dir.to_path(),
+        &opts.extra_gc_roots_dirs,
+        &bidx,
+    )?;
+    roots.extend(early_root_nodes);
+
+    // Add temp roots. Some may reference paths registered after our graph
+    // snapshot (a builder can register paths while we hold gc.lock as
+    // long as it wrote its temp root before we acquired it). Track those
+    // by basename so the unknown-on-disk scan won't delete them.
+    let mut temp_root_basenames: crate::HashSet<String> = crate::HashSet::default();
+    // Nix matches temp roots by hash part so that sibling files of an
+    // active build (`<path>.lock`, `<path>.chroot`, `<path>.check`) are
+    // protected too.
+    let mut temp_root_hashes: crate::HashSet<String> = crate::HashSet::default();
+    for tr in find_temp_roots(&store.state_dir)? {
+        if let Some(b) = tr.strip_prefix(&store_prefix) {
+            if b.len() > 32 && b.as_bytes()[32] == b'-' {
+                temp_root_hashes.insert(b[..32].to_owned());
+            }
+            if bidx.get_basename(b).is_none() {
+                temp_root_basenames.insert(b.to_owned());
+            }
+        }
+        if let Some(n) = bidx.get(&tr) {
+            roots.push(n);
+        }
+    }
+    // --keep-recent: treat recently registered paths as roots.
+    if let Some(cutoff) = opts.keep_recent_after {
+        let n_before = roots.len();
+        roots.extend(
+            graph
+                .nodes()
+                .filter(|&n| graph.registration_time(n) >= cutoff),
+        );
+        info!("{} recent paths kept", roots.len() - n_before);
+    }
+
+    roots.sort_unstable();
+    roots.dedup();
+    info!("found {} roots", roots.len());
+
+    info!("computing alive closure...");
+    let alive = graph.compute_closure(&roots);
+    let n_alive = alive.len();
+    info!("{} alive paths", n_alive);
+    info!("{} dead paths", graph.len() - n_alive);
+
+    // Find entries on disk that are not in the DB at all. Raw OsString
+    // names: a non-UTF-8 entry cannot be in the DB (it stores text), but
+    // it is still garbage that must be unlinked by its real bytes.
+    let mut unknown_on_disk: Vec<std::ffi::OsString> = Vec::new();
+    if let Ok(entries) = fs::read_dir(&store.real_store_dir) {
+        for entry in entries.flatten() {
+            let raw = entry.file_name();
+            if let Some(name) = raw.to_str() {
+                if name == ".links" {
+                    continue;
+                }
+                // An entry belongs to an active build if its first 32
+                // chars match a temp root's hash part.
+                let hash_part_active = name.len() >= 32
+                    && name.is_char_boundary(32)
+                    && temp_root_hashes.contains(&name[..32]);
+                if bidx.get_basename(name).is_some()
+                    || temp_root_basenames.contains(name)
+                    || hash_part_active
+                {
+                    continue;
+                }
+            }
+            unknown_on_disk.push(raw);
+        }
+    }
+    if !unknown_on_disk.is_empty() {
+        info!("{} unknown paths on disk not in DB", unknown_on_disk.len());
+    }
+
+    let dead_nodes: Vec<NodeIdx> = graph.nodes().filter(|&n| !alive.contains(n)).collect();
+
+    let max = max_freed.unwrap_or(u64::MAX);
+
+    if dry_run {
+        use std::io::Write;
+        let report_err = |source| Error::Report { source };
+        let mut stdout = std::io::BufWriter::new(std::io::stdout().lock());
+        let mut estimated = 0u64;
+        let mut count = 0usize;
+        // Roots can arrive over the gc-socket while we run. A real GC
+        // would honor them, so the report must too.
+        let protected = live.protected_snapshot();
+        let protected_unknown = live.protected_unknown_snapshot();
+        for &node in &dead_nodes {
+            if estimated >= max {
+                break;
+            }
+            if protected[node.index()] {
+                continue;
+            }
+            writeln!(stdout, "{}", graph.path(node)).map_err(report_err)?;
+            estimated += graph.nar_size(node);
+            count += 1;
+        }
+        for name in &unknown_on_disk {
+            if name.to_str().is_some_and(|n| protected_unknown.contains(n)) {
+                continue;
+            }
+            writeln!(stdout, "{store_prefix}{}", name.display()).map_err(report_err)?;
+            count += 1;
+        }
+        return Ok((estimated, count));
+    }
+
+    info!("deleting garbage...");
+
+    // Test sync point, so tests exercise the protect() path
+    // deterministically rather than racing the delete loop.
+    if let Ok(p) = std::env::var("_HARMONIA_GC_TEST_SYNC") {
+        let _ = fs::read(&p);
+    }
+
+    // Bulk-invalidate, then delete from disk in parallel. Safe to crash
+    // mid-delete: leftover dirs are picked up as unknown-on-disk next run.
+    let real_store_dir = store.real_store_dir.clone();
+    let bytes_freed = AtomicU64::new(0);
+    let paths_deleted = AtomicU64::new(0);
+
+    // Referrer-first deletion order (Kahn over the dead subgraph), so
+    // every prefix is safe to commit: still-valid paths never reference
+    // an already-deleted one. in_degree counts a dead node's dead
+    // referrers.
+    let dead_ref = |node: NodeIdx, m: NodeIdx| m != node && !alive.contains(m);
+    let mut in_degree = vec![0u32; graph.len()];
+    for &node in &dead_nodes {
+        for m in graph.refs(node).filter(|&m| dead_ref(node, m)) {
+            in_degree[m.index()] += 1;
+        }
+    }
+    let mut order: Vec<NodeIdx> = dead_nodes
+        .iter()
+        .copied()
+        .filter(|&m| in_degree[m.index()] == 0)
+        .collect();
+    let mut head = 0;
+    while head < order.len() {
+        let node = order[head];
+        head += 1;
+        for m in graph.refs(node).filter(|&m| dead_ref(node, m)) {
+            in_degree[m.index()] -= 1;
+            if in_degree[m.index()] == 0 {
+                order.push(m);
+            }
+        }
+    }
+    // Cyclic nodes never reach in-degree 0. They are mutually dependent,
+    // so they share one trailing chunk that is never split.
+    let acyclic_len = order.len();
+    if order.len() < dead_nodes.len() {
+        order.extend(
+            dead_nodes
+                .iter()
+                .copied()
+                .filter(|&m| in_degree[m.index()] != 0),
+        );
+    }
+
+    // Commit in bounded chunks, truncating the WAL after each, so disk
+    // use stays bounded and space is reclaimed incrementally.
+    let max_chunk = opts.chunk_size.unwrap_or(65_536).max(1);
+    let mut cursor = 0usize;
+    while cursor < order.len() {
+        let freed_so_far = bytes_freed.load(Ordering::Relaxed);
+        if freed_so_far >= max {
+            info!("deleted more than {max} bytes, stopping");
+            break;
+        }
+        let remaining = max - freed_so_far;
+        let mut chunk: Vec<NodeIdx> = Vec::new();
+        // narSize over-reports hard-linked paths, so estimated only
+        // bounds the chunk. Actual freed bytes are re-checked above.
+        let mut estimated = 0u64;
+        // Take the cyclic tail (from acyclic_len on) whole and unsplit.
+        let take_all = cursor >= acyclic_len;
+        while cursor < order.len()
+            && (take_all
+                || (cursor < acyclic_len && estimated < remaining && chunk.len() < max_chunk))
+        {
+            let node = order[cursor];
+            cursor += 1;
+            estimated = estimated.saturating_add(graph.nar_size(node));
+            chunk.push(node);
+        }
+        if chunk.is_empty() {
+            break;
+        }
+        // Claim atomically with the protection check, *before*
+        // invalidating DB rows. A protect() arriving for a claimed node
+        // blocks until the unlink finished, so a builder is never acked
+        // while the row deletion is in flight.
+        let (mut claimed, skipped) = live.claim_nodes(&chunk);
+        // protect() marks closures atomically, but the claim is per node:
+        // it may have kept a reference whose referrer got protected a
+        // moment earlier. Drop the closures of skipped paths.
+        if !skipped.is_empty() {
+            let keep_out = graph.compute_closure(&skipped);
+            claimed.retain(|&n| {
+                if keep_out.contains(n) {
+                    live.end_delete_node(n);
+                    false
+                } else {
+                    true
+                }
+            });
+        }
+        // Invalidate rows before unlinking: builders trust isValidPath(),
+        // so a path must never look valid after its disk entry is gone.
+        store
+            .db
+            .invalidate_ids(claimed.iter().map(|&n| graph.db_id(n)))?;
+        claimed.par_iter().for_each(|&node| {
+            let path = graph.path(node);
+            let basename = path.strip_prefix(&store_prefix).unwrap_or(path);
+            let real_path = real_store_dir.join(basename);
+            debug!("deleting '{path}'");
+            match delete_store_path(&real_path) {
+                Ok(freed) => {
+                    bytes_freed.fetch_add(freed, Ordering::Relaxed);
+                }
+                // The row is already invalidated. The leftover is picked
+                // up as unknown-on-disk by the next run.
+                Err(e) => warn!("failed to delete {}: {e}", real_path.display()),
+            }
+            live.end_delete_node(node);
+        });
+        let done =
+            paths_deleted.fetch_add(claimed.len() as u64, Ordering::Relaxed) + claimed.len() as u64;
+        debug!(
+            "deleted {done}/{} dead paths, {} freed",
+            order.len(),
+            format_size(bytes_freed.load(Ordering::Relaxed)),
+        );
+    }
+
+    // Unknown-on-disk paths, also in parallel. tmp-* dirs hold flock
+    // through deletion to avoid a TOCTOU race with a builder.
+    if bytes_freed.load(Ordering::Relaxed) < max {
+        // A builder may have registered a scanned path after our graph
+        // snapshot and then exited, leaving its temp root file stale.
+        // Unlinking such a path would orphan its ValidPaths row, so
+        // re-check the DB first. Once is enough: any registration from
+        // here on goes through the gc-socket and protected_unknown.
+        let mut unknown_on_disk = unknown_on_disk;
+        unknown_on_disk.retain(|name| {
+            // A non-UTF-8 name cannot be a DB path (the DB stores text).
+            let Some(name) = name.to_str() else {
+                return true;
+            };
+            match is_valid_path(store, &format!("{store_prefix}{name}")) {
+                Ok(valid) => !valid,
+                Err(e) => {
+                    warn!("skipping {store_prefix}{name}: validity check failed: {e}");
+                    false
+                }
+            }
+        });
+        unknown_on_disk.par_iter().for_each(|raw| {
+            // The liveset key is textual. Non-UTF-8 names cannot collide
+            // with anything a builder protects.
+            let name = raw.to_string_lossy();
+            if !live.try_begin_delete_unknown(&name) {
+                return;
+            }
+            let real_path = real_store_dir.join(raw);
+            // Only a directory can be a build temp dir a builder still
+            // holds. A stray tmp-* FIFO would fail flock() on macOS and
+            // be kept forever.
+            let is_locked_candidate = name.starts_with("tmp-")
+                && real_path
+                    .symlink_metadata()
+                    .map(|m| m.is_dir())
+                    .unwrap_or(false);
+            let _tmp_lock = if is_locked_candidate {
+                match try_lock_dir(&real_path) {
+                    Some(f) => Some(f),
+                    None => {
+                        debug!("skipping locked tempdir {}", real_path.display());
+                        live.end_delete_unknown(&name);
+                        return;
+                    }
+                }
+            } else {
+                None
+            };
+            debug!("deleting '{store_prefix}{name}'");
+            match delete_store_path(&real_path) {
+                Ok(freed) => {
+                    bytes_freed.fetch_add(freed, Ordering::Relaxed);
+                    paths_deleted.fetch_add(1, Ordering::Relaxed);
+                }
+                Err(e) => warn!("failed to delete {}: {e}", real_path.display()),
+            }
+            live.end_delete_unknown(&name);
+        });
+    }
+
+    let bytes_freed = bytes_freed.into_inner();
+    let paths_deleted = paths_deleted.into_inner() as usize;
+
+    let bytes_freed = bytes_freed + clean_links(&store.links_dir)?;
+
+    // Reclaim db space freed by the row deletions, still under the
+    // exclusive gc.lock. Best effort: a failed vacuum leaves the db
+    // valid.
+    if !opts.no_vacuum
+        && let Err(e) = store.db.maybe_vacuum()
+    {
+        warn!("vacuuming database failed: {e}");
+    }
+
+    Ok((bytes_freed, paths_deleted))
+}
+
+/// Check a raw path string against ValidPaths. Unknown-on-disk names are
+/// arbitrary bytes, so this cannot go through the typed StorePath API.
+fn is_valid_path(store: &GcStore, path: &str) -> Result<bool> {
+    // Cached: called once per unknown-on-disk entry, which can be many
+    // thousands after an interrupted nixos-install or nix copy.
+    let mut stmt = store
+        .db
+        .connection()
+        .prepare_cached("SELECT COUNT(*) FROM ValidPaths WHERE path = ?")
+        .map_err(harmonia_store_db::Error::from)?;
+    let n: i64 = stmt
+        .query_row([path], |r| r.get(0))
+        .map_err(harmonia_store_db::Error::from)?;
+    Ok(n > 0)
+}
+
+/// Remove hard links with link count 1 from the `.links` directory,
+/// returning bytes freed.
+///
+/// The dir can contain millions of entries. stat + unlink per entry is
+/// disk-bound, so process in parallel, and stream the entries instead of
+/// collecting them: a Vec of millions of DirEntries costs gigabytes.
+fn clean_links(links_dir: &Path) -> Result<u64> {
+    info!("deleting unused links...");
+    let entries = match fs::read_dir(links_dir) {
+        Ok(e) => e,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(0),
+        Err(e) => {
+            warn!("cannot read {}: {e}", links_dir.display());
+            return Ok(0);
+        }
+    };
+
+    // A link entry has one reference from .links plus one per store file.
+    // N references total mean hard linking saves (N-2)*size compared to
+    // independent copies.
+    let saved_bytes = AtomicU64::new(0);
+    let freed_bytes = AtomicU64::new(0);
+
+    entries.flatten().par_bridge().for_each(|entry| {
+        let path = entry.path();
+        let Ok(meta) = fs::symlink_metadata(&path) else {
+            return;
+        };
+        if meta.nlink() != 1 {
+            saved_bytes.fetch_add(
+                meta.nlink().saturating_sub(2) * meta.size(),
+                Ordering::Relaxed,
+            );
+            return;
+        }
+        if fs::remove_file(&path).is_ok() {
+            freed_bytes.fetch_add(meta.blocks() * 512, Ordering::Relaxed);
+        }
+    });
+
+    let saving = saved_bytes.into_inner();
+    if saving > 0 {
+        info!("hard linking is currently saving {}", format_size(saving));
+    }
+
+    Ok(freed_bytes.into_inner())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::os::unix::fs::PermissionsExt;
+
+    #[test]
+    fn delete_store_path_missing_is_zero() {
+        let tmp = tempfile::tempdir().unwrap();
+        assert_eq!(delete_store_path(&tmp.path().join("gone")).unwrap(), 0);
+    }
+
+    #[test]
+    fn delete_store_path_other_stat_errors_propagate() {
+        let tmp = tempfile::tempdir().unwrap();
+        let f = tmp.path().join("file");
+        fs::write(&f, b"x").unwrap();
+        // ENOTDIR, not ENOENT: must not be treated as "already gone".
+        assert!(delete_store_path(&f.join("sub")).is_err());
+    }
+
+    #[test]
+    fn delete_store_path_file_reports_disk_blocks() {
+        let tmp = tempfile::tempdir().unwrap();
+        let f = tmp.path().join("file");
+        fs::write(&f, vec![1u8; 5000]).unwrap();
+        let expected = fs::symlink_metadata(&f).unwrap().blocks() * 512;
+        assert!(expected > 0);
+        assert_eq!(delete_store_path(&f).unwrap(), expected);
+        assert!(!f.exists());
+    }
+
+    #[test]
+    fn delete_store_path_removes_readonly_tree() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("pkg");
+        fs::create_dir_all(dir.join("sub")).unwrap();
+        fs::write(dir.join("sub/file"), vec![1u8; 5000]).unwrap();
+        let mut expected = 0;
+        for e in walkdir::WalkDir::new(&dir) {
+            expected += e.unwrap().metadata().unwrap().blocks() * 512;
+        }
+        // Store paths are read-only on disk.
+        fs::set_permissions(dir.join("sub/file"), fs::Permissions::from_mode(0o444)).unwrap();
+        fs::set_permissions(dir.join("sub"), fs::Permissions::from_mode(0o555)).unwrap();
+        fs::set_permissions(&dir, fs::Permissions::from_mode(0o555)).unwrap();
+
+        assert_eq!(delete_store_path(&dir).unwrap(), expected);
+        assert!(!dir.exists());
+    }
+
+    #[test]
+    fn try_lock_dir_none_while_held() {
+        let tmp = tempfile::tempdir().unwrap();
+        let lock = try_lock_dir(tmp.path()).expect("unheld dir is lockable");
+        assert!(try_lock_dir(tmp.path()).is_none(), "held dir must not lock");
+        drop(lock);
+    }
+
+    #[test]
+    fn clean_links_removes_only_unreferenced() {
+        let tmp = tempfile::tempdir().unwrap();
+        let links = tmp.path().join(".links");
+        fs::create_dir_all(&links).unwrap();
+        let dead = links.join("dead");
+        fs::write(&dead, b"unreferenced").unwrap();
+        let shared = links.join("shared");
+        fs::write(&shared, b"referenced").unwrap();
+        fs::hard_link(&shared, tmp.path().join("user")).unwrap();
+
+        let dead_blocks = fs::symlink_metadata(&dead).unwrap().blocks() * 512;
+        let freed = clean_links(&links).unwrap();
+
+        assert!(!dead.exists());
+        assert!(shared.exists());
+        assert_eq!(freed, dead_blocks, "freed bytes of removed links");
+        // A missing .links dir is not an error.
+        assert_eq!(clean_links(&tmp.path().join("nope")).unwrap(), 0);
+    }
+}

--- a/harmonia-store-gc/src/gc_socket.rs
+++ b/harmonia-store-gc/src/gc_socket.rs
@@ -1,0 +1,623 @@
+// SPDX-FileCopyrightText: 2025 Jörg Thalheim
+// SPDX-License-Identifier: MIT
+
+//! GC roots socket, protocol-compatible with `nix-store --gc`.
+//!
+//! Builders that fail to acquire a shared `gc.lock` connect to
+//! `state/gc-socket/socket`, send newline-terminated store paths, and
+//! wait for a single `'1'` ack per line. We mark the closure protected
+//! before acking so the builder cannot recreate a path we are still
+//! unlinking.
+
+use std::fs;
+use std::io::{BufRead, BufReader, ErrorKind, Read, Write};
+use std::os::unix::fs::PermissionsExt;
+use std::os::unix::io::AsFd;
+use std::os::unix::net::{UnixListener, UnixStream};
+use std::path::{Path, PathBuf};
+use std::sync::{
+    Arc, Condvar, Mutex,
+    atomic::{AtomicBool, Ordering},
+};
+use std::thread::JoinHandle;
+
+use harmonia_store_db::{NodeIdx, StoreGraph};
+use nix::poll::{PollFd, PollFlags, PollTimeout, poll};
+use tracing::{debug, warn};
+
+use crate::error::{Error, Result};
+use crate::{HashMap, HashSet};
+
+/// Liveness state shared between the deletion loop and the socket server.
+///
+/// Roots from clients can only flip dead -> protected. `pending` tracks
+/// in-flight unlinks so `protect()` waits for them before acking.
+pub struct LiveSet {
+    inner: Mutex<LiveInner>,
+    cond: Condvar,
+}
+
+struct LiveInner {
+    /// GC teardown in progress. protect() must stop waiting.
+    cancelled: bool,
+    /// Per-node "do not delete" flag.
+    protected: Vec<bool>,
+    /// Protected basenames not (yet) in the graph, e.g. paths registered
+    /// after our database snapshot.
+    protected_unknown: HashSet<String>,
+    /// Graph nodes currently being deleted.
+    pending_nodes: HashSet<NodeIdx>,
+    /// Unknown-on-disk basenames currently being deleted.
+    pending_unknown: HashSet<String>,
+}
+
+impl LiveSet {
+    pub fn new(n_nodes: usize) -> Self {
+        LiveSet {
+            inner: Mutex::new(LiveInner {
+                cancelled: false,
+                protected: vec![false; n_nodes],
+                protected_unknown: HashSet::default(),
+                pending_nodes: HashSet::default(),
+                pending_unknown: HashSet::default(),
+            }),
+            cond: Condvar::new(),
+        }
+    }
+
+    /// Atomically check that `node` is unprotected and mark it pending.
+    /// Returns `false` (skip deletion) if the node was protected
+    /// meanwhile.
+    pub fn try_begin_delete_node(&self, node: NodeIdx) -> bool {
+        let mut g = self.inner.lock().unwrap();
+        if g.protected[node.index()] {
+            return false;
+        }
+        g.pending_nodes.insert(node);
+        true
+    }
+
+    pub fn end_delete_node(&self, node: NodeIdx) {
+        let mut g = self.inner.lock().unwrap();
+        g.pending_nodes.remove(&node);
+        drop(g);
+        self.cond.notify_all();
+    }
+
+    /// Snapshot of per-node protection flags (dry-run reporting).
+    pub fn protected_snapshot(&self) -> Vec<bool> {
+        self.inner.lock().unwrap().protected.clone()
+    }
+
+    /// Snapshot of protected basenames that are not in the graph.
+    pub fn protected_unknown_snapshot(&self) -> HashSet<String> {
+        self.inner.lock().unwrap().protected_unknown.clone()
+    }
+
+    /// Mark a basename outside the graph as protected. Used to carry
+    /// over roots received before the graph was loaded.
+    pub fn protect_unknown_basename(&self, basename: &str) {
+        self.inner
+            .lock()
+            .unwrap()
+            .protected_unknown
+            .insert(basename.to_owned());
+    }
+
+    /// Atomically partition `nodes` into (claimed, skipped). Skipped
+    /// nodes are protected. Claimed ones are marked pending, so a later
+    /// `protect()` blocks until their unlink finished. That is what keeps
+    /// a builder from being acked while the row deletion is in flight.
+    pub fn claim_nodes(&self, nodes: &[NodeIdx]) -> (Vec<NodeIdx>, Vec<NodeIdx>) {
+        let mut g = self.inner.lock().unwrap();
+        let mut claimed = Vec::with_capacity(nodes.len());
+        let mut skipped = Vec::new();
+        for &n in nodes {
+            if g.protected[n.index()] {
+                skipped.push(n);
+            } else {
+                g.pending_nodes.insert(n);
+                claimed.push(n);
+            }
+        }
+        (claimed, skipped)
+    }
+
+    /// Same as [`LiveSet::try_begin_delete_node`] for paths not in the
+    /// graph.
+    pub fn try_begin_delete_unknown(&self, basename: &str) -> bool {
+        let mut g = self.inner.lock().unwrap();
+        if g.protected_unknown.contains(basename) {
+            return false;
+        }
+        g.pending_unknown.insert(basename.to_owned());
+        true
+    }
+
+    pub fn end_delete_unknown(&self, basename: &str) {
+        let mut g = self.inner.lock().unwrap();
+        g.pending_unknown.remove(basename);
+        drop(g);
+        self.cond.notify_all();
+    }
+
+    /// Mark the closure of `basename` as protected and wait until none of
+    /// it is still being deleted.
+    fn protect(&self, basename: &str, graph: &StoreGraph, idx: &HashMap<String, NodeIdx>) {
+        let mut g = self.inner.lock().unwrap();
+        // Wait for every pending closure node, including ones an earlier
+        // overlapping protect() already marked. Acking before their
+        // unlinks finish would let the client recreate a path mid-delete.
+        let mut wait_for: Vec<NodeIdx> = Vec::new();
+        if let Some(&root) = idx.get(basename) {
+            let mut stack = vec![root];
+            let mut seen: HashSet<NodeIdx> = HashSet::default();
+            while let Some(n) = stack.pop() {
+                if !seen.insert(n) {
+                    continue;
+                }
+                g.protected[n.index()] = true;
+                if g.pending_nodes.contains(&n) {
+                    wait_for.push(n);
+                }
+                stack.extend(graph.refs(n));
+            }
+        } else {
+            g.protected_unknown.insert(basename.to_owned());
+        }
+
+        let conflict = |g: &LiveInner| {
+            wait_for.iter().any(|n| g.pending_nodes.contains(n))
+                || g.pending_unknown.contains(basename)
+        };
+        while conflict(&g) && !g.cancelled {
+            debug!("synchronising with deletion of {basename}");
+            g = self.cond.wait(g).unwrap();
+        }
+    }
+
+    /// Unblock every waiting protect(). Used on GC teardown, where an
+    /// error path may leave pending nodes that will never finish.
+    fn cancel(&self) {
+        self.inner.lock().unwrap().cancelled = true;
+        self.cond.notify_all();
+    }
+}
+
+/// Client connections and their handler threads, owned by the server.
+type Conns = Arc<Mutex<Vec<(UnixStream, JoinHandle<()>)>>>;
+
+/// Running GC roots socket server.
+///
+/// Dropping it tears down the listener, removes the socket file, and
+/// joins the accept thread and every client handler.
+pub struct GcSocketServer {
+    socket_path: PathBuf,
+    shutdown: Arc<AtomicBool>,
+    handle: Option<JoinHandle<()>>,
+    live: Arc<LiveSet>,
+    /// Live client connections. Drop shuts them down and joins their
+    /// handler threads so no `protect()` is still running afterwards.
+    /// Callers snapshot the LiveSet right after dropping the server.
+    conns: Conns,
+}
+
+impl GcSocketServer {
+    /// Bind `state_dir/gc-socket/socket` and spawn the accept thread.
+    pub fn start(state_dir: &Path, live: Arc<LiveSet>, graph: Arc<StoreGraph>) -> Result<Self> {
+        let dir = state_dir.join("gc-socket");
+        fs::create_dir_all(&dir).map_err(|source| Error::GcSocketServe {
+            path: dir.clone(),
+            source,
+        })?;
+        let socket_path = dir.join("socket");
+        let serve_err = |source| Error::GcSocketServe {
+            path: socket_path.clone(),
+            source,
+        };
+        // A previous GC may have crashed without cleaning up.
+        let _ = fs::remove_file(&socket_path);
+        let listener = UnixListener::bind(&socket_path).map_err(serve_err)?;
+        // Builders may run as a different user. Mirror Nix's 0666.
+        fs::set_permissions(&socket_path, fs::Permissions::from_mode(0o666)).map_err(serve_err)?;
+
+        // Owned map: BasenameIndex borrows from the graph and cannot be
+        // sent across threads alongside an Arc<StoreGraph>.
+        let mut idx: HashMap<String, NodeIdx> = HashMap::default();
+        idx.reserve(graph.len());
+        for node in graph.nodes() {
+            if let Some(b) = graph.path(node).strip_prefix(graph.store_prefix()) {
+                idx.insert(b.to_owned(), node);
+            }
+        }
+        let idx = Arc::new(idx);
+        let store_prefix = graph.store_prefix().to_owned();
+        let live_for_drop = Arc::clone(&live);
+        let shutdown = Arc::new(AtomicBool::new(false));
+        let accept_shutdown = Arc::clone(&shutdown);
+        let conns: Conns = Arc::new(Mutex::new(Vec::new()));
+        let accept_conns = Arc::clone(&conns);
+
+        let handle = std::thread::Builder::new()
+            .name("gc-socket".into())
+            .spawn(move || {
+                accept_loop(
+                    listener,
+                    store_prefix,
+                    live,
+                    graph,
+                    idx,
+                    accept_shutdown,
+                    accept_conns,
+                )
+            })
+            .map_err(|source| Error::SpawnThread {
+                name: "gc-socket",
+                source,
+            })?;
+
+        Ok(GcSocketServer {
+            socket_path,
+            shutdown,
+            handle: Some(handle),
+            live: live_for_drop,
+            conns,
+        })
+    }
+}
+
+impl Drop for GcSocketServer {
+    fn drop(&mut self) {
+        let _ = fs::remove_file(&self.socket_path);
+        self.shutdown.store(true, Ordering::Release);
+        if let Some(h) = self.handle.take() {
+            let _ = h.join();
+        }
+        // Cancel first so a protect() stuck on abandoned pending nodes
+        // cannot deadlock the join below. Unacked clients reconnect via
+        // Nix's addTempRoot restart loop.
+        self.live.cancel();
+        let conns = std::mem::take(&mut *self.conns.lock().unwrap());
+        for (stream, handle) in conns {
+            let _ = stream.shutdown(std::net::Shutdown::Both);
+            let _ = handle.join();
+        }
+    }
+}
+
+fn accept_loop(
+    listener: UnixListener,
+    store_prefix: String,
+    live: Arc<LiveSet>,
+    graph: Arc<StoreGraph>,
+    idx: Arc<HashMap<String, NodeIdx>>,
+    shutdown: Arc<AtomicBool>,
+    conns: Conns,
+) {
+    while !shutdown.load(Ordering::Acquire) {
+        let pfd = PollFd::new(listener.as_fd(), PollFlags::POLLIN);
+        match poll(&mut [pfd], PollTimeout::from(10_u8)) {
+            Ok(0) => continue,
+            Err(e) => {
+                // Don't hot-spin if poll fails persistently.
+                debug!("gc-socket poll: {e}");
+                std::thread::sleep(std::time::Duration::from_millis(10));
+                continue;
+            }
+            _ => {}
+        }
+        match listener.accept() {
+            Ok((stream, _)) => {
+                let store_prefix = store_prefix.clone();
+                let live = Arc::clone(&live);
+                let graph = Arc::clone(&graph);
+                let idx = Arc::clone(&idx);
+                let Ok(stream2) = stream.try_clone() else {
+                    continue;
+                };
+                let spawned = std::thread::Builder::new()
+                    .name("gc-socket-conn".into())
+                    .spawn(move || {
+                        if let Err(e) = handle_client(stream, &store_prefix, &live, &graph, &idx) {
+                            debug!("gc-socket client: {e}");
+                        }
+                    });
+                if let Ok(handle) = spawned {
+                    let mut g = conns.lock().unwrap();
+                    // Keep the list from growing with finished handlers.
+                    g.retain(|(_, h)| !h.is_finished());
+                    g.push((stream2, handle));
+                }
+            }
+            Err(e) if e.kind() == ErrorKind::Interrupted => {}
+            Err(e) => {
+                // Transient failures (EMFILE/ECONNABORTED) must not kill
+                // the server. Back off briefly and keep accepting.
+                warn!("gc-socket accept: {e}");
+                std::thread::sleep(std::time::Duration::from_millis(100));
+            }
+        }
+    }
+}
+
+fn handle_client(
+    stream: UnixStream,
+    store_prefix: &str,
+    live: &LiveSet,
+    graph: &StoreGraph,
+    idx: &HashMap<String, NodeIdx>,
+) -> Result<()> {
+    // The socket is world-writable. A peer streaming data without a
+    // newline must not OOM the GC.
+    const MAX_LINE: u64 = 64 * 1024;
+    let client_err = |source| Error::ClientIo { source };
+    let mut writer = stream.try_clone().map_err(client_err)?;
+    let mut reader = BufReader::new(stream);
+    let mut line = String::new();
+    loop {
+        line.clear();
+        let n = reader
+            .by_ref()
+            .take(MAX_LINE)
+            .read_line(&mut line)
+            .map_err(client_err)?;
+        if n == 0 {
+            return Ok(());
+        }
+        if n as u64 == MAX_LINE && !line.ends_with('\n') {
+            return Err(Error::LineTooLong);
+        }
+        let path = line.trim_end_matches('\n');
+        if let Some(basename) = path.strip_prefix(store_prefix).filter(|b| !b.is_empty()) {
+            debug!("got new GC root '{path}'");
+            live.protect(basename, graph, idx);
+        } else {
+            warn!("gc-socket: received garbage instead of a root: {path:?}");
+        }
+        writer.write_all(b"1").map_err(client_err)?;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use harmonia_store_db::{GraphOptions, StoreDb};
+    use harmonia_store_path::StoreDir;
+    use std::io::Read;
+
+    /// Load a graph with the given nodes and edges. `refs` are indices
+    /// into `paths`.
+    fn graph(paths: &[(&str, &[usize])]) -> Arc<StoreGraph> {
+        let db = StoreDb::open_memory().unwrap();
+        let mut ids = Vec::new();
+        for (name, _) in paths {
+            db.connection()
+                .execute(
+                    "INSERT INTO ValidPaths (path, hash, registrationTime) \
+                     VALUES (?, 'sha256:x', 1)",
+                    [format!("/nix/store/{name}")],
+                )
+                .unwrap();
+            ids.push(db.connection().last_insert_rowid());
+        }
+        for (i, (_, refs)) in paths.iter().enumerate() {
+            for &r in refs.iter() {
+                db.connection()
+                    .execute(
+                        "INSERT INTO Refs (referrer, reference) VALUES (?, ?)",
+                        [ids[i], ids[r]],
+                    )
+                    .unwrap();
+            }
+        }
+        let options = GraphOptions {
+            keep_derivations: false,
+            keep_outputs: false,
+        };
+        Arc::new(db.load_graph(&StoreDir::default(), &options).unwrap())
+    }
+
+    fn node(g: &StoreGraph, name: &str) -> NodeIdx {
+        g.nodes()
+            .find(|&n| g.path(n) == format!("/nix/store/{name}"))
+            .unwrap()
+    }
+
+    #[test]
+    fn drop_returns_when_idle_accept_loop_is_waiting() {
+        let g = graph(&[]);
+        let live = Arc::new(LiveSet::new(0));
+        let dir = tempfile::tempdir().unwrap();
+        let server = GcSocketServer::start(dir.path(), live, g).unwrap();
+
+        let (tx, rx) = std::sync::mpsc::channel();
+        let handle = std::thread::spawn(move || {
+            drop(server);
+            let _ = tx.send(());
+        });
+
+        rx.recv_timeout(std::time::Duration::from_secs(2))
+            .expect("GcSocketServer::drop did not finish");
+        handle.join().unwrap();
+    }
+
+    #[test]
+    fn protect_marks_closure_and_blocks_deletion() {
+        // a -> b -> c, d standalone
+        let g = graph(&[("a", &[1]), ("b", &[2]), ("c", &[]), ("d", &[])]);
+        let live = Arc::new(LiveSet::new(g.len()));
+        let dir = tempfile::tempdir().unwrap();
+        let server = GcSocketServer::start(dir.path(), Arc::clone(&live), Arc::clone(&g)).unwrap();
+        let sock = dir.path().join("gc-socket/socket");
+
+        let mut conn = UnixStream::connect(&sock).unwrap();
+        conn.write_all(b"/nix/store/a\n").unwrap();
+        let mut ack = [0u8; 1];
+        conn.read_exact(&mut ack).unwrap();
+        assert_eq!(ack, [b'1']);
+
+        // The closure of a (a, b, c) is protected. d is still deletable.
+        assert!(!live.try_begin_delete_node(node(&g, "a")));
+        assert!(!live.try_begin_delete_node(node(&g, "b")));
+        assert!(!live.try_begin_delete_node(node(&g, "c")));
+        assert!(live.try_begin_delete_node(node(&g, "d")));
+        live.end_delete_node(node(&g, "d"));
+
+        drop(server);
+        assert!(!sock.exists());
+    }
+
+    #[test]
+    fn protect_blocks_until_pending_delete_finishes() {
+        let g = graph(&[("x", &[])]);
+        let live = Arc::new(LiveSet::new(g.len()));
+        let dir = tempfile::tempdir().unwrap();
+        let _server = GcSocketServer::start(dir.path(), Arc::clone(&live), Arc::clone(&g)).unwrap();
+        let sock = dir.path().join("gc-socket/socket");
+
+        // Simulate the deleter claiming x.
+        let x = node(&g, "x");
+        assert!(live.try_begin_delete_node(x));
+
+        let mut conn = UnixStream::connect(&sock).unwrap();
+        conn.write_all(b"/nix/store/x\n").unwrap();
+        // The ack must not arrive until end_delete_node is called.
+        conn.set_read_timeout(Some(std::time::Duration::from_millis(50)))
+            .unwrap();
+        let mut ack = [0u8; 1];
+        assert!(conn.read_exact(&mut ack).is_err(), "ack arrived too early");
+
+        live.end_delete_node(x);
+        conn.set_read_timeout(None).unwrap();
+        conn.read_exact(&mut ack).unwrap();
+        assert_eq!(ack, [b'1']);
+        // After protection, a fresh delete attempt is refused.
+        assert!(!live.try_begin_delete_node(x));
+    }
+
+    #[test]
+    fn protect_waits_for_already_protected_pending_node() {
+        // Two roots a -> c and b -> c share a leaf. While c is mid-unlink,
+        // protecting a marks c protected and waits. A second protect for b
+        // must also wait for c, not ack early just because c is already
+        // protected.
+        let g = graph(&[("a", &[2]), ("b", &[2]), ("c", &[])]);
+        let live = Arc::new(LiveSet::new(g.len()));
+        let dir = tempfile::tempdir().unwrap();
+        let _server = GcSocketServer::start(dir.path(), Arc::clone(&live), Arc::clone(&g)).unwrap();
+        let sock = dir.path().join("gc-socket/socket");
+
+        // c is in flight.
+        let c = node(&g, "c");
+        assert!(live.try_begin_delete_node(c));
+
+        let mut conn_a = UnixStream::connect(&sock).unwrap();
+        conn_a.write_all(b"/nix/store/a\n").unwrap();
+        conn_a
+            .set_read_timeout(Some(std::time::Duration::from_millis(50)))
+            .unwrap();
+        let mut ack = [0u8; 1];
+        assert!(conn_a.read_exact(&mut ack).is_err(), "a acked too early");
+
+        // c is now protected (by a's protect) but still pending. b's
+        // protect must not ack yet.
+        let mut conn_b = UnixStream::connect(&sock).unwrap();
+        conn_b.write_all(b"/nix/store/b\n").unwrap();
+        conn_b
+            .set_read_timeout(Some(std::time::Duration::from_millis(50)))
+            .unwrap();
+        assert!(conn_b.read_exact(&mut ack).is_err(), "b acked too early");
+
+        // c finishes, both unblock.
+        live.end_delete_node(c);
+        for conn in [&mut conn_a, &mut conn_b] {
+            conn.set_read_timeout(None).unwrap();
+            conn.read_exact(&mut ack).unwrap();
+            assert_eq!(ack, [b'1']);
+        }
+    }
+
+    #[test]
+    fn claim_nodes_partitions_and_blocks_protect() {
+        let g = graph(&[("a", &[]), ("b", &[])]);
+        let live = Arc::new(LiveSet::new(g.len()));
+        let dir = tempfile::tempdir().unwrap();
+        let _server = GcSocketServer::start(dir.path(), Arc::clone(&live), Arc::clone(&g)).unwrap();
+        let sock = dir.path().join("gc-socket/socket");
+
+        // Protect b up front. claim must skip it and claim a.
+        let mut conn = UnixStream::connect(&sock).unwrap();
+        conn.write_all(b"/nix/store/b\n").unwrap();
+        let mut ack = [0u8; 1];
+        conn.read_exact(&mut ack).unwrap();
+
+        let (a, b) = (node(&g, "a"), node(&g, "b"));
+        let (claimed, skipped) = live.claim_nodes(&[a, b]);
+        assert_eq!(claimed, vec![a]);
+        assert_eq!(skipped, vec![b]);
+
+        // A protect for the claimed node must block until its unlink is
+        // done (the DB row is already gone; acking earlier would tell the
+        // builder a deleted row is protected).
+        conn.write_all(b"/nix/store/a\n").unwrap();
+        conn.set_read_timeout(Some(std::time::Duration::from_millis(50)))
+            .unwrap();
+        assert!(conn.read_exact(&mut ack).is_err(), "acked mid-deletion");
+
+        live.end_delete_node(a);
+        conn.set_read_timeout(None).unwrap();
+        conn.read_exact(&mut ack).unwrap();
+        assert_eq!(ack, [b'1']);
+    }
+
+    #[test]
+    fn drop_joins_handlers_and_snapshot_sees_acked_roots() {
+        // Every root acked before the server is dropped must be visible
+        // in the snapshot taken right after, even while the client
+        // connection is still open.
+        let g = graph(&[]);
+        let live = Arc::new(LiveSet::new(0));
+        let dir = tempfile::tempdir().unwrap();
+        let server = GcSocketServer::start(dir.path(), Arc::clone(&live), g).unwrap();
+        let sock = dir.path().join("gc-socket/socket");
+
+        let mut conn = UnixStream::connect(&sock).unwrap();
+        conn.write_all(b"/nix/store/early-root\n").unwrap();
+        let mut ack = [0u8; 1];
+        conn.read_exact(&mut ack).unwrap();
+        assert_eq!(ack, [b'1']);
+
+        // The handler is blocked in read_line. Drop must not hang.
+        let (tx, rx) = std::sync::mpsc::channel();
+        let joiner = std::thread::spawn(move || {
+            drop(server);
+            let _ = tx.send(());
+        });
+        rx.recv_timeout(std::time::Duration::from_secs(2))
+            .expect("GcSocketServer::drop hung joining a live connection");
+        joiner.join().unwrap();
+
+        assert!(
+            live.protected_unknown_snapshot().contains("early-root"),
+            "acked root missing from post-drop snapshot"
+        );
+    }
+
+    #[test]
+    fn unknown_path_protected_by_basename() {
+        let g = graph(&[]);
+        let live = Arc::new(LiveSet::new(0));
+        let dir = tempfile::tempdir().unwrap();
+        let _server = GcSocketServer::start(dir.path(), Arc::clone(&live), Arc::clone(&g)).unwrap();
+        let sock = dir.path().join("gc-socket/socket");
+
+        let mut conn = UnixStream::connect(&sock).unwrap();
+        conn.write_all(b"/nix/store/zzz-fresh\n").unwrap();
+        let mut ack = [0u8; 1];
+        conn.read_exact(&mut ack).unwrap();
+
+        assert!(!live.try_begin_delete_unknown("zzz-fresh"));
+        assert!(live.try_begin_delete_unknown("other"));
+        live.end_delete_unknown("other");
+    }
+}

--- a/harmonia-store-gc/src/lib.rs
+++ b/harmonia-store-gc/src/lib.rs
@@ -20,6 +20,7 @@ pub mod config;
 mod error;
 pub mod gc;
 pub mod gc_socket;
+pub mod profiles;
 pub mod roots;
 pub mod store;
 pub mod temp_roots;

--- a/harmonia-store-gc/src/lib.rs
+++ b/harmonia-store-gc/src/lib.rs
@@ -18,6 +18,8 @@
 
 pub mod config;
 mod error;
+pub mod gc;
+pub mod gc_socket;
 pub mod roots;
 pub mod store;
 pub mod temp_roots;

--- a/harmonia-store-gc/src/lib.rs
+++ b/harmonia-store-gc/src/lib.rs
@@ -1,0 +1,168 @@
+// SPDX-FileCopyrightText: 2025 Jörg Thalheim
+// SPDX-License-Identifier: MIT
+
+//! Garbage collection for the Nix store.
+//!
+//! A faster drop-in replacement for `nix-collect-garbage`. Instead of one
+//! SQLite query per store path, the reference graph is loaded once into
+//! memory (see [`harmonia_store_db::StoreGraph`]) and liveness is computed
+//! as a graph closure. Deletion runs in parallel.
+//!
+//! The crate speaks the same on-disk protocols as Nix itself. It takes
+//! the same `gc.lock`, honors the temp-root files that running builds
+//! register, and serves the `gc-socket` that builders use to protect new
+//! paths while a collection is in progress. Running it next to a busy
+//! nix-daemon is safe.
+//!
+//! Entry point: [`gc::collect_garbage`] with a [`store::GcStore`].
+
+pub mod config;
+mod error;
+pub mod store;
+
+pub use error::{Error, Result};
+
+use std::path::Path;
+
+/// Hash map keyed by store path strings.
+///
+/// SipHash showed up in GC profiles when hashing millions of ~50-char
+/// store paths, so foldhash is used instead.
+pub type HashMap<K, V> = std::collections::HashMap<K, V, foldhash::fast::RandomState>;
+/// Hash set counterpart of [`HashMap`].
+pub type HashSet<K> = std::collections::HashSet<K, foldhash::fast::RandomState>;
+
+/// Format a byte count for human-readable log output.
+///
+/// ```
+/// assert_eq!(harmonia_store_gc::format_size(1536), "1.50 KiB");
+/// ```
+pub fn format_size(bytes: u64) -> String {
+    const KIB: f64 = 1024.0;
+    const MIB: f64 = KIB * 1024.0;
+    const GIB: f64 = MIB * 1024.0;
+    let b = bytes as f64;
+    if b >= GIB {
+        format!("{:.2} GiB", b / GIB)
+    } else if b >= MIB {
+        format!("{:.2} MiB", b / MIB)
+    } else if b >= KIB {
+        format!("{:.2} KiB", b / KIB)
+    } else {
+        format!("{bytes} bytes")
+    }
+}
+
+/// Enter a private mount namespace so the read-write remount in
+/// [`make_store_writable`] stays scoped to this process, mirroring what
+/// the `nix` CLI does for root.
+///
+/// Must be called from `main` before any thread pool starts. Only the
+/// calling thread joins the new namespace, so worker threads created
+/// earlier would keep seeing the read-only store.
+///
+/// Failures are logged and ignored (e.g. EPERM in containers). We then
+/// fall back to remounting in the host namespace, like legacy `nix-store`.
+#[cfg(target_os = "linux")]
+pub fn unshare_mount_namespace() {
+    use nix::mount::{MsFlags, mount};
+    use nix::sched::{CloneFlags, unshare};
+    use nix::unistd::Uid;
+
+    if !Uid::effective().is_root() {
+        return;
+    }
+    if let Err(e) = unshare(CloneFlags::CLONE_NEWNS) {
+        tracing::warn!("failed to set up a private mount namespace: {e}");
+        return;
+    }
+    // Default propagation on systemd is `shared`. Without marking /
+    // private, the remount would propagate back to the host namespace.
+    if let Err(e) = mount(
+        None::<&str>,
+        "/",
+        None::<&str>,
+        MsFlags::MS_PRIVATE | MsFlags::MS_REC,
+        None::<&str>,
+    ) {
+        tracing::warn!("failed to mark / private in mount namespace: {e}");
+    }
+}
+
+#[cfg(not(target_os = "linux"))]
+pub fn unshare_mount_namespace() {}
+
+/// Remount the store read-write if needed. NixOS bind-mounts /nix/store
+/// read-only, so this must run before any deletion.
+#[cfg(target_os = "linux")]
+pub fn make_store_writable(real_store_dir: &Path) -> Result<()> {
+    use nix::mount::{MsFlags, mount};
+    use nix::sys::statvfs::{FsFlags, statvfs};
+    use nix::unistd::Uid;
+
+    if !Uid::effective().is_root() {
+        return Ok(());
+    }
+
+    let st = statvfs(real_store_dir).map_err(|source| Error::MountInfo {
+        path: real_store_dir.to_owned(),
+        source,
+    })?;
+    if !st.flags().contains(FsFlags::ST_RDONLY) {
+        return Ok(());
+    }
+
+    // Preserve locked mount flags (nodev etc.), otherwise the remount
+    // fails in a user namespace.
+    let mut flags = MsFlags::MS_REMOUNT | MsFlags::MS_BIND;
+    let f = st.flags();
+    for (fs_flag, ms_flag) in [
+        (FsFlags::ST_NODEV, MsFlags::MS_NODEV),
+        (FsFlags::ST_NOSUID, MsFlags::MS_NOSUID),
+        (FsFlags::ST_NOEXEC, MsFlags::MS_NOEXEC),
+        (FsFlags::ST_NOATIME, MsFlags::MS_NOATIME),
+        (FsFlags::ST_NODIRATIME, MsFlags::MS_NODIRATIME),
+        (FsFlags::ST_RELATIME, MsFlags::MS_RELATIME),
+        (FsFlags::ST_SYNCHRONOUS, MsFlags::MS_SYNCHRONOUS),
+    ] {
+        if f.contains(fs_flag) {
+            flags |= ms_flag;
+        }
+    }
+
+    mount(
+        None::<&str>,
+        real_store_dir,
+        None::<&str>,
+        flags,
+        None::<&str>,
+    )
+    .map_err(|source| Error::Remount {
+        path: real_store_dir.to_owned(),
+        source,
+    })?;
+    tracing::info!("remounted {} read-write", real_store_dir.display());
+    Ok(())
+}
+
+#[cfg(not(target_os = "linux"))]
+pub fn make_store_writable(_real_store_dir: &Path) -> Result<()> {
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::format_size;
+
+    #[test]
+    fn format_size_units() {
+        assert_eq!(format_size(0), "0 bytes");
+        assert_eq!(format_size(1023), "1023 bytes");
+        assert_eq!(format_size(1024), "1.00 KiB");
+        assert_eq!(format_size(1536), "1.50 KiB");
+        assert_eq!(format_size(1024 * 1024), "1.00 MiB");
+        assert_eq!(format_size(5 * 1024 * 1024 + 512 * 1024), "5.50 MiB");
+        assert_eq!(format_size(1024 * 1024 * 1024), "1.00 GiB");
+        assert_eq!(format_size(3 * 1024 * 1024 * 1024 / 2), "1.50 GiB");
+    }
+}

--- a/harmonia-store-gc/src/lib.rs
+++ b/harmonia-store-gc/src/lib.rs
@@ -18,7 +18,9 @@
 
 pub mod config;
 mod error;
+pub mod roots;
 pub mod store;
+pub mod temp_roots;
 
 pub use error::{Error, Result};
 

--- a/harmonia-store-gc/src/profiles.rs
+++ b/harmonia-store-gc/src/profiles.rs
@@ -1,0 +1,552 @@
+// SPDX-FileCopyrightText: 2025 Jörg Thalheim
+// SPDX-License-Identifier: MIT
+
+//! Profile generation cleanup (`--delete-old` / `--delete-older-than`).
+//!
+//! A profile is a symlink like `system` pointing at its current
+//! generation link `system-42-link`. Removing old generation links is
+//! what allows their store paths to become garbage.
+
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::{Duration, SystemTime};
+
+use rayon::prelude::*;
+use tracing::{info, warn};
+
+use crate::error::{Error, Result};
+
+/// Parse a Nix-style time spec into a point in the past.
+///
+/// ```
+/// use harmonia_store_gc::profiles::parse_older_than;
+///
+/// assert!(parse_older_than("30d").is_ok());
+/// assert!(parse_older_than("4h").is_ok());
+/// assert!(parse_older_than("banana").is_err());
+/// ```
+pub fn parse_older_than(spec: &str) -> Result<SystemTime> {
+    let invalid = |reason: &str| Error::TimeSpec {
+        spec: spec.to_owned(),
+        reason: reason.to_owned(),
+    };
+    // Take the last *character*. A byte-based split_at would panic on
+    // multi-byte input like "30日".
+    let Some((idx, unit)) = spec.char_indices().last() else {
+        return Err(invalid("expected e.g. '30d'"));
+    };
+    let num_str = &spec[..idx];
+    if num_str.is_empty() {
+        return Err(invalid("expected e.g. '30d'"));
+    }
+    let num: u64 = num_str
+        .parse()
+        .map_err(|e| invalid(&format!("invalid number: {e}")))?;
+    let unit_secs = match unit {
+        'h' => 3600,
+        'd' => 86400,
+        'w' => 7 * 86400,
+        'm' => 30 * 86400,
+        _ => return Err(invalid(&format!("unknown time unit '{unit}', use h/d/w/m"))),
+    };
+    let secs = num
+        .checked_mul(unit_secs)
+        .ok_or_else(|| invalid("out of range"))?;
+    SystemTime::now()
+        .checked_sub(Duration::from_secs(secs))
+        .ok_or_else(|| invalid("out of range"))
+}
+
+fn find_generation_links(profile: &Path) -> Result<Vec<(PathBuf, u64)>> {
+    let parent = profile.parent().unwrap_or(Path::new("."));
+    let profile_name = profile
+        .file_name()
+        .unwrap_or_default()
+        .to_string_lossy()
+        .to_string();
+
+    let mut gens = Vec::new();
+    let entries = match fs::read_dir(parent) {
+        Ok(e) => e,
+        Err(_) => return Ok(gens),
+    };
+
+    for entry in entries.flatten() {
+        let name = entry.file_name().to_string_lossy().to_string();
+        if let Some(rest) = name.strip_prefix(&format!("{profile_name}-"))
+            && let Some(num_str) = rest.strip_suffix("-link")
+            && let Ok(r#gen) = num_str.parse::<u64>()
+        {
+            gens.push((entry.path(), r#gen));
+        }
+    }
+    gens.sort_by_key(|(_, g)| *g);
+    Ok(gens)
+}
+
+fn current_generation(profile: &Path) -> Result<Option<u64>> {
+    let target = match fs::read_link(profile) {
+        Ok(t) => t,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(source) => {
+            return Err(Error::ReadLink {
+                path: profile.to_owned(),
+                source,
+            });
+        }
+    };
+    let name = target
+        .file_name()
+        .unwrap_or_default()
+        .to_string_lossy()
+        .to_string();
+    let profile_name = profile
+        .file_name()
+        .unwrap_or_default()
+        .to_string_lossy()
+        .to_string();
+
+    if let Some(rest) = name.strip_prefix(&format!("{profile_name}-"))
+        && let Some(num_str) = rest.strip_suffix("-link")
+        && let Ok(r#gen) = num_str.parse::<u64>()
+    {
+        return Ok(Some(r#gen));
+    }
+    Ok(None)
+}
+
+/// Lock held while mutating a profile's generations, interoperable with
+/// Nix's PathLocks protocol: flock(2) on `<profile>.lock`, stale
+/// detection via a non-empty file, deletion marker on release.
+struct ProfileLock {
+    lock_path: PathBuf,
+    file: nix::fcntl::Flock<fs::File>,
+}
+
+impl ProfileLock {
+    fn acquire(profile: &Path) -> Result<ProfileLock> {
+        use nix::errno::Errno;
+        use nix::fcntl::{Flock, FlockArg};
+        use std::os::unix::fs::OpenOptionsExt;
+        let mut name = profile.file_name().unwrap_or_default().to_os_string();
+        name.push(".lock");
+        let lock_path = profile.with_file_name(name);
+        let lock_err = |source| Error::ProfileLock {
+            path: lock_path.clone(),
+            source,
+        };
+        loop {
+            let mut file = fs::OpenOptions::new()
+                .read(true)
+                .write(true)
+                .create(true)
+                .truncate(false)
+                .mode(0o600)
+                .open(&lock_path)
+                .map_err(lock_err)?;
+            let file = loop {
+                match Flock::lock(file, FlockArg::LockExclusive) {
+                    Ok(lock) => break lock,
+                    // Flock does not retry EINTR itself.
+                    Err((f, Errno::EINTR)) => file = f,
+                    Err((_, errno)) => return Err(lock_err(errno.into())),
+                }
+            };
+            // Stale check (Nix protocol): a non-empty lock file was marked
+            // and unlinked by its previous holder. Retry on a fresh inode.
+            if file.metadata().map_err(lock_err)?.len() != 0 {
+                continue;
+            }
+            return Ok(ProfileLock { lock_path, file });
+        }
+    }
+}
+
+impl Drop for ProfileLock {
+    fn drop(&mut self) {
+        use std::io::Write;
+        // Nix's deleteLockFile: write the deletion marker, then unlink.
+        // The flock itself is released when the fd closes.
+        let _ = self.file.write_all(b"d");
+        let _ = fs::remove_file(&self.lock_path);
+    }
+}
+
+fn delete_old_generations(profile: &Path, dry_run: bool) -> Result<()> {
+    // Serialize against nix-env/nixos-rebuild generation switches, which
+    // take the same lock.
+    let _lock = ProfileLock::acquire(profile)?;
+    // Fail closed: without a known active generation, "delete all but
+    // current" would delete the active system too.
+    let Some(current) = current_generation(profile)? else {
+        warn!(
+            "cannot determine current generation of {}, skipping",
+            profile.display()
+        );
+        return Ok(());
+    };
+    let gens = find_generation_links(profile)?;
+
+    for (path, r#gen) in &gens {
+        if *r#gen == current {
+            continue;
+        }
+        if dry_run {
+            info!("would remove: {}", path.display());
+        } else {
+            info!("removing: {}", path.display());
+            if let Err(e) = fs::remove_file(path) {
+                warn!("cannot remove {}: {e}", path.display());
+            }
+        }
+    }
+    Ok(())
+}
+
+fn delete_generations_older_than(profile: &Path, cutoff: SystemTime, dry_run: bool) -> Result<()> {
+    let _lock = ProfileLock::acquire(profile)?;
+    // Same fail-closed rule as delete_old_generations.
+    let Some(current) = current_generation(profile)? else {
+        warn!(
+            "cannot determine current generation of {}, skipping",
+            profile.display()
+        );
+        return Ok(());
+    };
+    let gens = find_generation_links(profile)?;
+
+    let mtime_of = |path: &Path| -> Option<SystemTime> {
+        let meta = fs::symlink_metadata(path).ok()?;
+        Some(meta.modified().unwrap_or(SystemTime::UNIX_EPOCH))
+    };
+
+    // Like Nix, keep the newest generation older than the cutoff: it was
+    // active at that point in time and stays available for rollback.
+    let newest_older = gens
+        .iter()
+        .rev()
+        .find(|(path, _)| mtime_of(path).is_some_and(|t| t < cutoff))
+        .map(|(_, g)| *g);
+
+    for (path, r#gen) in &gens {
+        if *r#gen == current || Some(*r#gen) == newest_older {
+            continue;
+        }
+        let Some(mtime) = mtime_of(path) else {
+            continue;
+        };
+        if mtime < cutoff {
+            if dry_run {
+                info!("would remove (old): {}", path.display());
+            } else {
+                info!("removing (old): {}", path.display());
+                if let Err(e) = fs::remove_file(path) {
+                    warn!("cannot remove {}: {e}", path.display());
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Remove old generations of every profile found under `dir`,
+/// recursively. With `delete_older_than` set, only generations older
+/// than that point go. Without it, everything but the current
+/// generation goes.
+pub fn remove_old_generations(
+    dir: &Path,
+    delete_older_than: Option<SystemTime>,
+    dry_run: bool,
+) -> Result<()> {
+    let entries: Vec<_> = match fs::read_dir(dir) {
+        Ok(rd) => rd.flatten().collect(),
+        Err(_) => return Ok(()),
+    };
+
+    let can_write = nix::unistd::access(dir, nix::unistd::AccessFlags::W_OK).is_ok();
+
+    entries.par_iter().try_for_each(|entry| -> Result<()> {
+        let path = entry.path();
+        let ft = match fs::symlink_metadata(&path) {
+            Ok(m) => m.file_type(),
+            Err(_) => return Ok(()),
+        };
+
+        if ft.is_symlink() && can_write {
+            let link_target = match fs::read_link(&path) {
+                Ok(t) => t,
+                Err(_) => return Ok(()),
+            };
+            if link_target.to_string_lossy().contains("link") {
+                info!("removing old generations of profile {}", path.display());
+                if let Some(cutoff) = delete_older_than {
+                    delete_generations_older_than(&path, cutoff, dry_run)?;
+                } else {
+                    delete_old_generations(&path, dry_run)?;
+                }
+            }
+        } else if ft.is_dir() {
+            remove_old_generations(&path, delete_older_than, dry_run)?;
+        }
+        Ok(())
+    })?;
+
+    Ok(())
+}
+
+/// Directories scanned for profiles, mirroring `nix-collect-garbage`:
+/// the system profiles dir (recursed, so per-user is covered) and the
+/// invoking user's XDG state profiles dir. Never the home directory
+/// itself — [`remove_old_generations`] recurses, and treating arbitrary
+/// `*-N-link` symlinks under `$HOME` as generations would delete user
+/// data.
+pub fn profile_dirs(state_dir: &Path) -> BTreeSet<PathBuf> {
+    let mut dirs = BTreeSet::new();
+
+    dirs.insert(state_dir.join("profiles"));
+
+    let xdg_state = std::env::var("XDG_STATE_HOME")
+        .map(PathBuf::from)
+        .ok()
+        .filter(|p| p.is_absolute())
+        .or_else(|| {
+            std::env::var("HOME")
+                .ok()
+                .map(|h| PathBuf::from(h).join(".local/state"))
+        });
+    if let Some(state_home) = xdg_state {
+        dirs.insert(state_home.join("nix/profiles"));
+    }
+
+    dirs
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::os::unix::fs::symlink;
+    use std::time::{Duration, SystemTime};
+
+    fn approx_secs_ago(t: SystemTime, secs: u64) {
+        let elapsed = SystemTime::now().duration_since(t).unwrap();
+        let want = Duration::from_secs(secs);
+        let diff = elapsed.abs_diff(want);
+        assert!(
+            diff < Duration::from_secs(5),
+            "expected ~{secs}s ago, got {elapsed:?}"
+        );
+    }
+
+    #[test]
+    fn parse_older_than_units() {
+        approx_secs_ago(parse_older_than("2h").unwrap(), 2 * 3600);
+        approx_secs_ago(parse_older_than("3d").unwrap(), 3 * 86400);
+        approx_secs_ago(parse_older_than("2w").unwrap(), 2 * 7 * 86400);
+        approx_secs_ago(parse_older_than("2m").unwrap(), 2 * 30 * 86400);
+    }
+
+    #[test]
+    fn parse_older_than_rejects_invalid() {
+        assert!(parse_older_than("").is_err());
+        assert!(parse_older_than("d").is_err());
+        assert!(parse_older_than("5x").is_err());
+        assert!(parse_older_than("xd").is_err());
+        // Multi-byte unit must error, not panic on a char boundary.
+        assert!(parse_older_than("30日").is_err());
+        assert!(parse_older_than("日").is_err());
+        // Overflowing multiplication must error, not wrap.
+        assert!(parse_older_than("99999999999999999999d").is_err());
+        assert!(parse_older_than("9999999999999999999d").is_err());
+        // Fits in u64 after multiplication but reaches the edge of
+        // SystemTime's range. Must not panic.
+        let _ = parse_older_than("106751991167300d");
+    }
+
+    #[test]
+    fn generation_links_and_current() {
+        let dir = tempfile::tempdir().unwrap();
+        let profile = dir.path().join("system");
+
+        // Generation links plus noise that must be ignored.
+        for n in [3u64, 1, 2] {
+            let link = dir.path().join(format!("system-{n}-link"));
+            symlink(format!("/nix/store/fake-{n}"), &link).unwrap();
+        }
+        symlink("/nix/store/x", dir.path().join("other-1-link")).unwrap();
+        symlink("/nix/store/x", dir.path().join("system-foo-link")).unwrap();
+
+        symlink(dir.path().join("system-2-link"), &profile).unwrap();
+
+        let gens = find_generation_links(&profile).unwrap();
+        let nums: Vec<u64> = gens.iter().map(|(_, g)| *g).collect();
+        assert_eq!(nums, vec![1, 2, 3]);
+        assert_eq!(gens[0].0, dir.path().join("system-1-link"));
+
+        assert_eq!(current_generation(&profile).unwrap(), Some(2));
+    }
+
+    /// Build a temp profile dir with generations 1..=n and a `system`
+    /// symlink pointing at `system-{current}-link`.
+    fn setup_profile(n: u64, current: u64) -> (tempfile::TempDir, PathBuf) {
+        let dir = tempfile::tempdir().unwrap();
+        for i in 1..=n {
+            let link = dir.path().join(format!("system-{i}-link"));
+            symlink(format!("/nix/store/fake-{i}"), &link).unwrap();
+        }
+        let profile = dir.path().join("system");
+        symlink(dir.path().join(format!("system-{current}-link")), &profile).unwrap();
+        (dir, profile)
+    }
+
+    fn existing_gens(dir: &Path) -> Vec<u64> {
+        find_generation_links(&dir.join("system"))
+            .unwrap()
+            .into_iter()
+            .map(|(_, g)| g)
+            .collect()
+    }
+
+    fn set_link_mtime(path: &Path, t: SystemTime) {
+        use nix::sys::stat::{UtimensatFlags, utimensat};
+        use nix::sys::time::TimeSpec;
+        let d = t.duration_since(SystemTime::UNIX_EPOCH).unwrap();
+        let ts = TimeSpec::new(d.as_secs() as i64, d.subsec_nanos() as i64);
+        utimensat(
+            nix::fcntl::AT_FDCWD,
+            path,
+            &ts,
+            &ts,
+            UtimensatFlags::NoFollowSymlink,
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn delete_old_generations_keeps_only_current() {
+        let (dir, profile) = setup_profile(3, 2);
+
+        // Dry run leaves everything in place.
+        delete_old_generations(&profile, true).unwrap();
+        assert_eq!(existing_gens(dir.path()), vec![1, 2, 3]);
+
+        delete_old_generations(&profile, false).unwrap();
+        assert_eq!(existing_gens(dir.path()), vec![2]);
+    }
+
+    #[test]
+    fn delete_generations_older_than_cutoff() {
+        let (dir, profile) = setup_profile(4, 4);
+        let base = SystemTime::UNIX_EPOCH + Duration::from_secs(1_000_000);
+        // gen i has mtime base + i*100s
+        for i in 1u64..=4 {
+            set_link_mtime(
+                &dir.path().join(format!("system-{i}-link")),
+                base + Duration::from_secs(i * 100),
+            );
+        }
+
+        // Cutoff at gen 2's mtime: only gen 1 is older, and it is kept
+        // for rollback (active at the cutoff). Nothing goes.
+        let cutoff = base + Duration::from_secs(200);
+        delete_generations_older_than(&profile, cutoff, true).unwrap();
+        assert_eq!(existing_gens(dir.path()), vec![1, 2, 3, 4]);
+        delete_generations_older_than(&profile, cutoff, false).unwrap();
+        assert_eq!(existing_gens(dir.path()), vec![1, 2, 3, 4]);
+
+        // Cutoff between gen 3 and 4: gens 1-3 are older, gen 3 was
+        // active at the cutoff and is kept. Generations 1 and 2 go.
+        let cutoff = base + Duration::from_secs(350);
+        delete_generations_older_than(&profile, cutoff, false).unwrap();
+        assert_eq!(existing_gens(dir.path()), vec![3, 4]);
+
+        // Cutoff after all gens: the newest older one is the current
+        // generation itself, so everything else goes.
+        delete_generations_older_than(&profile, base + Duration::from_secs(10_000), false).unwrap();
+        assert_eq!(existing_gens(dir.path()), vec![4]);
+    }
+
+    #[test]
+    fn remove_old_generations_recurses_and_skips_non_link_targets() {
+        let outer = tempfile::tempdir().unwrap();
+        let nested = outer.path().join("per-user").join("alice");
+        fs::create_dir_all(&nested).unwrap();
+        for i in 1u64..=3 {
+            symlink(
+                format!("/nix/store/fake-{i}"),
+                nested.join(format!("prof-{i}-link")),
+            )
+            .unwrap();
+        }
+        symlink(nested.join("prof-3-link"), nested.join("prof")).unwrap();
+        // Symlink whose target does not contain "link" must be left alone.
+        symlink("/nix/store/zzz", outer.path().join("plain")).unwrap();
+
+        remove_old_generations(outer.path(), None, false).unwrap();
+
+        let gens: Vec<u64> = find_generation_links(&nested.join("prof"))
+            .unwrap()
+            .into_iter()
+            .map(|(_, g)| g)
+            .collect();
+        assert_eq!(gens, vec![3]);
+        assert!(outer.path().join("plain").symlink_metadata().is_ok());
+    }
+
+    #[test]
+    fn profile_dirs_includes_state_and_xdg_paths_but_not_home() {
+        let state = Path::new("/var/state");
+        let dirs = profile_dirs(state);
+        assert!(dirs.contains(&state.join("profiles")));
+        if let Ok(home) = std::env::var("HOME") {
+            // $HOME itself must never be scanned recursively.
+            assert!(!dirs.contains(&PathBuf::from(&home)));
+            if std::env::var("XDG_STATE_HOME").is_err() {
+                assert!(dirs.contains(&PathBuf::from(home).join(".local/state/nix/profiles")));
+            }
+        }
+    }
+
+    #[test]
+    fn profile_lock_acquire_release_cleans_up() {
+        let dir = tempfile::tempdir().unwrap();
+        let profile = dir.path().join("system");
+        let lock_path = dir.path().join("system.lock");
+        {
+            let _lock = ProfileLock::acquire(&profile).unwrap();
+            assert!(lock_path.exists());
+        }
+        // Released locks are unlinked (Nix deleteLockFile protocol).
+        assert!(!lock_path.exists());
+        let _lock = ProfileLock::acquire(&profile).unwrap();
+    }
+
+    #[test]
+    fn unparseable_current_generation_deletes_nothing() {
+        // Profile pointing at a non-generation target: refusing to guess
+        // protects the active generation from "delete all but current".
+        let (dir, profile) = setup_profile(3, 2);
+        fs::remove_file(&profile).unwrap();
+        symlink("/nix/store/custom-env", &profile).unwrap();
+
+        delete_old_generations(&profile, false).unwrap();
+        assert_eq!(existing_gens(dir.path()), vec![1, 2, 3]);
+
+        delete_generations_older_than(&profile, SystemTime::now(), false).unwrap();
+        assert_eq!(existing_gens(dir.path()), vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn current_generation_none_when_missing() {
+        let dir = tempfile::tempdir().unwrap();
+        assert_eq!(current_generation(&dir.path().join("nope")).unwrap(), None);
+
+        // Profile exists but does not point at a -link target.
+        let profile = dir.path().join("system");
+        symlink("/nix/store/whatever", &profile).unwrap();
+        assert_eq!(current_generation(&profile).unwrap(), None);
+
+        // No matching generation links anywhere.
+        assert_eq!(find_generation_links(&profile).unwrap(), vec![]);
+    }
+}

--- a/harmonia-store-gc/src/roots.rs
+++ b/harmonia-store-gc/src/roots.rs
@@ -1,0 +1,647 @@
+// SPDX-FileCopyrightText: 2025 Jörg Thalheim
+// SPDX-License-Identifier: MIT
+
+//! GC root discovery.
+//!
+//! A root is anything that keeps a store path alive: symlinks under
+//! `gcroots/` and `profiles/`, temp-root files of running processes, and
+//! runtime references found by scanning processes (/proc on Linux,
+//! libproc on macOS).
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use harmonia_store_db::{BasenameIndex, NodeIdx};
+use tracing::debug;
+
+use crate::HashSet;
+use crate::error::{Error, Result};
+
+/// Find all GC roots by walking the gcroots/profiles directories (plus
+/// any `extra_dirs`) and scanning running processes.
+///
+/// Returned nodes belong to the graph behind `idx`. Runtime-scan
+/// candidates that are not in the database are dropped, mirroring Nix's
+/// `findRuntimeRoots`.
+pub fn find_roots(
+    state_dir: &Path,
+    store_dir: &Path,
+    extra_dirs: &[PathBuf],
+    idx: &BasenameIndex,
+) -> Result<Vec<NodeIdx>> {
+    let mut roots = HashSet::default();
+    let store_prefix = store_dir.to_string_lossy().to_string();
+
+    // Errors here must abort the GC: silently dropping a roots directory
+    // (e.g. EACCES) would let the GC delete live paths.
+    let default_dirs = [state_dir.join("gcroots"), state_dir.join("profiles")];
+    for dir in default_dirs.iter().chain(extra_dirs.iter()) {
+        find_roots_in_dir(dir, &store_prefix, idx, &mut roots).map_err(|source| {
+            Error::ScanRoots {
+                dir: dir.clone(),
+                source: Box::new(source),
+            }
+        })?;
+    }
+
+    // The kernel reports canonical (symlink-resolved) paths for fds and
+    // mappings, but the DB stores the logical store path. Scan with both
+    // prefixes and normalize back to logical before validating.
+    let canonical_prefix = fs::canonicalize(store_dir)
+        .ok()
+        .map(|p| p.to_string_lossy().into_owned());
+
+    let mut candidates = find_runtime_roots(&store_prefix);
+    if let Some(canon) = &canonical_prefix
+        && canon != &store_prefix
+    {
+        for c in find_runtime_roots(canon) {
+            if let Some(rest) = c.strip_prefix(canon.as_str()) {
+                candidates.insert(format!("{store_prefix}{rest}"));
+            }
+        }
+    }
+
+    for candidate in candidates {
+        if let Some(node) = idx.get(&candidate) {
+            roots.insert(node);
+        }
+    }
+
+    Ok(roots.into_iter().collect())
+}
+
+fn find_roots_in_dir(
+    dir: &Path,
+    store_prefix: &str,
+    idx: &BasenameIndex,
+    roots: &mut HashSet<NodeIdx>,
+) -> Result<()> {
+    let read_dir_err = |source| Error::ReadDir {
+        path: dir.to_owned(),
+        source,
+    };
+    let entries = match fs::read_dir(dir) {
+        Ok(e) => e,
+        // A missing roots dir contributes no roots. Anything else (EACCES,
+        // EIO) hides an unknown number of roots and must fail the GC.
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(e) => return Err(read_dir_err(e)),
+    };
+
+    for entry in entries {
+        let entry = entry.map_err(read_dir_err)?;
+        let path = entry.path();
+        let meta = match fs::symlink_metadata(&path) {
+            Ok(m) => m,
+            // Entry removed while scanning: not a root anymore.
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => continue,
+            Err(source) => return Err(Error::Stat { path, source }),
+        };
+
+        if meta.file_type().is_symlink() {
+            let target = match fs::read_link(&path) {
+                Ok(t) => t,
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => continue,
+                Err(source) => return Err(Error::ReadLink { path, source }),
+            };
+            let target_str = target.to_string_lossy();
+
+            if is_in_store(store_prefix, &target_str) {
+                // Direct root pointing into the store.
+                if let Some(sp) = extract_store_path(store_prefix, &target_str)
+                    && let Some(node) = idx.get(&sp)
+                {
+                    roots.insert(node);
+                }
+            } else {
+                resolve_indirect_root(dir, &path, &target, store_prefix, idx, roots)?;
+            }
+        } else if meta.file_type().is_dir() {
+            find_roots_in_dir(&path, store_prefix, idx, roots)?;
+        } else if meta.file_type().is_file() {
+            // Regular file root (e.g. in auto-roots).
+            let name = path.file_name().unwrap_or_default().to_string_lossy();
+            let candidate = format!("{store_prefix}/{name}");
+            if let Some(node) = idx.get(&candidate) {
+                roots.insert(node);
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Indirect root: symlink -> symlink -> store. Nix's findRoots resolves
+/// at most one extra hop. Resolve it with lstat + readlink, never a
+/// following stat(): under fs.protected_symlinks, following a user-owned
+/// link in a sticky directory like /tmp fails with EACCES, even for root.
+fn resolve_indirect_root(
+    dir: &Path,
+    link: &Path,
+    target: &Path,
+    store_prefix: &str,
+    idx: &BasenameIndex,
+    roots: &mut HashSet<NodeIdx>,
+) -> Result<()> {
+    let abs_target = if target.is_absolute() {
+        target.to_path_buf()
+    } else {
+        dir.join(target)
+    };
+    let target_meta = match fs::symlink_metadata(&abs_target) {
+        Ok(m) => m,
+        // First hop gone: the indirect root was removed.
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            remove_stale_auto_link(dir, link);
+            return Ok(());
+        }
+        // EACCES/EIO say nothing about the target's existence. Dropping
+        // the root could let the GC delete a live path.
+        Err(source) => {
+            return Err(Error::Stat {
+                path: abs_target,
+                source,
+            });
+        }
+    };
+    if !target_meta.file_type().is_symlink() {
+        // Plain file or directory: not an indirect store root.
+        return Ok(());
+    }
+    let target2 = match fs::read_link(&abs_target) {
+        Ok(t) => t,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(source) => {
+            return Err(Error::ReadLink {
+                path: abs_target,
+                source,
+            });
+        }
+    };
+    if let Some(sp) = extract_store_path(store_prefix, &target2.to_string_lossy())
+        && let Some(node) = idx.get(&sp)
+    {
+        roots.insert(node);
+        return Ok(());
+    }
+    // No live root behind the link. Clean dangling auto links, but only
+    // when the second hop provably does not exist: EACCES/EIO prove
+    // nothing.
+    let abs_target2 = if target2.is_absolute() {
+        target2
+    } else {
+        abs_target.parent().unwrap_or(Path::new("/")).join(target2)
+    };
+    if fs::symlink_metadata(&abs_target2).is_err_and(|e| e.kind() == std::io::ErrorKind::NotFound) {
+        remove_stale_auto_link(dir, link);
+    }
+    Ok(())
+}
+
+/// Remove a dangling link in gcroots/auto. Component match, not
+/// substring: "gcroots/automatic" must not qualify.
+fn remove_stale_auto_link(dir: &Path, link: &Path) {
+    if dir.ends_with("gcroots/auto") {
+        debug!("removing stale link {}", link.display());
+        fs::remove_file(link).ok();
+    }
+}
+
+/// Extract the top-level store path from a potentially deeper path,
+/// e.g. `/nix/store/abc...-foo/bin/bar` -> `/nix/store/abc...-foo`.
+/// Validates that the basename looks like a store path so `..`, `.links`,
+/// and other directory entries are never treated as candidate roots.
+fn extract_store_path(store_prefix: &str, full_path: &str) -> Option<String> {
+    let rest = full_path.strip_prefix(store_prefix)?.strip_prefix('/')?;
+    let name = rest.split('/').next()?;
+    if !is_store_path_basename(name) {
+        return None;
+    }
+    Some(format!("{store_prefix}/{name}"))
+}
+
+/// True if `name` matches the store-path basename grammar:
+/// `<nix32hash>-<name>` where the hash is 32 chars of `[0-9a-z]`.
+fn is_store_path_basename(name: &str) -> bool {
+    let bytes = name.as_bytes();
+    if bytes.len() < 34 || bytes[32] != b'-' {
+        return false;
+    }
+    bytes[..32]
+        .iter()
+        .all(|&b| b.is_ascii_lowercase() || b.is_ascii_digit())
+        && name[33..].chars().all(is_store_path_char)
+}
+
+/// True for chars allowed in a Nix store path basename.
+/// Mirrors Nix's storePathRegex: `[0-9a-z]+[0-9a-zA-Z+\-._?=]*`.
+/// We accept the union since we extract only the first path component.
+fn is_store_path_char(c: char) -> bool {
+    c.is_ascii_alphanumeric() || matches!(c, '+' | '-' | '.' | '_' | '?' | '=')
+}
+
+/// True if `path` is inside the store directory (not just a string prefix
+/// like `/nix/store-other`). The next char after the prefix must be '/'.
+fn is_in_store(store_prefix: &str, path: &str) -> bool {
+    path.strip_prefix(store_prefix)
+        .is_some_and(|rest| rest.starts_with('/'))
+}
+
+/// Add an absolute path as an unchecked candidate root if it lies in the
+/// store.
+fn add_unchecked(store_prefix: &str, target: &str, unchecked: &mut HashSet<String>) {
+    if is_in_store(store_prefix, target)
+        && let Some(sp) = extract_store_path(store_prefix, target)
+    {
+        unchecked.insert(sp);
+    }
+}
+
+/// Scan a blob (e.g. environ) for embedded store paths using the
+/// store-path char alphabet, not arbitrary delimiters.
+fn scan_blob_for_store_paths(blob: &str, store_prefix: &str, unchecked: &mut HashSet<String>) {
+    let prefix = format!("{store_prefix}/");
+    let mut search_from = 0;
+    while let Some(idx) = blob[search_from..].find(&prefix) {
+        let abs = search_from + idx;
+        let after = abs + prefix.len();
+        let end = blob[after..]
+            .find(|c: char| !is_store_path_char(c))
+            .map(|e| after + e)
+            .unwrap_or(blob.len());
+        // A bare prefix (end == after) is rejected by add_unchecked's
+        // basename validation, no need to special-case it.
+        add_unchecked(store_prefix, &blob[abs..end], unchecked);
+        // end >= after > abs, so progress is guaranteed.
+        search_from = end;
+    }
+}
+
+/// Scan running processes for store paths they reference, mirroring
+/// Nix's `findRuntimeRootsUnchecked`. Returned candidate paths are
+/// *unchecked*: the caller must validate them against the database.
+fn find_runtime_roots(store_prefix: &str) -> HashSet<String> {
+    let mut unchecked = HashSet::default();
+    runtime_roots::scan(store_prefix, &mut unchecked);
+    unchecked
+}
+
+#[cfg(target_os = "linux")]
+mod runtime_roots {
+    use super::{add_unchecked, scan_blob_for_store_paths};
+    use crate::HashSet;
+    use std::fs;
+    use std::path::Path;
+
+    /// Read a /proc symlink, swallowing transient errors (process exited,
+    /// no permissions).
+    fn read_proc_link(path: &Path, store_prefix: &str, unchecked: &mut HashSet<String>) {
+        if let Ok(target) = fs::read_link(path)
+            && target.is_absolute()
+        {
+            add_unchecked(store_prefix, &target.to_string_lossy(), unchecked);
+        }
+    }
+
+    /// Read a /proc/sys file whose content is a path.
+    fn read_file_root(path: &Path, store_prefix: &str, unchecked: &mut HashSet<String>) {
+        if let Ok(content) = fs::read_to_string(path) {
+            add_unchecked(store_prefix, content.trim(), unchecked);
+        }
+    }
+
+    pub fn scan(store_prefix: &str, unchecked: &mut HashSet<String>) {
+        let entries = match fs::read_dir("/proc") {
+            Ok(e) => e,
+            Err(_) => return,
+        };
+
+        for entry in entries.flatten() {
+            let pid = entry.file_name().to_string_lossy().to_string();
+            if pid.is_empty() || !pid.chars().all(|c| c.is_ascii_digit()) {
+                continue;
+            }
+            let pid_dir = entry.path();
+
+            read_proc_link(&pid_dir.join("exe"), store_prefix, unchecked);
+            read_proc_link(&pid_dir.join("cwd"), store_prefix, unchecked);
+
+            if let Ok(fds) = fs::read_dir(pid_dir.join("fd")) {
+                for fd in fds.flatten() {
+                    if !fd.file_name().to_string_lossy().starts_with('.') {
+                        read_proc_link(&fd.path(), store_prefix, unchecked);
+                    }
+                }
+            }
+
+            // /proc/<pid>/maps: the 6th whitespace-separated field is the
+            // mapped file.
+            if let Ok(maps) = fs::read_to_string(pid_dir.join("maps")) {
+                for line in maps.lines() {
+                    if let Some(file) = line.split_whitespace().nth(5)
+                        && file.starts_with('/')
+                    {
+                        add_unchecked(store_prefix, file, unchecked);
+                    }
+                }
+            }
+
+            if let Ok(env_data) =
+                fs::read(pid_dir.join("environ")).map(|d| String::from_utf8_lossy(&d).into_owned())
+            {
+                scan_blob_for_store_paths(&env_data, store_prefix, unchecked);
+            }
+        }
+
+        // Kernel helper paths can also pin store entries.
+        for f in [
+            "/proc/sys/kernel/modprobe",
+            "/proc/sys/kernel/fbsplash",
+            "/proc/sys/kernel/poweroff_cmd",
+        ] {
+            read_file_root(Path::new(f), store_prefix, unchecked);
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        #[test]
+        fn read_file_root_trims_and_extracts() {
+            let tmp = tempfile::tempdir().unwrap();
+            let f = tmp.path().join("modprobe");
+            let sp = "/nix/store/00000000000000000000000000000000-modprobe";
+            fs::write(&f, format!("{sp}/bin/modprobe\n")).unwrap();
+            let mut set = HashSet::default();
+            read_file_root(&f, "/nix/store", &mut set);
+            assert!(set.contains(sp), "{set:?}");
+        }
+
+        #[test]
+        fn read_file_root_ignores_non_store_paths() {
+            let tmp = tempfile::tempdir().unwrap();
+            let f = tmp.path().join("modprobe");
+            fs::write(&f, "/sbin/modprobe\n").unwrap();
+            let mut set = HashSet::default();
+            read_file_root(&f, "/nix/store", &mut set);
+            assert!(set.is_empty());
+        }
+    }
+}
+
+/// macOS: libproc syscalls instead of shelling out to lsof.
+#[cfg(target_os = "macos")]
+mod runtime_roots;
+
+/// Other platforms: no runtime root detection.
+#[cfg(not(any(target_os = "linux", target_os = "macos")))]
+mod runtime_roots {
+    use crate::HashSet;
+    pub fn scan(_store_prefix: &str, _unchecked: &mut HashSet<String>) {}
+}
+
+/// Find temp roots from the temproots directory.
+///
+/// Each file is named by the PID that wrote it and contains
+/// NUL-terminated store paths. A file whose owning process has died is
+/// stale: we can acquire a write lock on it because the owner held one.
+/// Stale files are removed and their roots ignored, mirroring Nix's
+/// `findTempRoots`.
+pub fn find_temp_roots(state_dir: &Path) -> Result<HashSet<String>> {
+    let mut roots = HashSet::default();
+    let temp_dir = state_dir.join("temproots");
+
+    let entries = match fs::read_dir(&temp_dir) {
+        Ok(e) => e,
+        Err(_) => return Ok(roots),
+    };
+
+    for entry in entries.flatten() {
+        let name = entry.file_name();
+        let name = name.to_string_lossy();
+        // Hidden files (e.g. portage's .keep) and non-PID names are not
+        // temp root files.
+        if name.starts_with('.') || !name.chars().all(|c| c.is_ascii_digit()) {
+            continue;
+        }
+
+        let path = entry.path();
+        let temp_root_err = |source| Error::TempRootFile {
+            path: path.clone(),
+            source,
+        };
+        let f = match fs::OpenOptions::new().read(true).write(true).open(&path) {
+            Ok(f) => f,
+            // Owner exited and the file was cleaned up meanwhile.
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => continue,
+            // Anything else (EACCES, EIO) hides live roots. Deleting their
+            // targets would yank paths from under a running builder.
+            Err(e) => return Err(temp_root_err(e)),
+        };
+
+        // The owner holds a write lock while alive. If we can take it,
+        // the file is stale.
+        if let Ok(mut lock) =
+            nix::fcntl::Flock::lock(f, nix::fcntl::FlockArg::LockExclusiveNonblock)
+        {
+            debug!("removing stale temporary roots file {}", path.display());
+            fs::remove_file(&path).ok();
+            // Nix protocol: write "d" after unlinking so a client that
+            // re-acquires its fd sees the marker and recreates the file
+            // instead of writing roots into an unlinked inode.
+            use std::io::Write;
+            let _ = lock.write_all(b"d");
+            continue;
+        }
+
+        let contents = fs::read(&path).map_err(temp_root_err)?;
+
+        // Each path is NUL-terminated. A trailing run without a NUL is a
+        // partial write from a live builder. Drop it.
+        let Some(end) = contents.iter().rposition(|&b| b == 0) else {
+            continue;
+        };
+        for segment in contents[..end].split(|&b| b == 0) {
+            if segment.is_empty() {
+                continue;
+            }
+            if let Ok(s) = std::str::from_utf8(segment) {
+                roots.insert(s.to_string());
+            }
+        }
+    }
+
+    Ok(roots)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use harmonia_store_db::{BasenameIndex, GraphOptions, StoreDb, StoreGraph};
+    use harmonia_store_path::StoreDir;
+
+    const HASH: &str = "abcdefghijklmnopqrstuvwxyz012345"; // 32 chars
+
+    /// Load a graph containing the given store path basenames.
+    fn graph(basenames: &[&str]) -> StoreGraph {
+        let db = StoreDb::open_memory().unwrap();
+        for name in basenames {
+            db.connection()
+                .execute(
+                    "INSERT INTO ValidPaths (path, hash, registrationTime) \
+                     VALUES (?, 'sha256:x', 1)",
+                    [format!("/nix/store/{name}")],
+                )
+                .unwrap();
+        }
+        let options = GraphOptions {
+            keep_derivations: false,
+            keep_outputs: false,
+        };
+        db.load_graph(&StoreDir::default(), &options).unwrap()
+    }
+
+    #[test]
+    fn find_roots_scans_extra_dirs() {
+        let tmp = tempfile::tempdir().unwrap();
+        let state = tmp.path().join("state");
+        fs::create_dir_all(state.join("gcroots")).unwrap();
+        fs::create_dir_all(state.join("profiles")).unwrap();
+        let extra = tmp.path().join("extra-roots");
+        fs::create_dir_all(&extra).unwrap();
+
+        let target = format!("/nix/store/{HASH}-foo");
+        std::os::unix::fs::symlink(&target, extra.join("link")).unwrap();
+
+        let g = graph(&[&format!("{HASH}-foo")]);
+        let idx = BasenameIndex::new(&g);
+        let store_dir = Path::new("/nix/store");
+
+        // Without the extra dir the symlink is invisible.
+        let roots = find_roots(&state, store_dir, &[], &idx).unwrap();
+        assert!(roots.is_empty(), "{roots:?}");
+
+        // With it, the symlink target becomes a root.
+        let roots = find_roots(&state, store_dir, &[extra], &idx).unwrap();
+        let expected = idx.get(&target).unwrap();
+        assert_eq!(roots, vec![expected], "{roots:?}");
+    }
+
+    #[test]
+    fn store_path_basename_grammar() {
+        assert!(is_store_path_basename(&format!("{HASH}-foo")));
+        assert!(is_store_path_basename(&format!("{HASH}-foo-1.2+x_y?z=")));
+        // Too short / missing dash at position 32.
+        assert!(!is_store_path_basename("short"));
+        assert!(!is_store_path_basename(&format!("{HASH}xfoo")));
+        // Uppercase or invalid chars in the hash part.
+        assert!(!is_store_path_basename(
+            "ABCDEFGHIJKLMNOPQRSTUVWXYZ012345-foo"
+        ));
+        // Invalid char in the name part: both halves must hold.
+        assert!(!is_store_path_basename(&format!("{HASH}-foo bar")));
+        // .links and .. must never look like store paths.
+        assert!(!is_store_path_basename(".links"));
+        assert!(!is_store_path_basename(".."));
+    }
+
+    #[test]
+    fn is_in_store_requires_separator() {
+        assert!(is_in_store("/nix/store", "/nix/store/abc"));
+        assert!(!is_in_store("/nix/store", "/nix/store"));
+        assert!(!is_in_store("/nix/store", "/nix/store-other/abc"));
+        assert!(!is_in_store("/nix/store", "/somewhere/else"));
+    }
+
+    #[test]
+    fn extract_store_path_takes_first_component() {
+        let sp = format!("/nix/store/{HASH}-foo");
+        assert_eq!(
+            extract_store_path("/nix/store", &format!("{sp}/bin/bar")),
+            Some(sp.clone())
+        );
+        assert_eq!(extract_store_path("/nix/store", &sp), Some(sp));
+        assert_eq!(
+            extract_store_path("/nix/store", "/nix/store/.links/x"),
+            None
+        );
+        assert_eq!(extract_store_path("/nix/store", "/nix/store"), None);
+    }
+
+    #[test]
+    fn scan_blob_finds_embedded_store_paths() {
+        let sp1 = format!("/nix/store/{HASH}-foo");
+        let sp2 = format!("/nix/store/{HASH}-bar");
+        // Paths embedded mid-blob with trailing junk, and one ending the
+        // blob.
+        let blob = format!("PATH={sp1}/bin:other LD={sp2}");
+        let mut set = HashSet::default();
+        scan_blob_for_store_paths(&blob, "/nix/store", &mut set);
+        assert_eq!(set.len(), 2, "{set:?}");
+        assert!(set.contains(&sp1));
+        assert!(set.contains(&sp2));
+    }
+
+    #[test]
+    fn scan_blob_ignores_bare_prefix() {
+        let mut set = HashSet::default();
+        scan_blob_for_store_paths("x /nix/store/ y /nix/store::", "/nix/store", &mut set);
+        assert!(set.is_empty(), "{set:?}");
+    }
+
+    #[test]
+    fn temp_roots_reads_locked_skips_stale_and_junk() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("temproots");
+        fs::create_dir_all(&dir).unwrap();
+
+        let sp1 = format!("/nix/store/{HASH}-live1");
+        let sp2 = format!("/nix/store/{HASH}-live2");
+        // Live file: owner (us) holds the write lock. The trailing segment
+        // without a NUL is a partial write and must be dropped.
+        let live = dir.join("12345");
+        fs::write(&live, format!("{sp1}\0{sp2}\0partial")).unwrap();
+        let f = fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(&live)
+            .unwrap();
+        let _lock =
+            nix::fcntl::Flock::lock(f, nix::fcntl::FlockArg::LockExclusiveNonblock).unwrap();
+
+        // Stale file: no lock held, must be removed and ignored.
+        let stale = dir.join("999");
+        fs::write(&stale, format!("/nix/store/{HASH}-stale\0")).unwrap();
+
+        // Hidden and non-PID files are not temp roots.
+        fs::write(dir.join(".keep"), b"junk").unwrap();
+        fs::write(dir.join("notapid"), format!("/nix/store/{HASH}-junk\0")).unwrap();
+
+        // Keep an fd on the stale file to observe the "d" marker.
+        let stale_fd = fs::File::open(&stale).unwrap();
+
+        let roots = find_temp_roots(tmp.path()).unwrap();
+        assert!(roots.contains(&sp1));
+        assert!(roots.contains(&sp2));
+        assert_eq!(roots.len(), 2, "{roots:?}");
+        assert!(!stale.exists(), "stale temp roots file removed");
+        // Nix clients detect deletion by reading back a "d" marker.
+        {
+            use std::io::{Read, Seek};
+            let mut f = stale_fd;
+            f.seek(std::io::SeekFrom::Start(0)).unwrap();
+            let mut b = [0u8; 1];
+            f.read_exact(&mut b).unwrap();
+            assert_eq!(&b, b"d", "missing deletion marker");
+        }
+        assert!(dir.join(".keep").exists());
+        assert!(dir.join("notapid").exists());
+    }
+
+    #[test]
+    fn temp_roots_missing_dir_is_empty() {
+        let tmp = tempfile::tempdir().unwrap();
+        assert!(find_temp_roots(tmp.path()).unwrap().is_empty());
+    }
+}

--- a/harmonia-store-gc/src/roots/runtime_roots.rs
+++ b/harmonia-store-gc/src/roots/runtime_roots.rs
@@ -1,0 +1,299 @@
+// SPDX-FileCopyrightText: 2025 Jörg Thalheim
+// SPDX-License-Identifier: MIT
+
+//! macOS runtime root scanning via libproc syscalls, instead of shelling
+//! out to lsof.
+
+// libproc has no safe wrapper in our dependency set. The FFI itself is
+// unavoidable here; every call site keeps its buffer handling local.
+#![allow(unsafe_code)]
+
+use super::{add_unchecked, scan_blob_for_store_paths};
+use crate::HashSet;
+use std::ffi::CStr;
+use std::os::raw::{c_int, c_void};
+
+const PROC_ALL_PIDS: u32 = 1;
+const PROC_PIDLISTFDS: c_int = 1;
+const PROC_PIDVNODEPATHINFO: c_int = 9;
+const PROC_PIDREGIONPATHINFO: c_int = 8;
+// proc_info.h: PROC_PIDFDVNODEINFO is 1 and carries no path;
+// PATHINFO is 2.
+const PROC_PIDFDVNODEPATHINFO: c_int = 2;
+const PROX_FDTYPE_VNODE: u32 = 1;
+const PROC_PIDPATHINFO_MAXSIZE: usize = 4 * 1024;
+const MAXPATHLEN: usize = 1024;
+// sysctl
+const CTL_KERN: c_int = 1;
+const KERN_PROCARGS2: c_int = 49;
+const KERN_ARGMAX: c_int = 8;
+
+unsafe extern "C" {
+    fn proc_listpids(type_: u32, typeinfo: u32, buffer: *mut c_void, buffersize: c_int) -> c_int;
+    fn proc_pidpath(pid: c_int, buffer: *mut c_void, buffersize: u32) -> c_int;
+    fn proc_pidinfo(
+        pid: c_int,
+        flavor: c_int,
+        arg: u64,
+        buffer: *mut c_void,
+        buffersize: c_int,
+    ) -> c_int;
+    fn proc_pidfdinfo(
+        pid: c_int,
+        fd: c_int,
+        flavor: c_int,
+        buffer: *mut c_void,
+        buffersize: c_int,
+    ) -> c_int;
+    fn sysctl(
+        name: *mut c_int,
+        namelen: u32,
+        oldp: *mut c_void,
+        oldlenp: *mut usize,
+        newp: *mut c_void,
+        newlen: usize,
+    ) -> c_int;
+}
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+struct ProcFdInfo {
+    proc_fd: i32,
+    proc_fdtype: u32,
+}
+
+/// Layout of the prefix of struct vnode_info_path / vnode_fdinfowithpath /
+/// proc_regionwithpathinfo: lots of opaque fields, then a NUL-terminated
+/// path at a known offset. We only read the path; using a fixed-size
+/// scratch buffer avoids replicating the full struct definitions.
+fn extract_cstr_path(buf: &[u8]) -> Option<String> {
+    // Path is the trailing MAXPATHLEN bytes; find first NUL there.
+    if buf.len() < MAXPATHLEN {
+        return None;
+    }
+    let path_bytes = &buf[buf.len() - MAXPATHLEN..];
+    let cstr = CStr::from_bytes_until_nul(path_bytes).ok()?;
+    let s = cstr.to_str().ok()?;
+    if s.is_empty() {
+        None
+    } else {
+        Some(s.to_string())
+    }
+}
+
+fn list_pids() -> Vec<i32> {
+    unsafe {
+        let count = proc_listpids(PROC_ALL_PIDS, 0, std::ptr::null_mut(), 0);
+        if count <= 0 {
+            return Vec::new();
+        }
+        let mut pids = vec![0i32; count as usize / std::mem::size_of::<i32>()];
+        let bytes = proc_listpids(
+            PROC_ALL_PIDS,
+            0,
+            pids.as_mut_ptr() as *mut c_void,
+            (pids.len() * std::mem::size_of::<i32>()) as c_int,
+        );
+        if bytes <= 0 {
+            return Vec::new();
+        }
+        pids.truncate(bytes as usize / std::mem::size_of::<i32>());
+        pids.retain(|&p| p > 0);
+        pids
+    }
+}
+
+fn pid_exe(pid: i32, store_prefix: &str, unchecked: &mut HashSet<String>) {
+    let mut buf = vec![0u8; PROC_PIDPATHINFO_MAXSIZE];
+    let n = unsafe { proc_pidpath(pid, buf.as_mut_ptr() as *mut c_void, buf.len() as u32) };
+    if n > 0 {
+        if let Ok(s) = std::str::from_utf8(&buf[..n as usize]) {
+            add_unchecked(store_prefix, s, unchecked);
+        }
+    }
+}
+
+/// proc_vnodepathinfo holds cwd then root, each ending with a path.
+/// sizeof(struct vnode_info_path) = sizeof(struct vnode_info)=152 + MAXPATHLEN = 1176.
+const VNODE_INFO_PATH_SIZE: usize = 152 + MAXPATHLEN;
+
+fn pid_cwd_root(pid: i32, store_prefix: &str, unchecked: &mut HashSet<String>) {
+    // struct proc_vnodepathinfo { vnode_info_path pvi_cdir; vnode_info_path pvi_rdir; }
+    let mut buf = vec![0u8; VNODE_INFO_PATH_SIZE * 2];
+    let n = unsafe {
+        proc_pidinfo(
+            pid,
+            PROC_PIDVNODEPATHINFO,
+            0,
+            buf.as_mut_ptr() as *mut c_void,
+            buf.len() as c_int,
+        )
+    };
+    if n <= 0 {
+        return;
+    }
+    for chunk in buf.chunks(VNODE_INFO_PATH_SIZE) {
+        if let Some(p) = extract_cstr_path(chunk) {
+            add_unchecked(store_prefix, &p, unchecked);
+        }
+    }
+}
+
+/// sizeof(struct vnode_fdinfowithpath) = sizeof(proc_fileinfo)=24
+/// + sizeof(vnode_info_path)=1176 = 1200.
+const VNODE_FDINFO_SIZE: usize = 24 + VNODE_INFO_PATH_SIZE;
+
+fn pid_fds(pid: i32, store_prefix: &str, unchecked: &mut HashSet<String>) {
+    let n = unsafe { proc_pidinfo(pid, PROC_PIDLISTFDS, 0, std::ptr::null_mut(), 0) };
+    if n <= 0 {
+        return;
+    }
+    let count = n as usize / std::mem::size_of::<ProcFdInfo>();
+    let mut fds = vec![
+        ProcFdInfo {
+            proc_fd: 0,
+            proc_fdtype: 0
+        };
+        count
+    ];
+    let n = unsafe {
+        proc_pidinfo(
+            pid,
+            PROC_PIDLISTFDS,
+            0,
+            fds.as_mut_ptr() as *mut c_void,
+            (fds.len() * std::mem::size_of::<ProcFdInfo>()) as c_int,
+        )
+    };
+    if n <= 0 {
+        return;
+    }
+    let count = n as usize / std::mem::size_of::<ProcFdInfo>();
+    let mut buf = vec![0u8; VNODE_FDINFO_SIZE];
+    for fd in &fds[..count] {
+        if fd.proc_fdtype != PROX_FDTYPE_VNODE {
+            continue;
+        }
+        buf.fill(0);
+        let r = unsafe {
+            proc_pidfdinfo(
+                pid,
+                fd.proc_fd,
+                PROC_PIDFDVNODEPATHINFO,
+                buf.as_mut_ptr() as *mut c_void,
+                buf.len() as c_int,
+            )
+        };
+        if r > 0 {
+            if let Some(p) = extract_cstr_path(&buf) {
+                add_unchecked(store_prefix, &p, unchecked);
+            }
+        }
+    }
+}
+
+/// sizeof(struct proc_regionwithpathinfo) = sizeof(proc_regioninfo)=96
+/// + sizeof(vnode_info_path)=1176 = 1272.
+const PROC_REGIONINFO_SIZE: usize = 96;
+const REGION_PATH_INFO_SIZE: usize = PROC_REGIONINFO_SIZE + VNODE_INFO_PATH_SIZE;
+/// proc_regioninfo trailing fields: pri_address (u64), pri_size (u64).
+const PRI_ADDRESS_OFFSET: usize = PROC_REGIONINFO_SIZE - 16;
+const PRI_SIZE_OFFSET: usize = PROC_REGIONINFO_SIZE - 8;
+
+fn pid_regions(pid: i32, store_prefix: &str, unchecked: &mut HashSet<String>) {
+    let mut addr: u64 = 0;
+    let mut buf = vec![0u8; REGION_PATH_INFO_SIZE];
+    // Iterate region by region. Each call returns info for the region
+    // containing/after `addr`; bump addr past it. Cap iterations to
+    // avoid pathological loops.
+    for _ in 0..8192 {
+        buf.fill(0);
+        let r = unsafe {
+            proc_pidinfo(
+                pid,
+                PROC_PIDREGIONPATHINFO,
+                addr,
+                buf.as_mut_ptr() as *mut c_void,
+                buf.len() as c_int,
+            )
+        };
+        if r <= 0 {
+            break;
+        }
+        let pri_address = u64::from_ne_bytes(
+            buf[PRI_ADDRESS_OFFSET..PRI_ADDRESS_OFFSET + 8]
+                .try_into()
+                .unwrap(),
+        );
+        let pri_size = u64::from_ne_bytes(
+            buf[PRI_SIZE_OFFSET..PRI_SIZE_OFFSET + 8]
+                .try_into()
+                .unwrap(),
+        );
+        if let Some(p) = extract_cstr_path(&buf) {
+            add_unchecked(store_prefix, &p, unchecked);
+        }
+        let next = pri_address.saturating_add(pri_size.max(4096));
+        if next <= addr {
+            break;
+        }
+        addr = next;
+    }
+}
+
+fn pid_environ(pid: i32, argmax: usize, store_prefix: &str, unchecked: &mut HashSet<String>) {
+    let mut mib = [CTL_KERN, KERN_PROCARGS2, pid];
+    let mut buf = vec![0u8; argmax];
+    let mut size = argmax;
+    let r = unsafe {
+        sysctl(
+            mib.as_mut_ptr(),
+            mib.len() as u32,
+            buf.as_mut_ptr() as *mut c_void,
+            &mut size,
+            std::ptr::null_mut(),
+            0,
+        )
+    };
+    if r != 0 {
+        return;
+    }
+    // KERN_PROCARGS2 returns argc(4 bytes) + exec_path + NULs + argv + envp.
+    // Just scan whole blob for store path substrings.
+    let size = size.min(buf.len());
+    let blob = String::from_utf8_lossy(&buf[..size]);
+    scan_blob_for_store_paths(&blob, store_prefix, unchecked);
+}
+
+fn kern_argmax() -> usize {
+    let mut mib = [CTL_KERN, KERN_ARGMAX];
+    let mut argmax: c_int = 0;
+    let mut size = std::mem::size_of::<c_int>();
+    let r = unsafe {
+        sysctl(
+            mib.as_mut_ptr(),
+            mib.len() as u32,
+            &mut argmax as *mut c_int as *mut c_void,
+            &mut size,
+            std::ptr::null_mut(),
+            0,
+        )
+    };
+    if r == 0 && argmax > 0 {
+        argmax as usize
+    } else {
+        // sane fallback
+        256 * 1024
+    }
+}
+
+pub fn scan(store_prefix: &str, unchecked: &mut HashSet<String>) {
+    let argmax = kern_argmax();
+    for pid in list_pids() {
+        pid_exe(pid, store_prefix, unchecked);
+        pid_cwd_root(pid, store_prefix, unchecked);
+        pid_fds(pid, store_prefix, unchecked);
+        pid_regions(pid, store_prefix, unchecked);
+        pid_environ(pid, argmax, store_prefix, unchecked);
+    }
+}

--- a/harmonia-store-gc/src/store.rs
+++ b/harmonia-store-gc/src/store.rs
@@ -1,0 +1,141 @@
+// SPDX-FileCopyrightText: 2025 Jörg Thalheim
+// SPDX-License-Identifier: MIT
+
+//! Store handle for garbage collection.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use harmonia_store_db::{GraphOptions, OpenMode, StoreDb};
+use harmonia_store_path::StoreDir;
+
+use crate::error::Result;
+
+/// Everything the garbage collector needs to know about one store: the
+/// open database plus the directory layout around it.
+///
+/// The GC settings in [`GcStore::graph_options`] are initialized from the
+/// host's nix.conf (`keep-derivations`, `keep-outputs`) and can be
+/// overridden before calling [`crate::gc::collect_garbage`].
+///
+/// ```no_run
+/// # fn main() -> harmonia_store_gc::Result<()> {
+/// use std::path::Path;
+/// use harmonia_store_gc::store::GcStore;
+///
+/// let store = GcStore::open(Path::new("/nix/store"), Path::new("/nix/var/nix"))?;
+/// # Ok(())
+/// # }
+/// ```
+pub struct GcStore {
+    /// The store database at `state_dir/db/db.sqlite`.
+    pub db: StoreDb,
+    /// The logical store directory, e.g. `/nix/store`. This is the form
+    /// recorded in the database.
+    pub store_dir: StoreDir,
+    /// The Nix state directory, e.g. `/nix/var/nix`. Holds `gc.lock`,
+    /// `temproots/`, `gc-socket/` and the database.
+    pub state_dir: PathBuf,
+    /// The physical store directory: `store_dir` with symlinks resolved.
+    /// The database records logical paths, but disk operations need real
+    /// ones.
+    pub real_store_dir: PathBuf,
+    /// The hard-link dedup directory `real_store_dir/.links`.
+    pub links_dir: PathBuf,
+    /// Which liveness edges the reference graph should include.
+    pub graph_options: GraphOptions,
+}
+
+impl GcStore {
+    /// Open the store database read-write, as needed for an actual
+    /// collection.
+    pub fn open(store_dir: &Path, state_dir: &Path) -> Result<Self> {
+        Self::open_with_mode(store_dir, state_dir, false)
+    }
+
+    /// Open the store database read-only, for dry runs. No journal-mode
+    /// flip, no write lock. This also works on a read-only filesystem.
+    pub fn open_read_only(store_dir: &Path, state_dir: &Path) -> Result<Self> {
+        Self::open_with_mode(store_dir, state_dir, true)
+    }
+
+    fn open_with_mode(store_dir: &Path, state_dir: &Path, read_only: bool) -> Result<Self> {
+        let store_dir = StoreDir::new(normalize_dir(store_dir))?;
+        let db_path = state_dir.join("db/db.sqlite");
+        let db = if read_only {
+            StoreDb::open_readonly(&db_path)?
+        } else {
+            let db = StoreDb::open(&db_path, OpenMode::ReadWrite)?;
+            configure_for_gc(&db)?;
+            db
+        };
+
+        // Fall back to the logical dir when it cannot be resolved, like
+        // Nix's realStoreDir.
+        let real_store_dir =
+            fs::canonicalize(store_dir.to_path()).unwrap_or_else(|_| store_dir.to_path().into());
+
+        Ok(GcStore {
+            db,
+            state_dir: state_dir.to_owned(),
+            links_dir: real_store_dir.join(".links"),
+            real_store_dir,
+            store_dir,
+            graph_options: GraphOptions {
+                keep_derivations: crate::config::bool_setting("keep-derivations", true),
+                keep_outputs: crate::config::bool_setting("keep-outputs", false),
+            },
+        })
+    }
+}
+
+/// Prepare the connection for GC writes.
+fn configure_for_gc(db: &StoreDb) -> Result<()> {
+    let conn = db.connection();
+    // Install the busy handler first: the journal-mode flip takes a write
+    // lock and would otherwise fail instantly while the daemon writes.
+    conn.busy_timeout(std::time::Duration::from_secs(60))
+        .map_err(harmonia_store_db::Error::from)?;
+    conn.pragma_update(None, "journal_mode", "WAL")
+        .map_err(harmonia_store_db::Error::from)?;
+    conn.pragma_update(None, "synchronous", "NORMAL")
+        .map_err(harmonia_store_db::Error::from)?;
+    Ok(())
+}
+
+/// Strip trailing slashes but keep a bare "/".
+///
+/// The store prefix comparisons throughout the GC append their own '/'.
+/// With a trailing slash left in, every prefix check would miss and the
+/// whole store would look dead.
+fn normalize_dir(dir: &Path) -> PathBuf {
+    use std::os::unix::ffi::{OsStrExt, OsStringExt};
+    let bytes = dir.as_os_str().as_bytes();
+    let mut end = bytes.len();
+    while end > 1 && bytes[end - 1] == b'/' {
+        end -= 1;
+    }
+    PathBuf::from(std::ffi::OsString::from_vec(bytes[..end].to_vec()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalize_dir_strips_trailing_slashes() {
+        assert_eq!(
+            normalize_dir(Path::new("/nix/store/")),
+            Path::new("/nix/store")
+        );
+        assert_eq!(
+            normalize_dir(Path::new("/nix/store//")),
+            Path::new("/nix/store")
+        );
+        assert_eq!(
+            normalize_dir(Path::new("/nix/store")),
+            Path::new("/nix/store")
+        );
+        assert_eq!(normalize_dir(Path::new("/")), Path::new("/"));
+    }
+}

--- a/harmonia-store-gc/src/temp_roots.rs
+++ b/harmonia-store-gc/src/temp_roots.rs
@@ -1,0 +1,290 @@
+// SPDX-FileCopyrightText: 2025 Jörg Thalheim
+// SPDX-License-Identifier: MIT
+
+//! Temp-root client, protocol-compatible with Nix's `addTempRoot`.
+//!
+//! A temp root pins a store path for the lifetime of one process, e.g. a
+//! build that has not registered its outputs yet. Each process owns a
+//! `temproots/<pid>` file holding NUL-terminated store paths. Roots are
+//! registered either under a momentary shared `gc.lock`, or handed to a
+//! running GC through its `gc-socket`.
+
+use std::fs;
+use std::io::{Read, Write};
+use std::os::unix::net::UnixStream;
+use std::path::{Path, PathBuf};
+
+use nix::errno::Errno;
+use nix::fcntl::{Flock, FlockArg};
+
+use crate::error::{Error, Result};
+
+/// `Flock::lock` with retry on EINTR, which the nix crate does not do
+/// itself. A signal (e.g. SIGCHLD in a build supervisor) must not fail
+/// root registration.
+fn flock_retry(mut f: fs::File, arg: FlockArg) -> std::io::Result<Flock<fs::File>> {
+    loop {
+        match Flock::lock(f, arg) {
+            Ok(lock) => return Ok(lock),
+            Err((file, Errno::EINTR)) => f = file,
+            Err((_, errno)) => return Err(errno.into()),
+        }
+    }
+}
+
+/// This process's temp-root registration handle.
+///
+/// While the value lives, every path passed to [`TempRoots::add`] is
+/// protected from garbage collection. Dropping it releases all of them.
+///
+/// ```no_run
+/// # fn main() -> harmonia_store_gc::Result<()> {
+/// use std::path::Path;
+/// use harmonia_store_gc::temp_roots::TempRoots;
+///
+/// let mut roots = TempRoots::create(Path::new("/nix/var/nix"))?;
+/// roots.add("/nix/store/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-example")?;
+/// # Ok(())
+/// # }
+/// ```
+pub struct TempRoots {
+    /// `temproots/<pid>`. We hold the exclusive flock for our lifetime so
+    /// a concurrent GC treats the file as live.
+    file: Flock<fs::File>,
+    /// `gc.lock` fd, locked shared only for the duration of each `add`.
+    /// `None` after an unlock failure. Reopened lazily.
+    gc_lock: Option<fs::File>,
+    gc_lock_path: PathBuf,
+    socket_path: PathBuf,
+    socket: Option<UnixStream>,
+}
+
+fn open_gc_lock(path: &Path) -> Result<fs::File> {
+    use std::os::unix::fs::OpenOptionsExt;
+    fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .mode(0o600)
+        .open(path)
+        .map_err(|source| Error::GcLock {
+            path: path.to_owned(),
+            source,
+        })
+}
+
+impl TempRoots {
+    /// Create (or take over) this process's temp roots file, mirroring
+    /// Nix's `createTempRootsFile`.
+    pub fn create(state_dir: &Path) -> Result<TempRoots> {
+        use std::os::unix::fs::OpenOptionsExt;
+
+        let dir = state_dir.join("temproots");
+        fs::create_dir_all(&dir).map_err(|source| Error::TempRootFile {
+            path: dir.clone(),
+            source,
+        })?;
+        let path = dir.join(std::process::id().to_string());
+        let temp_root_err = |source| Error::TempRootFile {
+            path: path.clone(),
+            source,
+        };
+
+        let file = loop {
+            // An existing file with our pid must be stale: no two live
+            // processes share a pid.
+            let _ = fs::remove_file(&path);
+            let f = fs::OpenOptions::new()
+                .read(true)
+                .write(true)
+                .create(true)
+                .truncate(false)
+                .mode(0o600)
+                .open(&path)
+                .map_err(temp_root_err)?;
+            let locked = flock_retry(f, FlockArg::LockExclusive).map_err(temp_root_err)?;
+            // Non-empty means the GC wrote its "d" marker and unlinked the
+            // file before we got the lock. Retry on a fresh inode.
+            if locked.metadata().map_err(temp_root_err)?.len() == 0 {
+                break locked;
+            }
+        };
+
+        let gc_lock_path = state_dir.join("gc.lock");
+        let gc_lock = open_gc_lock(&gc_lock_path)?;
+
+        Ok(TempRoots {
+            file,
+            gc_lock: Some(gc_lock),
+            gc_lock_path,
+            socket_path: state_dir.join("gc-socket/socket"),
+            socket: None,
+        })
+    }
+
+    /// Register a full store path as a temp root. After this returns, no
+    /// GC will delete the path while this process lives.
+    pub fn add(&mut self, store_path: &str) -> Result<()> {
+        loop {
+            // A shared gc.lock means no GC is running. Hold it across the
+            // write so none starts mid-register.
+            if let Some(guard) = self.try_shared_gc_lock()? {
+                let res = self.write_root(store_path);
+                // Unlock failure drops the fd. Reopened on the next add.
+                self.gc_lock = guard.unlock().ok();
+                return res;
+            }
+            // GC running: hand the root to it over the gc-socket. The
+            // socket may vanish at any time (GC finished). Restart then.
+            match self.notify_gc(store_path)? {
+                true => return self.write_root(store_path),
+                false => continue,
+            }
+        }
+    }
+
+    /// Take the shared gc.lock without blocking. `Ok(None)` means a GC
+    /// holds it exclusively.
+    fn try_shared_gc_lock(&mut self) -> Result<Option<Flock<fs::File>>> {
+        let file = match self.gc_lock.take() {
+            Some(f) => f,
+            None => open_gc_lock(&self.gc_lock_path)?,
+        };
+        match Flock::lock(file, FlockArg::LockSharedNonblock) {
+            Ok(guard) => Ok(Some(guard)),
+            Err((file, Errno::EWOULDBLOCK)) => {
+                self.gc_lock = Some(file);
+                Ok(None)
+            }
+            Err((_, errno)) => Err(Error::GcLock {
+                path: self.gc_lock_path.clone(),
+                source: errno.into(),
+            }),
+        }
+    }
+
+    fn write_root(&mut self, store_path: &str) -> Result<()> {
+        self.file
+            .write_all(format!("{store_path}\0").as_bytes())
+            .map_err(|source| Error::TempRootWrite { source })
+    }
+
+    /// Send the root to the running GC. `Ok(false)` means the GC went
+    /// away and the caller should restart with the lock.
+    fn notify_gc(&mut self, store_path: &str) -> Result<bool> {
+        if self.socket.is_none() {
+            match UnixStream::connect(&self.socket_path) {
+                Ok(s) => self.socket = Some(s),
+                Err(e)
+                    if matches!(
+                        e.kind(),
+                        std::io::ErrorKind::ConnectionRefused | std::io::ErrorKind::NotFound
+                    ) =>
+                {
+                    // GC exited or has not created the socket yet.
+                    std::thread::sleep(std::time::Duration::from_millis(100));
+                    return Ok(false);
+                }
+                Err(source) => {
+                    return Err(Error::GcSocketClient {
+                        path: self.socket_path.clone(),
+                        source,
+                    });
+                }
+            }
+        }
+        let sock = self.socket.as_mut().expect("socket set above");
+        let gone = |e: &std::io::Error| {
+            matches!(
+                e.kind(),
+                std::io::ErrorKind::BrokenPipe
+                    | std::io::ErrorKind::ConnectionReset
+                    | std::io::ErrorKind::UnexpectedEof
+            )
+        };
+        let io = (|| -> std::io::Result<()> {
+            sock.write_all(format!("{store_path}\n").as_bytes())?;
+            let mut ack = [0u8; 1];
+            sock.read_exact(&mut ack)?;
+            if ack != *b"1" {
+                return Err(std::io::Error::other("unexpected gc-socket ack"));
+            }
+            Ok(())
+        })();
+        match io {
+            Ok(()) => Ok(true),
+            Err(e) if gone(&e) => {
+                self.socket = None;
+                Ok(false)
+            }
+            Err(source) => Err(Error::GcSocketClient {
+                path: self.socket_path.clone(),
+                source,
+            }),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn add_writes_nul_terminated_roots() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mut tr = TempRoots::create(tmp.path()).unwrap();
+        tr.add("/nix/store/aaa-x").unwrap();
+        tr.add("/nix/store/bbb-y").unwrap();
+
+        let path = tmp
+            .path()
+            .join("temproots")
+            .join(std::process::id().to_string());
+        let data = fs::read(&path).unwrap();
+        assert_eq!(data, b"/nix/store/aaa-x\0/nix/store/bbb-y\0");
+        // We hold the write lock, so the file reads as live to a GC.
+        let f = fs::File::open(&path).unwrap();
+        assert!(Flock::lock(f, FlockArg::LockExclusiveNonblock).is_err());
+    }
+
+    #[test]
+    fn add_uses_gc_socket_when_gc_holds_the_lock() {
+        use std::io::BufRead;
+        use std::os::unix::net::UnixListener;
+
+        let tmp = tempfile::tempdir().unwrap();
+
+        // Simulate a running GC: exclusive gc.lock + listening socket.
+        let gc_lock = fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .open(tmp.path().join("gc.lock"))
+            .unwrap();
+        let _gc_lock = Flock::lock(gc_lock, FlockArg::LockExclusive).unwrap();
+        fs::create_dir_all(tmp.path().join("gc-socket")).unwrap();
+        let listener = UnixListener::bind(tmp.path().join("gc-socket/socket")).unwrap();
+        let server = std::thread::spawn(move || {
+            let (stream, _) = listener.accept().unwrap();
+            let mut writer = stream.try_clone().unwrap();
+            let mut line = String::new();
+            std::io::BufReader::new(stream)
+                .read_line(&mut line)
+                .unwrap();
+            writer.write_all(b"1").unwrap();
+            line
+        });
+
+        let mut tr = TempRoots::create(tmp.path()).unwrap();
+        tr.add("/nix/store/ccc-z").unwrap();
+
+        assert_eq!(server.join().unwrap(), "/nix/store/ccc-z\n");
+        let path = tmp
+            .path()
+            .join("temproots")
+            .join(std::process::id().to_string());
+        assert_eq!(fs::read(&path).unwrap(), b"/nix/store/ccc-z\0");
+    }
+}

--- a/harmonia-store-gc/tests/integration.rs
+++ b/harmonia-store-gc/tests/integration.rs
@@ -1,0 +1,1347 @@
+use std::fs;
+use std::os::fd::AsRawFd;
+use std::path::PathBuf;
+use std::process::Command;
+
+use rusqlite::Connection;
+
+use harmonia_store_db::{OpenMode, StoreDb};
+
+struct TestStore {
+    #[allow(dead_code)] // keep tempdir alive
+    dir: tempfile::TempDir,
+    store_dir: PathBuf,
+    state_dir: PathBuf,
+}
+
+#[derive(Clone)]
+struct Pkg {
+    id: i64,
+    path: PathBuf,
+    full: String,
+}
+
+/// Derive a store hash from the package name so tests don't have to spell
+/// out 32 chars by hand. Not a real hash, just stable and unique per name.
+fn fake_hash(name: &str) -> String {
+    let mut h: u64 = 0xcbf29ce484222325;
+    for b in name.bytes() {
+        h ^= b as u64;
+        h = h.wrapping_mul(0x100000001b3);
+    }
+    let mut s = String::with_capacity(32);
+    let mut x = h;
+    for _ in 0..32 {
+        s.push(b"0123456789abcdfghijklmnpqrsvwxyz"[(x & 0x1f) as usize] as char);
+        x = x.rotate_left(5) ^ h;
+    }
+    s
+}
+
+impl TestStore {
+    fn new() -> Self {
+        Self::new_inner(false)
+    }
+
+    /// Store dir is a symlink to the real directory, like /nix/store on
+    /// installs with a relocated store. The kernel reports canonical
+    /// paths for fds, the DB stores logical ones.
+    fn new_symlinked() -> Self {
+        Self::new_inner(true)
+    }
+
+    fn new_inner(symlink_store: bool) -> Self {
+        let dir = tempfile::tempdir().unwrap();
+        let store_dir = dir.path().join("store");
+        let state_dir = dir.path().join("state");
+
+        if symlink_store {
+            let real = dir.path().join("store-real");
+            fs::create_dir_all(&real).unwrap();
+            std::os::unix::fs::symlink(&real, &store_dir).unwrap();
+        } else {
+            fs::create_dir_all(&store_dir).unwrap();
+        }
+        for d in ["db", "gcroots", "profiles", "temproots"] {
+            fs::create_dir_all(state_dir.join(d)).unwrap();
+        }
+        fs::create_dir_all(store_dir.join(".links")).unwrap();
+
+        let db = StoreDb::open(state_dir.join("db/db.sqlite"), OpenMode::Create).unwrap();
+        db.create_schema().unwrap();
+
+        TestStore {
+            dir,
+            store_dir,
+            state_dir,
+        }
+    }
+
+    fn db(&self) -> Connection {
+        Connection::open(self.state_dir.join("db/db.sqlite")).unwrap()
+    }
+
+    fn add_path(&self, name: &str, nar_size: u64) -> Pkg {
+        let hash = fake_hash(name);
+        let basename = format!("{hash}-{name}");
+        let path = self.store_dir.join(&basename);
+        let full = format!("{}/{basename}", self.store_dir.display());
+
+        fs::create_dir_all(&path).unwrap();
+        fs::write(path.join("file"), "x".repeat(nar_size as usize)).unwrap();
+
+        let conn = self.db();
+        conn.execute(
+            "INSERT INTO ValidPaths (path, hash, registrationTime, narSize) VALUES (?, ?, 1000, ?)",
+            rusqlite::params![full, format!("sha256:{hash}"), nar_size as i64],
+        )
+        .unwrap();
+        Pkg {
+            id: conn.last_insert_rowid(),
+            path,
+            full,
+        }
+    }
+
+    fn add_ref(&self, referrer: &Pkg, reference: &Pkg) {
+        self.db()
+            .execute(
+                "INSERT OR IGNORE INTO Refs (referrer, reference) VALUES (?, ?)",
+                rusqlite::params![referrer.id, reference.id],
+            )
+            .unwrap();
+    }
+
+    fn set_deriver(&self, out: &Pkg, drv: &Pkg) {
+        self.db()
+            .execute(
+                "UPDATE ValidPaths SET deriver = ? WHERE path = ?",
+                rusqlite::params![drv.full, out.full],
+            )
+            .unwrap();
+    }
+
+    fn set_registration_time(&self, p: &Pkg, time: i64) {
+        self.db()
+            .execute(
+                "UPDATE ValidPaths SET registrationTime = ? WHERE path = ?",
+                rusqlite::params![time, p.full],
+            )
+            .unwrap();
+    }
+
+    fn add_drv_output(&self, drv: &Pkg, output_name: &str, out: &Pkg) {
+        self.db()
+            .execute(
+                "INSERT INTO DerivationOutputs (drv, id, path) VALUES (?, ?, ?)",
+                rusqlite::params![drv.id, output_name, out.full],
+            )
+            .unwrap();
+    }
+
+    /// Insert a BuildTraceV3 row (Nix ≥2.35 schema: drvPath is a store
+    /// path basename, outputPath is a full store path).
+    fn add_build_trace(&self, drv: &Pkg, output_name: &str, out: &Pkg) {
+        let conn = self.db();
+        conn.execute_batch(
+            "CREATE TABLE IF NOT EXISTS BuildTraceV3 (
+                id integer primary key autoincrement not null,
+                drvPath text not null,
+                outputName text not null,
+                outputPath text not null,
+                signatures text
+            );
+            CREATE INDEX IF NOT EXISTS IndexBuildTraceV3 ON BuildTraceV3(drvPath, outputName);",
+        )
+        .unwrap();
+        // drvPath is a basename (no store dir prefix), matching Nix's
+        // DrvOutput::to_string() which skips the store dir.
+        let drv_basename = drv
+            .full
+            .strip_prefix(&format!("{}/", self.store_dir.display()))
+            .unwrap_or(&drv.full);
+        conn.execute(
+            "INSERT INTO BuildTraceV3 (drvPath, outputName, outputPath) VALUES (?, ?, ?)",
+            rusqlite::params![drv_basename, output_name, out.full],
+        )
+        .unwrap();
+    }
+
+    fn add_root(&self, root_name: &str, target: &Pkg) {
+        let link = self.state_dir.join("gcroots").join(root_name);
+        std::os::unix::fs::symlink(&target.path, &link).unwrap();
+    }
+
+    fn in_db(&self, p: &Pkg) -> bool {
+        self.db()
+            .query_row(
+                "SELECT COUNT(*) FROM ValidPaths WHERE path = ?",
+                [&p.full],
+                |r| r.get::<_, i64>(0),
+            )
+            .unwrap()
+            > 0
+    }
+
+    fn run_gc(&self, extra_args: &[&str]) -> std::process::Output {
+        Command::new(env!("CARGO_BIN_EXE_harmonia-gc"))
+            .arg("--store-dir")
+            .arg(&self.store_dir)
+            .arg("--state-dir")
+            .arg(&self.state_dir)
+            .args(extra_args)
+            .output()
+            .unwrap()
+    }
+
+    fn run_gc_ok(&self, extra_args: &[&str]) -> std::process::Output {
+        let out = self.run_gc(extra_args);
+        assert!(
+            out.status.success(),
+            "stderr: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+        out
+    }
+
+    /// Run GC with keep-outputs enabled via CLI flag.
+    fn run_gc_keep_outputs_ok(&self) -> std::process::Output {
+        self.run_gc_ok(&["--keep-outputs", "true"])
+    }
+}
+
+#[test]
+fn gc_deletes_unreferenced_paths() {
+    let store = TestStore::new();
+
+    let lib = store.add_path("lib", 100);
+    let app = store.add_path("app", 200);
+    store.add_ref(&app, &lib);
+    store.add_root("app-root", &app);
+    let dead = store.add_path("dead", 500);
+
+    store.run_gc_ok(&[]);
+
+    assert!(lib.path.exists() && app.path.exists());
+    assert!(store.in_db(&lib) && store.in_db(&app));
+    assert!(!dead.path.exists());
+    assert!(!store.in_db(&dead));
+}
+
+#[test]
+fn gc_dry_run_does_not_delete() {
+    let store = TestStore::new();
+    let dead = store.add_path("dead", 500);
+
+    let out = store.run_gc_ok(&["--dry-run"]);
+
+    assert!(dead.path.exists() && store.in_db(&dead));
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    // narSize of "dead" is 500; the estimate must be summed correctly.
+    assert!(
+        stdout.contains("1 store paths would be deleted (~500 bytes)"),
+        "stdout: {stdout}"
+    );
+}
+
+#[test]
+fn gc_removes_unlocked_tmp_dir() {
+    let store = TestStore::new();
+
+    let tmp = store.store_dir.join("tmp-build-9999");
+    fs::create_dir_all(&tmp).unwrap();
+    fs::write(tmp.join("left-over"), "data").unwrap();
+
+    let out = store.run_gc_ok(&[]);
+
+    assert!(!tmp.exists(), "unlocked tmp dir is garbage");
+    // No shared links exist, so no savings line must be logged.
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(!stderr.contains("currently saving"), "stderr: {stderr}");
+}
+
+#[test]
+fn gc_dry_run_counts_unknown_on_disk() {
+    let store = TestStore::new();
+
+    let unknown = store
+        .store_dir
+        .join(format!("{}-unknown", fake_hash("unknown")));
+    fs::create_dir_all(&unknown).unwrap();
+
+    let out = store.run_gc_ok(&["--dry-run"]);
+
+    assert!(unknown.exists());
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("1 store paths would be deleted (~0 bytes)"),
+        "stdout: {stdout}"
+    );
+}
+
+#[test]
+fn gc_cleans_unused_links_only_when_not_dry_run() {
+    let store = TestStore::new();
+
+    let links = store.store_dir.join(".links");
+    let dead_link = links.join("deadlink");
+    fs::write(&dead_link, "unreferenced").unwrap();
+    let shared_link = links.join("sharedlink");
+    fs::write(&shared_link, "referenced").unwrap();
+    let pkg = store.add_path("linked", 100);
+    store.add_root("linked-root", &pkg);
+    fs::hard_link(&shared_link, pkg.path.join("shared")).unwrap();
+    fs::hard_link(&shared_link, pkg.path.join("shared2")).unwrap();
+
+    store.run_gc_ok(&["--dry-run"]);
+    assert!(dead_link.exists(), "dry run must not clean links");
+
+    let out = store.run_gc_ok(&[]);
+    assert!(!dead_link.exists(), "unreferenced link removed");
+    assert!(shared_link.exists(), "referenced link kept");
+    // "referenced" is 10 bytes with nlink 3 (one .links entry + two store
+    // copies): dedup saves (3-2)*10 over independent copies.
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("currently saving 10 bytes"),
+        "stderr: {stderr}"
+    );
+}
+
+#[test]
+fn gc_keeps_transitive_closure() {
+    let store = TestStore::new();
+
+    let c = store.add_path("c", 10);
+    let b = store.add_path("b", 10);
+    let a = store.add_path("a", 10);
+    store.add_ref(&a, &b);
+    store.add_ref(&b, &c);
+    store.add_root("root", &a);
+    let trash = store.add_path("trash", 10);
+
+    store.run_gc_ok(&[]);
+
+    assert!(a.path.exists() && b.path.exists() && c.path.exists());
+    assert!(!trash.path.exists());
+}
+
+#[test]
+fn gc_handles_self_references() {
+    let store = TestStore::new();
+
+    let s = store.add_path("self-ref", 100);
+    store.add_ref(&s, &s);
+    store.add_root("root", &s);
+    let trash = store.add_path("trash", 50);
+
+    store.run_gc_ok(&[]);
+
+    assert!(s.path.exists());
+    assert!(!trash.path.exists());
+}
+
+#[test]
+fn gc_removes_unknown_disk_entries() {
+    let store = TestStore::new();
+
+    let orphan = store
+        .store_dir
+        .join(format!("{}-orphan", fake_hash("orphan")));
+    fs::create_dir_all(&orphan).unwrap();
+    fs::write(orphan.join("stuff"), "data").unwrap();
+
+    store.run_gc_ok(&[]);
+
+    assert!(!orphan.exists());
+}
+
+/// A path registered after the graph snapshot, whose owner exited right
+/// after the DB commit (stale temp root), shows up in the unknown-on-disk
+/// scan. GC must not unlink it: that would leave a ValidPaths row without
+/// a disk entry.
+#[test]
+fn gc_keeps_unknown_path_registered_after_snapshot() {
+    let store = TestStore::new();
+
+    // Anchor path so the store isn't empty.
+    let root = store.add_path("root", 10);
+    store.add_root("keep", &root);
+
+    // On disk before GC starts, not yet in the DB: shows up in the
+    // unknown-on-disk scan.
+    let basename = format!("{}-late", fake_hash("late"));
+    let late_path = store.store_dir.join(&basename);
+    fs::create_dir_all(&late_path).unwrap();
+    fs::write(late_path.join("file"), "data").unwrap();
+    let late_full = format!("{}/{basename}", store.store_dir.display());
+
+    // GC blocks on this fifo after the snapshot + unknown scan.
+    let fifo = store.state_dir.join("sync.fifo");
+    nix::unistd::mkfifo(&fifo, nix::sys::stat::Mode::from_bits(0o600).unwrap()).unwrap();
+
+    let mut child = Command::new(env!("CARGO_BIN_EXE_harmonia-gc"))
+        .arg("--store-dir")
+        .arg(&store.store_dir)
+        .arg("--state-dir")
+        .arg(&store.state_dir)
+        .env("_HARMONIA_GC_TEST_SYNC", &fifo)
+        .spawn()
+        .unwrap();
+
+    // Blocks until GC opened the read end, i.e. the snapshot and the
+    // unknown-on-disk scan are done.
+    let fifo_w = fs::OpenOptions::new().write(true).open(&fifo).unwrap();
+
+    // The "builder" registers the path; its temp root file is already gone.
+    store
+        .db()
+        .execute(
+            "INSERT INTO ValidPaths (path, hash, registrationTime, narSize) VALUES (?, ?, 2000, 4)",
+            rusqlite::params![late_full, format!("sha256:{}", fake_hash("late"))],
+        )
+        .unwrap();
+
+    drop(fifo_w);
+    let status = child.wait().unwrap();
+    assert!(status.success());
+
+    let in_db = store
+        .db()
+        .query_row(
+            "SELECT COUNT(*) FROM ValidPaths WHERE path = ?",
+            [&late_full],
+            |r| r.get::<_, i64>(0),
+        )
+        .unwrap()
+        > 0;
+    assert!(in_db, "registered path lost its ValidPaths row");
+    assert!(
+        late_path.exists(),
+        "disk entry deleted while ValidPaths row exists (stale DB entry)"
+    );
+}
+
+#[test]
+fn gc_max_freed_stops_early() {
+    use harmonia_store_gc::gc::{GcOptions, collect_garbage};
+    use harmonia_store_gc::store::GcStore;
+    let store = TestStore::new();
+    store.add_path("dead1", 100);
+    store.add_path("dead2", 100);
+
+    let gc_store = GcStore::open(&store.store_dir, &store.state_dir).unwrap();
+    let opts = GcOptions {
+        max_freed: Some(1),
+        ..Default::default()
+    };
+    let (_, deleted) = collect_garbage(&gc_store, &opts).unwrap();
+
+    assert_eq!(deleted, 1, "should stop after one path");
+}
+
+#[test]
+fn gc_max_freed_batches_by_estimated_size() {
+    use harmonia_store_gc::gc::{GcOptions, collect_garbage};
+    use harmonia_store_gc::store::GcStore;
+    let store = TestStore::new();
+    // narSize 100 each, budget 250: first chunk = 3 paths (100+100+100 >= 250).
+    // Real on-disk usage exceeds 250 after that, so the loop stops at 3.
+    for i in 0..6 {
+        store.add_path(&format!("dead{i}"), 100);
+    }
+
+    let gc_store = GcStore::open(&store.store_dir, &store.state_dir).unwrap();
+    let opts = GcOptions {
+        max_freed: Some(250),
+        ..Default::default()
+    };
+    let (_, deleted) = collect_garbage(&gc_store, &opts).unwrap();
+
+    assert_eq!(deleted, 3, "first chunk must batch three paths by narSize");
+}
+
+#[test]
+fn gc_max_freed_referrer_never_outlives_reference() {
+    use harmonia_store_gc::gc::{GcOptions, collect_garbage};
+    use harmonia_store_gc::store::GcStore;
+    let store = TestStore::new();
+    // dep has the lower id, so the first chunk picks it while top still
+    // references it. Without referrer expansion the early stop leaves top
+    // valid in the DB pointing at a deleted row.
+    let dep = store.add_path("dead-dep", 100);
+    let top = store.add_path("dead-top", 100);
+    store.add_ref(&top, &dep);
+
+    let gc_store = GcStore::open(&store.store_dir, &store.state_dir).unwrap();
+    let opts = GcOptions {
+        max_freed: Some(1), // stop after the first chunk
+        ..Default::default()
+    };
+    collect_garbage(&gc_store, &opts).unwrap();
+
+    let conn = store.db();
+    let valid = |full: &str| -> i64 {
+        conn.query_row(
+            "SELECT COUNT(*) FROM ValidPaths WHERE path = ?",
+            [full],
+            |r| r.get(0),
+        )
+        .unwrap()
+    };
+    // top surviving the early stop is fine, but only together with dep.
+    assert!(
+        valid(&top.full) == 0 || valid(&dep.full) == 1,
+        "referrer outlived its reference in the DB"
+    );
+}
+
+#[test]
+fn gc_chunk_size_one_deletes_whole_dead_chain() {
+    use harmonia_store_gc::gc::{GcOptions, collect_garbage};
+    use harmonia_store_gc::store::GcStore;
+    let store = TestStore::new();
+    // A reference chain a -> b -> c, all dead. With one path per
+    // transaction, referrer-first order must still delete every node and
+    // never leave a surviving referrer pointing at a deleted reference.
+    let c = store.add_path("dead-c", 100);
+    let b = store.add_path("dead-b", 100);
+    let a = store.add_path("dead-a", 100);
+    store.add_ref(&a, &b);
+    store.add_ref(&b, &c);
+
+    let gc_store = GcStore::open(&store.store_dir, &store.state_dir).unwrap();
+    let opts = GcOptions {
+        chunk_size: Some(1),
+        ..Default::default()
+    };
+    collect_garbage(&gc_store, &opts).unwrap();
+
+    for p in [&a, &b, &c] {
+        assert!(!p.path.exists(), "{} should be GC'd", p.full);
+    }
+    let conn = store.db();
+    let remaining: i64 = conn
+        .query_row("SELECT COUNT(*) FROM ValidPaths", [], |r| r.get(0))
+        .unwrap();
+    assert_eq!(remaining, 0, "all dead paths should be invalidated");
+}
+
+#[test]
+fn gc_keep_recent_pins_recently_registered() {
+    use harmonia_store_gc::gc::{GcOptions, collect_garbage};
+    use harmonia_store_gc::store::GcStore;
+    let store = TestStore::new();
+
+    let old = store.add_path("old", 100);
+    let recent = store.add_path("recent", 100);
+    store.set_registration_time(&old, 1000);
+    store.set_registration_time(&recent, 5000);
+
+    let gc_store = GcStore::open(&store.store_dir, &store.state_dir).unwrap();
+    let opts = GcOptions {
+        keep_recent_after: Some(3000),
+        ..Default::default()
+    };
+    collect_garbage(&gc_store, &opts).unwrap();
+
+    assert!(!old.path.exists(), "old path should be GC'd");
+    assert!(
+        recent.path.exists(),
+        "recent path should survive --keep-recent"
+    );
+}
+
+// libproc on macOS can't inspect other processes inside the nix
+// sandbox; we can only test this via /proc on Linux.
+#[cfg(target_os = "linux")]
+#[test]
+// pre_exec to pass an inherited fd needs unsafe.
+#[allow(unsafe_code)]
+fn gc_keeps_runtime_roots_from_open_fd() {
+    use std::os::unix::process::CommandExt;
+    let store = TestStore::new();
+
+    let held = store.add_path("held", 100);
+    let trash = store.add_path("trash", 100);
+
+    // Inherit an fd into the child so the path shows up in the GC's
+    // own /proc/<pid>/fd. Sandboxes can't always inspect other PIDs.
+    let f = fs::File::open(held.path.join("file")).unwrap();
+    let raw_fd = f.as_raw_fd();
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_harmonia-gc"));
+    cmd.arg("--store-dir")
+        .arg(&store.store_dir)
+        .arg("--state-dir")
+        .arg(&store.state_dir);
+    unsafe {
+        cmd.pre_exec(move || {
+            use nix::fcntl::{F_GETFD, F_SETFD, FdFlag, fcntl};
+            use std::os::fd::BorrowedFd;
+            let fd = BorrowedFd::borrow_raw(raw_fd);
+            if let Ok(flags) = fcntl(fd, F_GETFD) {
+                let mut flags = FdFlag::from_bits_truncate(flags);
+                flags.remove(FdFlag::FD_CLOEXEC);
+                let _ = fcntl(fd, F_SETFD(flags));
+            }
+            Ok(())
+        });
+    }
+    let out = cmd.output().unwrap();
+    drop(f);
+    assert!(
+        out.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    assert!(held.path.exists() && store.in_db(&held));
+    assert!(!trash.path.exists());
+}
+
+#[test]
+// pre_exec to pass an inherited fd needs unsafe.
+#[allow(unsafe_code)]
+fn gc_rebases_canonical_runtime_roots_to_logical_store() {
+    use std::os::unix::process::CommandExt;
+    let store = TestStore::new_symlinked();
+
+    let held = store.add_path("held", 100);
+    let trash = store.add_path("trash", 100);
+
+    // Open via the canonical (symlink-resolved) path; /proc/<pid>/fd will
+    // report that path, which must be rebased to the logical store prefix
+    // before DB validation.
+    let canon = fs::canonicalize(held.path.join("file")).unwrap();
+    assert_ne!(canon, held.path.join("file"));
+    let f = fs::File::open(&canon).unwrap();
+    let raw_fd = f.as_raw_fd();
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_harmonia-gc"));
+    cmd.arg("--store-dir")
+        .arg(&store.store_dir)
+        .arg("--state-dir")
+        .arg(&store.state_dir);
+    unsafe {
+        cmd.pre_exec(move || {
+            use nix::fcntl::{F_GETFD, F_SETFD, FdFlag, fcntl};
+            use std::os::fd::BorrowedFd;
+            let fd = BorrowedFd::borrow_raw(raw_fd);
+            if let Ok(flags) = fcntl(fd, F_GETFD) {
+                let mut flags = FdFlag::from_bits_truncate(flags);
+                flags.remove(FdFlag::FD_CLOEXEC);
+                let _ = fcntl(fd, F_SETFD(flags));
+            }
+            Ok(())
+        });
+    }
+    let out = cmd.output().unwrap();
+    drop(f);
+    assert!(
+        out.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    assert!(held.path.exists() && store.in_db(&held));
+    assert!(!trash.path.exists());
+}
+
+#[test]
+fn gc_keeps_runtime_roots_from_environ() {
+    let store = TestStore::new();
+
+    let held = store.add_path("held", 100);
+    let trash = store.add_path("trash", 100);
+
+    // Pin via the child's environment, scanned from /proc/<pid>/environ.
+    let out = Command::new(env!("CARGO_BIN_EXE_harmonia-gc"))
+        .arg("--store-dir")
+        .arg(&store.store_dir)
+        .arg("--state-dir")
+        .arg(&store.state_dir)
+        .env("HARMONIA_GC_TEST_PIN", &held.full)
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    assert!(held.path.exists() && store.in_db(&held));
+    assert!(!trash.path.exists());
+}
+
+#[test]
+fn gc_runtime_roots_validated_against_db() {
+    let store = TestStore::new();
+
+    // On disk and held open, but not in the DB. Runtime-root scan must
+    // not pin an invalid path.
+    let orphan = store
+        .store_dir
+        .join(format!("{}-orphan", fake_hash("orphan")));
+    fs::create_dir_all(&orphan).unwrap();
+    fs::write(orphan.join("file"), "data").unwrap();
+    let _fd = fs::File::open(orphan.join("file")).unwrap();
+
+    store.run_gc_ok(&[]);
+
+    assert!(!orphan.exists());
+}
+
+#[test]
+fn gc_skips_locked_tmp_dir() {
+    let store = TestStore::new();
+
+    let tmp = store.store_dir.join("tmp-build-1234");
+    fs::create_dir_all(&tmp).unwrap();
+    fs::write(tmp.join("in-progress"), "data").unwrap();
+
+    let f = fs::File::open(&tmp).unwrap();
+    let lock = nix::fcntl::Flock::lock(f, nix::fcntl::FlockArg::LockExclusiveNonblock)
+        .expect("flock tmp dir");
+
+    store.run_gc_ok(&[]);
+
+    assert!(tmp.exists(), "locked tmp dir should survive");
+    drop(lock);
+}
+
+#[test]
+fn gc_deletes_readonly_paths() {
+    use std::os::unix::fs::PermissionsExt;
+    let store = TestStore::new();
+
+    let ro = store.add_path("readonly", 100);
+    fs::set_permissions(&ro.path, fs::Permissions::from_mode(0o555)).unwrap();
+    fs::set_permissions(ro.path.join("file"), fs::Permissions::from_mode(0o444)).unwrap();
+
+    store.run_gc_ok(&[]);
+
+    assert!(!ro.path.exists());
+}
+
+#[test]
+fn gc_ignores_invalid_store_basenames() {
+    let store = TestStore::new();
+
+    // gcroot pointing at something inside the store dir that isn't a
+    // store path (no hash-name prefix) — must not become a root.
+    let bogus = store.store_dir.join("not-a-store-path");
+    fs::create_dir_all(&bogus).unwrap();
+    std::os::unix::fs::symlink(&bogus, store.state_dir.join("gcroots/bogus")).unwrap();
+
+    let trash = store.add_path("trash", 100);
+
+    store.run_gc_ok(&[]);
+
+    assert!(!trash.path.exists());
+    assert!(!bogus.exists());
+}
+
+#[test]
+fn gc_keeps_deriver_of_alive_path() {
+    let store = TestStore::new();
+
+    let drv = store.add_path("pkg.drv", 50);
+    let out = store.add_path("pkg", 200);
+    store.set_deriver(&out, &drv);
+    store.add_root("out-root", &out);
+    let trash = store.add_path("trash", 100);
+
+    store.run_gc_ok(&[]);
+
+    // keep-derivations: rooted output keeps its .drv alive.
+    assert!(out.path.exists() && drv.path.exists());
+    assert!(!trash.path.exists());
+}
+
+#[test]
+fn gc_deletes_drv_when_output_deriver_is_unset() {
+    let store = TestStore::new();
+
+    // Output with NULL deriver but a DerivationOutputs row: Nix's
+    // keep-derivations pins drvs only via ValidPaths.deriver (gc.cc
+    // requires queryPathInfo(out)->deriver == drv), so the drv is garbage.
+    let drv = store.add_path("ca-pkg.drv", 50);
+    let out = store.add_path("ca-pkg", 200);
+    store.add_drv_output(&drv, "out", &out);
+    store.add_root("ca-out-root", &out);
+
+    store.run_gc_ok(&[]);
+
+    assert!(out.path.exists(), "output deleted");
+    assert!(
+        !drv.path.exists(),
+        "drv kept despite no alive path naming it as deriver"
+    );
+}
+
+#[test]
+fn gc_keeps_ca_outputs_of_alive_drv() {
+    let store = TestStore::new();
+
+    // Alive .drv should keep its outputs via DerivationOutputs.
+    let drv = store.add_path("ca-pkg.drv", 50);
+    let out = store.add_path("ca-pkg", 200);
+    store.add_drv_output(&drv, "out", &out);
+    store.add_root("drv-root", &drv);
+    let trash = store.add_path("trash", 100);
+
+    store.run_gc_keep_outputs_ok();
+
+    // keep-outputs: alive .drv keeps its outputs alive.
+    assert!(drv.path.exists(), "drv deleted");
+    assert!(out.path.exists(), "CA output deleted despite alive drv");
+    assert!(!trash.path.exists());
+}
+
+#[test]
+fn gc_drops_partial_temp_root() {
+    let store = TestStore::new();
+
+    let complete = store.add_path("complete", 100);
+    let partial = store.add_path("partial", 100);
+
+    // Trailing entry without a NUL is a partial write — must not pin.
+    let tmp_file = store.state_dir.join("temproots/99999");
+    let mut data = complete.full.clone().into_bytes();
+    data.push(0);
+    data.extend_from_slice(partial.full.as_bytes());
+    fs::write(&tmp_file, &data).unwrap();
+
+    let f = fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .open(&tmp_file)
+        .unwrap();
+    let lock = nix::fcntl::Flock::lock(f, nix::fcntl::FlockArg::LockSharedNonblock)
+        .expect("flock temp roots file");
+
+    store.run_gc_ok(&[]);
+
+    assert!(complete.path.exists());
+    assert!(!partial.path.exists());
+    drop(lock);
+}
+
+#[test]
+fn gc_keeps_temp_root_not_yet_in_db() {
+    let store = TestStore::new();
+
+    // Simulate a builder that wrote a temp root and materialized the
+    // store path on disk, but hasn't registered it in ValidPaths yet.
+    let hash = fake_hash("in-progress");
+    let basename = format!("{hash}-in-progress");
+    let path = store.store_dir.join(&basename);
+    fs::create_dir_all(&path).unwrap();
+    fs::write(path.join("file"), "building").unwrap();
+
+    let tmp_file = store.state_dir.join("temproots/12345");
+    let mut data = format!("{}/{basename}", store.store_dir.display()).into_bytes();
+    data.push(0);
+    fs::write(&tmp_file, &data).unwrap();
+
+    let f = fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .open(&tmp_file)
+        .unwrap();
+    let lock = nix::fcntl::Flock::lock(f, nix::fcntl::FlockArg::LockSharedNonblock)
+        .expect("flock temp roots file");
+
+    store.run_gc_ok(&[]);
+
+    assert!(
+        path.exists(),
+        "path with temp root deleted as unknown-on-disk"
+    );
+    drop(lock);
+}
+
+#[test]
+fn gc_removes_stale_temp_roots_file() {
+    let store = TestStore::new();
+
+    // Temp roots file with no live owner — its roots are ignored.
+    let dead = store.add_path("dead", 100);
+    let tmp_file = store.state_dir.join("temproots/12345");
+    let mut data = dead.full.clone().into_bytes();
+    data.push(0);
+    fs::write(&tmp_file, &data).unwrap();
+
+    store.run_gc_ok(&[]);
+
+    assert!(!tmp_file.exists());
+    assert!(!dead.path.exists());
+}
+
+#[test]
+fn gc_empty_store_is_noop() {
+    let store = TestStore::new();
+    let out = store.run_gc_ok(&[]);
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("0 store paths deleted"), "stdout: {stdout}");
+}
+
+#[test]
+fn gc_keeps_ca_output_via_build_trace() {
+    // Dynamic / CA derivation: BuildTraceV3 maps drv→output.
+    // With keep-outputs, alive drv keeps its CA output via BuildTraceV3.
+    let store = TestStore::new();
+
+    let drv = store.add_path("dyn-pkg.drv", 50);
+    let out = store.add_path("dyn-pkg-out", 200);
+    // No DerivationOutputs entry — only BuildTraceV3.
+    store.add_build_trace(&drv, "out", &out);
+    store.add_root("drv-root", &drv);
+    let trash = store.add_path("trash", 100);
+
+    store.run_gc_keep_outputs_ok();
+
+    assert!(drv.path.exists(), "drv deleted");
+    assert!(
+        out.path.exists(),
+        "CA output deleted despite alive drv (BuildTraceV3)"
+    );
+    assert!(!trash.path.exists());
+}
+
+#[test]
+fn gc_keeps_ca_deriver_via_deriver_field_not_build_trace() {
+    // An alive CA output keeps its drv only through ValidPaths.deriver,
+    // like Nix; a BuildTraceV3 row alone must not pin the drv (the
+    // output may have been rebuilt by a newer drv since).
+    let store = TestStore::new();
+
+    let stale_drv = store.add_path("dyn-pkg-old.drv", 50);
+    let drv = store.add_path("dyn-pkg.drv", 50);
+    let out = store.add_path("dyn-pkg-out", 200);
+    store.add_build_trace(&stale_drv, "out", &out);
+    store.add_build_trace(&drv, "out", &out);
+    store.set_deriver(&out, &drv);
+    store.add_root("out-root", &out);
+
+    store.run_gc_ok(&[]);
+
+    assert!(out.path.exists(), "output deleted");
+    assert!(drv.path.exists(), "deriver deleted despite alive output");
+    assert!(
+        !stale_drv.path.exists(),
+        "stale drv kept via BuildTraceV3 alone"
+    );
+}
+
+#[test]
+fn gc_store_dir_trailing_slash_is_normalized() {
+    // "--store-dir /path/" must behave like "--store-dir /path"; an
+    // unnormalized prefix would make every DB path look dead.
+    let store = TestStore::new();
+    let lib = store.add_path("lib", 100);
+    store.add_root("lib-root", &lib);
+
+    let out = Command::new(env!("CARGO_BIN_EXE_harmonia-gc"))
+        .arg("--store-dir")
+        .arg(format!("{}/", store.store_dir.display()))
+        .arg("--state-dir")
+        .arg(&store.state_dir)
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(lib.path.exists() && store.in_db(&lib), "live path deleted");
+}
+
+#[test]
+fn gc_refuses_store_dir_mismatching_db() {
+    // A store dir that matches no DB path means the DB belongs to a
+    // different store; deleting "garbage" would wipe everything.
+    let store = TestStore::new();
+    let lib = store.add_path("lib", 100);
+    store.add_root("lib-root", &lib);
+
+    let other = store.dir.path().join("other-store");
+    fs::create_dir_all(&other).unwrap();
+    let out = Command::new(env!("CARGO_BIN_EXE_harmonia-gc"))
+        .arg("--store-dir")
+        .arg(&other)
+        .arg("--state-dir")
+        .arg(&store.state_dir)
+        .output()
+        .unwrap();
+    assert!(
+        !out.status.success(),
+        "GC must refuse a mismatched store dir"
+    );
+    assert!(lib.path.exists() && store.in_db(&lib));
+}
+
+#[test]
+fn gc_fails_when_roots_dir_is_unreadable() {
+    use std::os::unix::fs::PermissionsExt;
+    if nix::unistd::geteuid().is_root() {
+        // Root bypasses permission checks; cannot simulate EACCES.
+        return;
+    }
+    let store = TestStore::new();
+    let lib = store.add_path("lib", 100);
+    let sub = store.state_dir.join("gcroots/sub");
+    fs::create_dir_all(&sub).unwrap();
+    std::os::unix::fs::symlink(&lib.path, sub.join("lib-root")).unwrap();
+    fs::set_permissions(&sub, fs::Permissions::from_mode(0o000)).unwrap();
+
+    let out = store.run_gc(&[]);
+
+    fs::set_permissions(&sub, fs::Permissions::from_mode(0o755)).unwrap();
+    assert!(
+        !out.status.success(),
+        "GC must fail closed when a roots dir is unreadable"
+    );
+    assert!(lib.path.exists() && store.in_db(&lib), "live path deleted");
+}
+
+#[test]
+fn gc_keeps_auto_root_with_unreadable_target() {
+    use std::os::unix::fs::PermissionsExt;
+    if nix::unistd::geteuid().is_root() {
+        return; // root bypasses permission checks
+    }
+    // An EACCES on the indirect target says nothing about its existence;
+    // the auto link must survive and the GC must fail closed.
+    let store = TestStore::new();
+    let lib = store.add_path("lib", 100);
+    let auto = store.state_dir.join("gcroots/auto");
+    fs::create_dir_all(&auto).unwrap();
+    let private = store.dir.path().join("private");
+    fs::create_dir_all(&private).unwrap();
+    let user_link = private.join("result");
+    std::os::unix::fs::symlink(&lib.path, &user_link).unwrap();
+    std::os::unix::fs::symlink(&user_link, auto.join("x0")).unwrap();
+    fs::set_permissions(&private, fs::Permissions::from_mode(0o000)).unwrap();
+
+    let out = store.run_gc(&[]);
+
+    fs::set_permissions(&private, fs::Permissions::from_mode(0o755)).unwrap();
+    assert!(!out.status.success(), "GC must fail closed");
+    assert!(
+        auto.join("x0").symlink_metadata().is_ok(),
+        "auto root removed"
+    );
+    assert!(lib.path.exists());
+}
+
+#[test]
+fn gc_keeps_indirect_auto_root() {
+    // auto link -> user symlink -> store path. This covers ordinary
+    // indirect-root retention; the next test covers an unfollowable second hop,
+    // which is the property protected_symlinks exposes in practice.
+    let store = TestStore::new();
+    let lib = store.add_path("lib", 100);
+    let auto = store.state_dir.join("gcroots/auto");
+    fs::create_dir_all(&auto).unwrap();
+    let user_link = store.dir.path().join("result");
+    std::os::unix::fs::symlink(&lib.path, &user_link).unwrap();
+    std::os::unix::fs::symlink(&user_link, auto.join("x0")).unwrap();
+
+    store.run_gc_ok(&[]);
+
+    assert!(
+        lib.path.exists() && store.in_db(&lib),
+        "indirect root deleted"
+    );
+    assert!(
+        auto.join("x0").symlink_metadata().is_ok(),
+        "live auto root removed"
+    );
+}
+
+#[test]
+fn gc_scans_roots_despite_unfollowable_indirect_target() {
+    use std::os::unix::fs::PermissionsExt;
+    if nix::unistd::geteuid().is_root() {
+        return; // root bypasses permission checks
+    }
+    // A readable link whose target only fails to resolve *through* it
+    // (here: second hop in a mode-000 dir, standing in for
+    // fs.protected_symlinks, which a test cannot flip) is provably not a
+    // store root — the scan must carry on, not abort.
+    let store = TestStore::new();
+    let lib = store.add_path("lib", 100);
+    store.add_root("keep", &lib);
+    let auto = store.state_dir.join("gcroots/auto");
+    fs::create_dir_all(&auto).unwrap();
+    let private = store.dir.path().join("private");
+    fs::create_dir_all(&private).unwrap();
+    fs::write(private.join("notes"), "").unwrap();
+    let user_link = store.dir.path().join("result");
+    std::os::unix::fs::symlink(private.join("notes"), &user_link).unwrap();
+    std::os::unix::fs::symlink(&user_link, auto.join("x0")).unwrap();
+    fs::set_permissions(&private, fs::Permissions::from_mode(0o000)).unwrap();
+
+    let out = store.run_gc(&[]);
+
+    fs::set_permissions(&private, fs::Permissions::from_mode(0o755)).unwrap();
+    assert!(
+        out.status.success(),
+        "scan aborted on unfollowable non-store target: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(lib.path.exists() && store.in_db(&lib), "live path deleted");
+    assert!(
+        auto.join("x0").symlink_metadata().is_ok(),
+        "auto root with unprovable target removed"
+    );
+}
+
+#[test]
+fn gc_removes_dangling_auto_root() {
+    let store = TestStore::new();
+    let auto = store.state_dir.join("gcroots/auto");
+    fs::create_dir_all(&auto).unwrap();
+    std::os::unix::fs::symlink(store.dir.path().join("gone"), auto.join("x1")).unwrap();
+
+    store.run_gc_ok(&[]);
+
+    assert!(
+        auto.join("x1").symlink_metadata().is_err(),
+        "dangling auto root must be removed"
+    );
+}
+
+#[test]
+fn gc_keeps_lock_file_of_active_build() {
+    let store = TestStore::new();
+
+    // Builder holds a temp root for the path it is building; its .lock
+    // sibling (not in the DB) shares the hash part and must survive.
+    let alive = store.add_path("being-built", 100);
+    let basename = alive
+        .full
+        .strip_prefix(&format!("{}/", store.store_dir.display()))
+        .unwrap();
+    let lock_file = store.store_dir.join(format!("{basename}.lock"));
+    fs::write(&lock_file, "").unwrap();
+    // Unrelated stale lock file: still garbage.
+    let stale_lock = store
+        .store_dir
+        .join(format!("{}-stale.lock", fake_hash("stale")));
+    fs::write(&stale_lock, "").unwrap();
+
+    let tmp_file = store.state_dir.join("temproots/4242");
+    let mut data = alive.full.clone().into_bytes();
+    data.push(0);
+    fs::write(&tmp_file, &data).unwrap();
+    let f = fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .open(&tmp_file)
+        .unwrap();
+    let lock = nix::fcntl::Flock::lock(f, nix::fcntl::FlockArg::LockSharedNonblock).unwrap();
+
+    store.run_gc_ok(&[]);
+
+    assert!(lock_file.exists(), "active build's .lock file deleted");
+    assert!(!stale_lock.exists(), "stale lock file kept");
+    drop(lock);
+}
+
+// APFS rejects non-UTF-8 file names (EILSEQ), so this scenario can only be
+// constructed on Linux.
+#[cfg(target_os = "linux")]
+#[test]
+fn gc_deletes_non_utf8_store_entry() {
+    use std::os::unix::ffi::OsStrExt;
+    let store = TestStore::new();
+    let raw = std::ffi::OsStr::from_bytes(b"junk-\xff\xfe-entry");
+    let path = store.store_dir.join(raw);
+    match fs::write(&path, "garbage") {
+        Ok(()) => {}
+        // Filesystem enforces UTF-8 names (e.g. ZFS utf8only=on); the
+        // scenario cannot exist here, so skip.
+        Err(e) if e.raw_os_error() == Some(nix::libc::EILSEQ) => return,
+        Err(e) => panic!("{e}"),
+    }
+
+    let out = store.run_gc_ok(&[]);
+
+    assert!(
+        path.symlink_metadata().is_err(),
+        "non-UTF-8 garbage entry must be deleted"
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("1 store paths deleted"), "stdout: {stdout}");
+}
+
+#[test]
+fn gc_does_not_hang_on_tmp_fifo() {
+    let store = TestStore::new();
+    let fifo = store.store_dir.join("tmp-fifo");
+    nix::unistd::mkfifo(&fifo, nix::sys::stat::Mode::from_bits(0o644).unwrap()).unwrap();
+
+    // Must terminate (no blocking open) and remove the FIFO.
+    store.run_gc_ok(&[]);
+    assert!(fifo.symlink_metadata().is_err(), "FIFO not collected");
+}
+
+#[test]
+fn gc_removes_reserved_space_file_and_creates_private_lock() {
+    use std::os::unix::fs::PermissionsExt;
+    let store = TestStore::new();
+    let reserved = store.state_dir.join("db/reserved");
+    fs::write(&reserved, vec![b'X'; 1024]).unwrap();
+
+    store.run_gc_ok(&[]);
+
+    assert!(!reserved.exists(), "reserved space file must be freed");
+    let mode = fs::metadata(store.state_dir.join("gc.lock"))
+        .unwrap()
+        .permissions()
+        .mode()
+        & 0o777;
+    assert_eq!(mode, 0o600, "gc.lock must not be lockable by other users");
+}
+
+/// Connect to the gc-socket during the early window (before the graph is
+/// loaded), register a root, and let the GC continue.
+fn run_gc_with_early_root(
+    store: &TestStore,
+    root: &str,
+    extra_args: &[&str],
+) -> std::process::Output {
+    use std::io::{Read, Write};
+
+    let fifo = store.dir.path().join("sync-early");
+    nix::unistd::mkfifo(&fifo, nix::sys::stat::Mode::from_bits(0o600).unwrap()).unwrap();
+
+    let child = Command::new(env!("CARGO_BIN_EXE_harmonia-gc"))
+        .arg("--store-dir")
+        .arg(&store.store_dir)
+        .arg("--state-dir")
+        .arg(&store.state_dir)
+        .args(extra_args)
+        .env("_HARMONIA_GC_TEST_SYNC_EARLY", &fifo)
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .unwrap();
+
+    // Blocks until the GC reached the sync point: lock held, early
+    // socket up, graph not loaded yet.
+    let fifo_w = fs::OpenOptions::new().write(true).open(&fifo).unwrap();
+
+    let sock = store.state_dir.join("gc-socket/socket");
+    let mut conn = std::os::unix::net::UnixStream::connect(&sock)
+        .expect("gc-socket must be served before the graph is loaded");
+    conn.write_all(format!("{root}\n").as_bytes()).unwrap();
+    let mut ack = [0u8; 1];
+    conn.read_exact(&mut ack).unwrap();
+    assert_eq!(ack, [b'1'], "early root must be acked immediately");
+
+    drop(fifo_w); // release the GC
+    let out = child.wait_with_output().unwrap();
+    assert!(
+        out.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    out
+}
+
+#[test]
+fn gc_socket_serves_before_graph_load_and_keeps_early_roots() {
+    let store = TestStore::new();
+    let dead = store.add_path("now-needed", 100);
+    let trash = store.add_path("trash", 100);
+
+    run_gc_with_early_root(&store, &dead.full, &[]);
+
+    assert!(
+        dead.path.exists() && store.in_db(&dead),
+        "early-socket root was deleted"
+    );
+    assert!(!trash.path.exists());
+}
+
+#[test]
+fn gc_dry_run_serves_socket_and_honors_roots() {
+    let store = TestStore::new();
+    let dead = store.add_path("now-needed", 100);
+    let trash = store.add_path("trash", 100);
+
+    let out = run_gc_with_early_root(&store, &dead.full, &["--dry-run"]);
+
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        !stdout.contains(&dead.full),
+        "protected path reported as dead: {stdout}"
+    );
+    assert!(stdout.contains(&trash.full), "stdout: {stdout}");
+    assert!(dead.path.exists() && trash.path.exists());
+}
+
+#[test]
+fn gc_socket_root_mid_gc_keeps_path_and_deletes_rest() {
+    // Mirror of the NixOS test's gc-socket phase: while the delete loop is
+    // blocked on _HARMONIA_GC_TEST_SYNC, protect one dead path over the
+    // socket; after release, it survives and the other dead path is gone.
+    use std::io::{Read, Write};
+    let store = TestStore::new();
+    let saved = store.add_path("saved", 10);
+    let other = store.add_path("other", 10);
+
+    let fifo = store.dir.path().join("sync.fifo");
+    nix::unistd::mkfifo(&fifo, nix::sys::stat::Mode::from_bits(0o600).unwrap()).unwrap();
+
+    let mut child = Command::new(env!("CARGO_BIN_EXE_harmonia-gc"))
+        .arg("--store-dir")
+        .arg(&store.store_dir)
+        .arg("--state-dir")
+        .arg(&store.state_dir)
+        .env("_HARMONIA_GC_TEST_SYNC", &fifo)
+        .spawn()
+        .unwrap();
+
+    let fifo_w = fs::OpenOptions::new().write(true).open(&fifo).unwrap();
+
+    let sock = store.state_dir.join("gc-socket/socket");
+    let mut conn = std::os::unix::net::UnixStream::connect(&sock).unwrap();
+    conn.write_all(format!("{}\n", saved.full).as_bytes())
+        .unwrap();
+    let mut ack = [0u8; 1];
+    conn.read_exact(&mut ack).unwrap();
+    assert_eq!(ack, [b'1']);
+
+    drop(fifo_w);
+    let status = child.wait().unwrap();
+    assert!(status.success());
+
+    assert!(saved.path.exists() && store.in_db(&saved), "saved deleted");
+    assert!(!other.path.exists(), "other survived");
+    assert!(!store.in_db(&other));
+}
+
+#[test]
+fn gc_vacuums_db_after_mass_deletion() {
+    let store = TestStore::new();
+    // Enough rows that deleting them leaves a freelist big enough to
+    // trip the auto-vacuum heuristic (>25% free pages, >=64 pages).
+    for i in 0..5000 {
+        store.add_path(&format!("dead-{i}-padpadpadpadpadpadpadpadpad"), 1);
+    }
+    let db_path = store.state_dir.join("db/db.sqlite");
+    let before = fs::metadata(&db_path).unwrap().len();
+
+    let out = store.run_gc_ok(&[]);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains("vacuum"), "stderr: {stderr}");
+
+    let after = fs::metadata(&db_path).unwrap().len();
+    assert!(
+        after < before / 2,
+        "db not vacuumed: before={before} after={after}"
+    );
+}

--- a/harmonia-store-gc/tests/socket_concurrency.rs
+++ b/harmonia-store-gc/tests/socket_concurrency.rs
@@ -1,0 +1,181 @@
+// SPDX-FileCopyrightText: 2025 Jörg Thalheim
+// SPDX-License-Identifier: MIT
+
+//! Concurrency stress test for the gc-socket protocol.
+//!
+//! It drives the real GcSocketServer with concurrent clients against a
+//! deleter that mirrors gc.rs's claim/end_delete cycle, over many random
+//! graphs.
+//!
+//! Invariant: a node must never be unlinked after it has been acked to a
+//! client. An acked builder treats the path as stable and may hardlink
+//! into it, so unlinking it afterwards resurrects a path the GC believes
+//! it deleted. The acked node's whole closure is checked.
+
+use std::io::{Read, Write};
+use std::os::unix::net::UnixStream;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Barrier};
+
+use harmonia_store_db::{GraphOptions, NodeIdx, StoreDb, StoreGraph};
+use harmonia_store_gc::gc_socket::{GcSocketServer, LiveSet};
+use harmonia_store_path::StoreDir;
+use rand::rngs::StdRng;
+use rand::{Rng, SeedableRng};
+
+fn full_path(i: usize) -> String {
+    format!("/nix/store/{i:032x}-pkg")
+}
+
+/// Random DAG: node i only references nodes < i, so closures are acyclic.
+fn gen_graph(rng: &mut StdRng, n: usize) -> StoreGraph {
+    let db = StoreDb::open_memory().unwrap();
+    for i in 0..n {
+        db.connection()
+            .execute(
+                "INSERT INTO ValidPaths (id, path, hash, registrationTime, narSize) \
+                 VALUES (?, ?, 'sha256:x', 1, 0)",
+                rusqlite::params![i as i64 + 1, full_path(i)],
+            )
+            .unwrap();
+    }
+    for i in 0..n {
+        for j in 0..i {
+            if rng.random_bool(0.25) {
+                db.connection()
+                    .execute(
+                        "INSERT INTO Refs (referrer, reference) VALUES (?, ?)",
+                        rusqlite::params![i as i64 + 1, j as i64 + 1],
+                    )
+                    .unwrap();
+            }
+        }
+    }
+    db.load_graph(
+        &StoreDir::default(),
+        &GraphOptions {
+            keep_derivations: false,
+            keep_outputs: false,
+        },
+    )
+    .unwrap()
+}
+
+/// Mirror of the gc.rs deletion loop: claim a chunk, drop the closures of
+/// skipped (protected) paths, then unlink each claimed node.
+fn run_deleter(graph: &StoreGraph, live: &LiveSet, acked: &[AtomicBool], seed: u64) {
+    let mut rng = StdRng::seed_from_u64(seed);
+    let all: Vec<NodeIdx> = graph.nodes().collect();
+    let mut cursor = 0;
+    while cursor < all.len() {
+        let chunk: Vec<NodeIdx> = all[cursor..]
+            .iter()
+            .copied()
+            .take(rng.random_range(1..=4))
+            .collect();
+        cursor += chunk.len();
+
+        let (mut claimed, skipped) = live.claim_nodes(&chunk);
+        if !skipped.is_empty() {
+            let keep = graph.compute_closure(&skipped);
+            claimed.retain(|&node| {
+                if keep.contains(node) {
+                    live.end_delete_node(node);
+                }
+                !keep.contains(node)
+            });
+        }
+        for &node in &claimed {
+            // Hold the node mid-unlink briefly so clients reliably race the
+            // gap between claim and unlink, the window protect() must
+            // synchronise on; without it the bug only shows up by luck.
+            std::thread::sleep(std::time::Duration::from_micros(50));
+            assert!(
+                !acked[node.index()].load(Ordering::SeqCst),
+                "unlinking node {} after it was acked to a client",
+                node.index(),
+            );
+            live.end_delete_node(node);
+        }
+    }
+}
+
+/// Register random roots and mark each acked root's closure; the deleter
+/// must never unlink an acked node.
+fn run_client(
+    sock: &std::path::Path,
+    graph: &StoreGraph,
+    acked: &[AtomicBool],
+    stop: &AtomicBool,
+    seed: u64,
+) {
+    let mut rng = StdRng::seed_from_u64(seed);
+    let all: Vec<NodeIdx> = graph.nodes().collect();
+    let Ok(mut conn) = UnixStream::connect(sock) else {
+        return;
+    };
+    while !stop.load(Ordering::Acquire) {
+        let root = all[rng.random_range(0..all.len())];
+        let line = format!("{}\n", graph.path(root));
+        let mut ack = [0u8; 1];
+        if conn.write_all(line.as_bytes()).is_err() || conn.read_exact(&mut ack).is_err() {
+            return;
+        }
+        assert_eq!(ack, *b"1");
+        let closure = graph.compute_closure(&[root]);
+        for &node in &all {
+            if closure.contains(node) {
+                acked[node.index()].store(true, Ordering::SeqCst);
+            }
+        }
+    }
+}
+
+fn one_run(seed: u64) {
+    let mut rng = StdRng::seed_from_u64(seed);
+    let n = rng.random_range(4..44);
+    let graph = Arc::new(gen_graph(&mut rng, n));
+    let live = Arc::new(LiveSet::new(n));
+    let acked: Arc<Vec<AtomicBool>> = Arc::new((0..n).map(|_| AtomicBool::new(false)).collect());
+
+    let dir = tempfile::tempdir().unwrap();
+    let server = GcSocketServer::start(dir.path(), Arc::clone(&live), Arc::clone(&graph)).unwrap();
+    let sock = dir.path().join("gc-socket/socket");
+
+    let stop = Arc::new(AtomicBool::new(false));
+    let n_clients = 4;
+    let barrier = Arc::new(Barrier::new(n_clients + 1));
+
+    let clients: Vec<_> = (0..n_clients)
+        .map(|c| {
+            let graph = Arc::clone(&graph);
+            let acked = Arc::clone(&acked);
+            let stop = Arc::clone(&stop);
+            let barrier = Arc::clone(&barrier);
+            let sock = sock.clone();
+            std::thread::spawn(move || {
+                barrier.wait();
+                run_client(&sock, &graph, &acked, &stop, seed ^ (c as u64 + 1));
+            })
+        })
+        .collect();
+
+    barrier.wait();
+    run_deleter(&graph, &live, &acked, seed);
+
+    stop.store(true, Ordering::Release);
+    // Dropping the server closes client connections so the threads exit.
+    drop(server);
+    for c in clients {
+        c.join().unwrap();
+    }
+}
+
+#[test]
+fn concurrent_clients_never_resurrect_deleted_paths() {
+    // Deterministic per seed; a protect() deadlock regression surfaces as
+    // the harness timing out.
+    for seed in 1..=60u64 {
+        one_run(seed);
+    }
+}

--- a/harmonia-store-path/src/lib.rs
+++ b/harmonia-store-path/src/lib.rs
@@ -19,7 +19,7 @@ pub use path::{
     ParseStorePathError, StorePath, StorePathError, StorePathHash, StorePathName,
     StorePathNameError,
 };
-pub use store_dir::{FromStoreDirStr, StoreDir, StoreDirDisplay};
+pub use store_dir::{FromStoreDirStr, StoreDir, StoreDirDisplay, StoreDirError};
 
 pub type StorePathSet = BTreeSet<StorePath>;
 


### PR DESCRIPTION
The integration tests run the harmonia-gc binary against a temporary
store: liveness through refs, derivers and CA outputs, temp and
runtime roots, tmp dirs and lock files, max-freed and chunking
invariants, and the gc-socket in its pre-graph and mid-deletion
windows. Fifo sync points in the binary make the race windows
deterministic.

The socket concurrency test hammers GcSocketServer with four client
threads over sixty random DAGs: a path must never be unlinked after
its protection was acked to a client.