### PR TITLE
store-fs: add filesystem layout crate for the local store

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1173,6 +1173,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "harmonia-store-fs"
+version = "3.2.0"
+dependencies = [
+ "harmonia-store-path",
+ "nix",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
 name = "harmonia-store-nar-info"
 version = "3.2.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ members = [
     "harmonia-store-derivation",
     "harmonia-store-ref-scan",
     "harmonia-store-db",
+    "harmonia-store-fs",
     "harmonia-store-path",
     "harmonia-utils-signature",
     "harmonia-store-nar-info",
@@ -56,7 +57,7 @@ getrandom = "0.4"
 libc = "0.2"
 md5 = "0.8"
 memchr = "2"
-nix = { version = "0.31", features = [ "signal", "mman" ] }
+nix = { version = "0.31", features = [ "signal", "mman", "fs", "user", "mount", "sched" ] }
 num_enum = "0.7"
 pin-project-lite = "0.2"
 prometheus = { version = "0.14", default-features = false }
@@ -107,6 +108,7 @@ harmonia-store-build-result    = { path = "harmonia-store-build-result" }
 harmonia-store-content-address = { path = "harmonia-store-content-address" }
 harmonia-store-db              = { path = "harmonia-store-db" }
 harmonia-store-derivation      = { path = "harmonia-store-derivation" }
+harmonia-store-fs              = { path = "harmonia-store-fs" }
 harmonia-store-nar-info        = { path = "harmonia-store-nar-info" }
 harmonia-store-path            = { path = "harmonia-store-path" }
 harmonia-store-path-info       = { path = "harmonia-store-path-info" }

--- a/docs/architecture/harmonia-store-structure.md
+++ b/docs/architecture/harmonia-store-structure.md
@@ -111,6 +111,7 @@ graph BT
     utils-signature --> utils-base-encoding
     store-path --> utils-hash
     store-content-address --> store-path
+    store-fs --> store-path
     store-ref-scan --> store-path
     store-derivation --> store-content-address
     store-derivation --> utils-signature

--- a/harmonia-store-fs/Cargo.toml
+++ b/harmonia-store-fs/Cargo.toml
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: 2026 Jörg Thalheim
+# SPDX-License-Identifier: MIT
+
+[package]
+name        = "harmonia-store-fs"
+description = "Filesystem layout of a local Nix store"
+version     = { workspace = true }
+edition     = { workspace = true }
+license     = { workspace = true }
+
+[dependencies]
+harmonia-store-path = { workspace = true }
+thiserror           = { workspace = true }
+tracing             = { workspace = true }
+
+[target.'cfg(target_os = "linux")'.dependencies]
+nix = { workspace = true }
+
+[lints]
+workspace = true

--- a/harmonia-store-fs/src/lib.rs
+++ b/harmonia-store-fs/src/lib.rs
@@ -1,0 +1,162 @@
+// SPDX-FileCopyrightText: 2026 Jörg Thalheim
+// SPDX-License-Identifier: MIT
+
+//! Filesystem layout of a local Nix store.
+//!
+//! A local store is more than the store directory. Nix keeps its
+//! database, locks and GC state in a separate state directory, and the
+//! store directory itself can be a symlink or bind mount whose physical
+//! location differs from the `/nix/store` paths recorded in the
+//! database. [`StoreLayout`] resolves all of these once, so tools that
+//! modify the store (garbage collection, store optimisation) agree on
+//! where things are:
+//!
+//! - the logical store directory, as recorded in the database
+//! - the physical directory behind it, for actual disk operations
+//! - the state directory with the database, `gc.lock` and temp roots
+//! - the `.links` directory holding one hard link per unique file for
+//!   deduplication
+//!
+//! On NixOS `/nix/store` is bind-mounted read-only so nothing tampers
+//! with it by accident. Store mutation must undo that for itself:
+//! [`unshare_mount_namespace`] gives the process a private mount
+//! namespace, and [`make_store_writable`] remounts the store read-write
+//! inside it, invisible to the rest of the system.
+
+use std::fs;
+use std::os::unix::ffi::{OsStrExt, OsStringExt};
+use std::path::{Path, PathBuf};
+
+mod mount;
+pub use mount::{make_store_writable, unshare_mount_namespace};
+
+use harmonia_store_path::StoreDir;
+pub use harmonia_store_path::StoreDirError;
+
+/// A filesystem operation on the store failed.
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum Error {
+    /// The store directory is not a valid absolute path
+    #[error(transparent)]
+    StoreDir(#[from] StoreDirError),
+
+    /// Querying mount information for the store failed
+    #[cfg(target_os = "linux")]
+    #[error("getting mount info for {path}: {source}")]
+    MountInfo { path: PathBuf, source: nix::Error },
+
+    /// Remounting the store read-write failed
+    #[cfg(target_os = "linux")]
+    #[error("remounting {path} writable: {source}")]
+    Remount { path: PathBuf, source: nix::Error },
+
+    /// Setting up a private mount namespace failed
+    #[cfg(target_os = "linux")]
+    #[error("setting up a private mount namespace: {source}")]
+    Unshare { source: nix::Error },
+}
+
+/// Where a local Nix store lives on disk.
+///
+/// ```
+/// use std::path::Path;
+/// use harmonia_store_fs::StoreLayout;
+///
+/// let layout = StoreLayout::new(Path::new("/nix/store/"), Path::new("/nix/var/nix"))?;
+/// assert_eq!(layout.store_dir().to_str(), "/nix/store");
+/// assert_eq!(layout.db_path(), Path::new("/nix/var/nix/db/db.sqlite"));
+/// # Ok::<(), harmonia_store_fs::Error>(())
+/// ```
+pub struct StoreLayout {
+    store_dir: StoreDir,
+    real_store_dir: PathBuf,
+    state_dir: PathBuf,
+    links_dir: PathBuf,
+}
+
+impl StoreLayout {
+    /// Resolve the layout for the store at `store_dir` with state in
+    /// `state_dir`.
+    ///
+    /// Falls back to the logical dir when it cannot be canonicalized,
+    /// like Nix's `realStoreDir`.
+    pub fn new(store_dir: &Path, state_dir: &Path) -> Result<Self, Error> {
+        let store_dir = StoreDir::new(normalize_dir(store_dir))?;
+        let real_store_dir = fs::canonicalize(store_dir.to_path()).unwrap_or_else(|e| {
+            tracing::debug!(
+                "cannot canonicalize {}: {e}, using it as-is",
+                store_dir.to_str()
+            );
+            store_dir.to_path().into()
+        });
+        Ok(StoreLayout {
+            links_dir: real_store_dir.join(".links"),
+            real_store_dir,
+            state_dir: state_dir.to_owned(),
+            store_dir,
+        })
+    }
+
+    /// The logical store directory, e.g. `/nix/store`. This is the form
+    /// recorded in the database.
+    pub fn store_dir(&self) -> &StoreDir {
+        &self.store_dir
+    }
+
+    /// The physical store directory: [`Self::store_dir`] with symlinks
+    /// resolved. The database records logical paths, but disk operations
+    /// need real ones.
+    pub fn real_store_dir(&self) -> &Path {
+        &self.real_store_dir
+    }
+
+    /// The Nix state directory, e.g. `/nix/var/nix`. Holds `gc.lock`,
+    /// `temproots/`, `gc-socket/` and the database.
+    pub fn state_dir(&self) -> &Path {
+        &self.state_dir
+    }
+
+    /// The hard-link dedup directory `real_store_dir/.links`.
+    pub fn links_dir(&self) -> &Path {
+        &self.links_dir
+    }
+
+    /// The store database file `state_dir/db/db.sqlite`.
+    pub fn db_path(&self) -> PathBuf {
+        self.state_dir.join("db/db.sqlite")
+    }
+}
+
+/// Strip trailing slashes but keep a bare "/". A trailing slash would
+/// break every store prefix comparison downstream.
+fn normalize_dir(dir: &Path) -> PathBuf {
+    let bytes = dir.as_os_str().as_bytes();
+    let mut end = bytes.len();
+    while end > 1 && bytes[end - 1] == b'/' {
+        end -= 1;
+    }
+    PathBuf::from(std::ffi::OsString::from_vec(bytes[..end].to_vec()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalize_dir_strips_trailing_slashes() {
+        assert_eq!(
+            normalize_dir(Path::new("/nix/store/")),
+            Path::new("/nix/store")
+        );
+        assert_eq!(
+            normalize_dir(Path::new("/nix/store//")),
+            Path::new("/nix/store")
+        );
+        assert_eq!(
+            normalize_dir(Path::new("/nix/store")),
+            Path::new("/nix/store")
+        );
+        assert_eq!(normalize_dir(Path::new("/")), Path::new("/"));
+    }
+}

--- a/harmonia-store-fs/src/mount.rs
+++ b/harmonia-store-fs/src/mount.rs
@@ -1,0 +1,122 @@
+// SPDX-FileCopyrightText: 2026 Jörg Thalheim
+// SPDX-License-Identifier: MIT
+
+//! Remounting a read-only store for mutation. Only Linux bind-mounts the
+//! store, so the other platforms are no-ops.
+
+#[cfg(target_os = "linux")]
+mod linux {
+    use std::path::Path;
+
+    use nix::mount::{MsFlags, mount};
+    use nix::sched::{CloneFlags, unshare};
+    use nix::sys::statvfs::{FsFlags, statvfs};
+    use nix::unistd::Uid;
+
+    use crate::Error;
+
+    /// Enter a private mount namespace so the read-write remount in
+    /// [`make_store_writable`] stays scoped to this process, mirroring
+    /// what the `nix` CLI does for root.
+    ///
+    /// Must be called from `main` before any thread pool starts: only the
+    /// calling thread joins the new namespace.
+    ///
+    /// Errors are reported, not acted on: EPERM is normal in containers,
+    /// and the caller can still remount in the host namespace like
+    /// legacy `nix-store` does.
+    pub fn unshare_mount_namespace() -> Result<(), Error> {
+        if !Uid::effective().is_root() {
+            tracing::debug!("not root, skipping private mount namespace");
+            return Ok(());
+        }
+        unshare(CloneFlags::CLONE_NEWNS).map_err(|source| Error::Unshare { source })?;
+        // Default propagation on systemd is `shared`. Without marking /
+        // private, the remount would propagate back to the host
+        // namespace.
+        mount(
+            None::<&str>,
+            "/",
+            None::<&str>,
+            MsFlags::MS_PRIVATE | MsFlags::MS_REC,
+            None::<&str>,
+        )
+        .map_err(|source| Error::Unshare { source })?;
+        Ok(())
+    }
+
+    /// Remount the store read-write if needed. NixOS bind-mounts
+    /// /nix/store read-only, so this must run before any store mutation.
+    pub fn make_store_writable(real_store_dir: &Path) -> Result<(), Error> {
+        if !Uid::effective().is_root() {
+            tracing::debug!("not root, skipping read-write remount of the store");
+            return Ok(());
+        }
+
+        let st = statvfs(real_store_dir).map_err(|source| Error::MountInfo {
+            path: real_store_dir.to_owned(),
+            source,
+        })?;
+        if !st.flags().contains(FsFlags::ST_RDONLY) {
+            return Ok(());
+        }
+
+        // Preserve locked mount flags (nodev etc.), otherwise the remount
+        // fails in a user namespace. Flags that neither nix nor libc can
+        // report from statvfs (e.g. nosymfollow) cannot be preserved.
+        // For the store that is moot: it is full of symlinks, a
+        // nosymfollow mount would break Nix itself.
+        let mut flags = MsFlags::MS_REMOUNT | MsFlags::MS_BIND;
+        let f = st.flags();
+        for (fs_flag, ms_flag) in [
+            (FsFlags::ST_NODEV, MsFlags::MS_NODEV),
+            (FsFlags::ST_NOSUID, MsFlags::MS_NOSUID),
+            (FsFlags::ST_NOEXEC, MsFlags::MS_NOEXEC),
+            (FsFlags::ST_NOATIME, MsFlags::MS_NOATIME),
+            (FsFlags::ST_NODIRATIME, MsFlags::MS_NODIRATIME),
+            (FsFlags::ST_RELATIME, MsFlags::MS_RELATIME),
+            (FsFlags::ST_SYNCHRONOUS, MsFlags::MS_SYNCHRONOUS),
+        ] {
+            if f.contains(fs_flag) {
+                flags |= ms_flag;
+            }
+        }
+
+        mount(
+            None::<&str>,
+            real_store_dir,
+            None::<&str>,
+            flags,
+            None::<&str>,
+        )
+        .map_err(|source| Error::Remount {
+            path: real_store_dir.to_owned(),
+            source,
+        })?;
+        tracing::info!("remounted {} read-write", real_store_dir.display());
+        Ok(())
+    }
+}
+
+#[cfg(target_os = "linux")]
+pub use linux::{make_store_writable, unshare_mount_namespace};
+
+#[cfg(not(target_os = "linux"))]
+mod other {
+    use std::path::Path;
+
+    use crate::Error;
+
+    /// No-op outside Linux.
+    pub fn unshare_mount_namespace() -> Result<(), Error> {
+        Ok(())
+    }
+
+    /// No-op outside Linux.
+    pub fn make_store_writable(_real_store_dir: &Path) -> Result<(), Error> {
+        Ok(())
+    }
+}
+
+#[cfg(not(target_os = "linux"))]
+pub use other::{make_store_writable, unshare_mount_namespace};

--- a/harmonia-store-path/src/lib.rs
+++ b/harmonia-store-path/src/lib.rs
@@ -19,7 +19,7 @@ pub use path::{
     ParseStorePathError, StorePath, StorePathError, StorePathHash, StorePathName,
     StorePathNameError,
 };
-pub use store_dir::{FromStoreDirStr, StoreDir, StoreDirDisplay};
+pub use store_dir::{FromStoreDirStr, StoreDir, StoreDirDisplay, StoreDirError};
 
 pub type StorePathSet = BTreeSet<StorePath>;
 

--- a/scripts/dependency-diagram.py
+++ b/scripts/dependency-diagram.py
@@ -140,6 +140,7 @@ def generate_mermaid(
     # Store crates that perform I/O (blacklist — excluded from the pure group).
     STORE_IMPURE = {
         "store-db",
+        "store-fs",
         "store-remote",
     }
     # Store crates that are I/O-free (whitelist — included in the pure group).


### PR DESCRIPTION
StoreLayout resolves where a store lives on disk: the logical store
dir recorded in the database, the physical dir behind it, the state
dir and the .links dedup dir. The garbage collector and the upcoming
store optimiser need the same bundle.

The mount helpers for NixOS's read-only /nix/store live here too:
remounting is part of preparing the store for mutation, not of any
particular tool.