### PR TITLE
file-nar: record narOffset in NAR listings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -933,6 +933,7 @@ dependencies = [
  "harmonia-store-path-info",
  "harmonia-utils-base-encoding",
  "harmonia-utils-hash",
+ "harmonia-utils-io",
  "harmonia-utils-signature",
  "harmonia-utils-test",
  "http-range",

--- a/harmonia-cache/Cargo.toml
+++ b/harmonia-cache/Cargo.toml
@@ -55,6 +55,7 @@ nix                          = { workspace = true, features = [ "socket", "fs" ]
 prometheus                   = { workspace = true }
 
 [dev-dependencies]
+harmonia-utils-io   = { workspace = true }
 harmonia-utils-test = { workspace = true }
 nix                 = { workspace = true }
 tempfile            = { workspace = true }

--- a/harmonia-cache/src/narlist.rs
+++ b/harmonia-cache/src/narlist.rs
@@ -213,11 +213,13 @@ mod test {
         let ours: serde_json::Value = serde_json::to_value(&json.root).unwrap();
 
         // Strip fields that may differ between nix versions:
-        // - narOffset: present in NAR listings but not filesystem listings
+        // - narOffset: only a listing read from a NAR knows byte offsets
         // - executable: false may be absent in older nix (pre-NixOS/nix#15834)
-        fn normalize(v: &mut serde_json::Value) {
+        fn normalize(v: &mut serde_json::Value, strip_offsets: bool) {
             if let Some(obj) = v.as_object_mut() {
-                obj.remove("narOffset");
+                if strip_offsets {
+                    obj.remove("narOffset");
+                }
                 if obj.get("executable") == Some(&serde_json::Value::Bool(false)) {
                     obj.remove("executable");
                 }
@@ -225,17 +227,31 @@ mod test {
                     && let Some(map) = entries.as_object_mut()
                 {
                     for (_, child) in map.iter_mut() {
-                        normalize(child);
+                        normalize(child, strip_offsets);
                     }
                 }
             }
         }
         let mut ours_normalized = ours;
-        normalize(&mut ours_normalized);
-        let mut reference_normalized = reference;
-        normalize(&mut reference_normalized);
+        normalize(&mut ours_normalized, true);
+        let mut reference_normalized = reference.clone();
+        normalize(&mut reference_normalized, true);
 
         assert_eq!(ours_normalized, reference_normalized);
+
+        // A listing read from the NAR must match nix down to the byte offsets.
+        let nar = fs::read(&nar_file).io_context("Failed to read nar file")?;
+        let listing = harmonia_file_nar::parse_nar_listing(harmonia_utils_io::BytesReader::new(
+            std::io::Cursor::new(nar),
+        ))
+        .await
+        .io_context("Failed to parse nar listing")?;
+        let mut from_nar = serde_json::to_value(&listing).unwrap();
+        normalize(&mut from_nar, false);
+        let mut reference_with_offsets = reference;
+        normalize(&mut reference_with_offsets, false);
+
+        assert_eq!(from_nar, reference_with_offsets);
 
         Ok(())
     }

--- a/harmonia-file-nar/src/archive/parser.rs
+++ b/harmonia-file-nar/src/archive/parser.rs
@@ -10,6 +10,7 @@ use tracing::trace;
 
 use crate::ByteString;
 use crate::padded_reader::PaddedReader;
+use crate::wire::calc_aligned;
 use harmonia_utils_io::{AsyncBufReadCompat, AsyncBytesRead, BytesReader, Lending, LentReader};
 
 use super::NarEvent;
@@ -29,7 +30,8 @@ pin_project! {
         // increasing like Nix requires, which also rules out duplicates.
         // Empty means no entry seen yet (valid names are never empty).
         prev_names: Vec<ByteString>,
-        parsed: usize,
+        // Bytes consumed so far; see [`NarParser::position`].
+        position: u64,
         state: Inner<false>,
     }
 }
@@ -54,7 +56,7 @@ where
     pub fn new(reader: R) -> Self {
         Self {
             reader: Lending::new(reader),
-            parsed: 0,
+            position: 0,
             name: None,
             prev_names: Vec::new(),
             state: Inner {
@@ -62,6 +64,11 @@ where
                 state: InnerState::Root(0),
             },
         }
+    }
+
+    /// The parser's byte offset in the NAR (`narOffset`)
+    pub fn position(&self) -> u64 {
+        self.position
     }
 }
 
@@ -76,8 +83,12 @@ where
         let mut this = self.project();
         let mut reader = ready!(this.reader.as_mut().poll_reader(cx))?;
         match this.state.state {
-            InnerState::ReadContents(NodeType::ExecutableFile | NodeType::File, _, _)
-            | InnerState::ReadDir => {
+            InnerState::ReadContents(NodeType::ExecutableFile | NodeType::File, size, _) => {
+                // The file's reader has drained the contents and their padding.
+                *this.position = this.position.saturating_add(calc_aligned(size));
+                this.state.bump_next();
+            }
+            InnerState::ReadDir => {
                 this.state.bump_next();
             }
             InnerState::FinishReadEntry => {
@@ -100,6 +111,7 @@ where
             let cnt = this.state.drive(&buf)?;
             buf.advance(cnt);
             reader.as_mut().consume(cnt);
+            *this.position += cnt as u64;
             trace!(state=?this.state.state, cnt, "Loop state");
             match this.state.state {
                 InnerState::ReadContents(
@@ -131,6 +143,7 @@ where
                     let target = buf.split_to(len);
                     buf.advance(aligned - len);
                     reader.as_mut().consume(aligned);
+                    *this.position += aligned as u64;
                     this.state.bump_next();
                     let name = this.name.take().unwrap_or_default();
                     return Poll::Ready(Some(Ok(NarEvent::Symlink { name, target })));
@@ -162,6 +175,7 @@ where
                     *this.name = Some(name_buf);
                     buf.advance(aligned - len);
                     reader.as_mut().consume(aligned);
+                    *this.position += aligned as u64;
                     this.state.bump_next();
                 }
                 InnerState::ReadDir => {

--- a/harmonia-file-nar/src/listing.rs
+++ b/harmonia-file-nar/src/listing.rs
@@ -31,7 +31,10 @@ where
     let mut stack: Vec<DirFrame> = Vec::new();
     let mut result: Option<FileTree<NarFileInfo>> = None;
 
-    while let Some(event) = parser.next().await {
+    loop {
+        let Some(event) = parser.next().await else {
+            break;
+        };
         let event = event?;
         match event {
             NarEvent::File {
@@ -40,12 +43,14 @@ where
                 size,
                 mut reader,
             } => {
+                let nar_offset = parser.position();
+
                 // Drain the file contents (we only want metadata)
                 tokio::io::copy(&mut reader, &mut tokio::io::sink()).await?;
 
                 let info = NarFileInfo {
                     size,
-                    nar_offset: None, // TODO: track byte offset
+                    nar_offset: Some(nar_offset),
                 };
                 let node = FileTree(FileSystemObject::Regular(Regular {
                     executable,
@@ -114,6 +119,8 @@ mod tests {
     use futures_util::TryStreamExt;
     use harmonia_utils_io::BytesReader;
 
+    use crate::archive::test_data;
+
     #[tokio::test]
     async fn test_listing_from_nar() {
         // Create a temp dir, dump it as NAR bytes, then parse the listing
@@ -130,7 +137,7 @@ mod tests {
         let nar_bytes: Vec<u8> = chunks.into_iter().flatten().collect();
 
         // Parse the listing
-        let reader = BytesReader::new(std::io::Cursor::new(nar_bytes));
+        let reader = BytesReader::new(std::io::Cursor::new(nar_bytes.clone()));
         let listing = parse_nar_listing(reader).await.unwrap();
 
         // Verify structure
@@ -149,5 +156,36 @@ mod tests {
         let sub_entries = entries["subdir"]["entries"].as_object().unwrap();
         assert!(sub_entries.contains_key("nested"));
         assert_eq!(sub_entries["nested"]["size"], 7);
+
+        // Every narOffset must address the file's contents in the NAR itself.
+        assert_contents_at(&nar_bytes, &entries["hello"], b"world");
+        assert_contents_at(&nar_bytes, &sub_entries["nested"], b"content");
+
+        // Only regular files carry an offset.
+        assert!(entries["link"].get("narOffset").is_none());
+        assert!(entries["subdir"].get("narOffset").is_none());
+    }
+
+    #[tokio::test]
+    async fn test_listing_root_file_offset() {
+        for (events, expected, contents) in [
+            (test_data::text_file(), 96, b"Hello world!".as_slice()),
+            (test_data::exec_file(), 128, b"Very cool stuff".as_slice()),
+        ] {
+            let nar_bytes = crate::archive::write_nar(events.iter());
+
+            let reader = BytesReader::new(std::io::Cursor::new(nar_bytes.clone()));
+            let listing = parse_nar_listing(reader).await.unwrap();
+
+            let json = serde_json::to_value(&listing).unwrap();
+            assert_eq!(json["narOffset"], expected);
+            assert_contents_at(&nar_bytes, &json, contents);
+        }
+    }
+
+    /// Assert that `entry`'s `narOffset` addresses `contents` within `nar`.
+    fn assert_contents_at(nar: &[u8], entry: &serde_json::Value, contents: &[u8]) {
+        let offset = entry["narOffset"].as_u64().unwrap() as usize;
+        assert_eq!(&nar[offset..offset + contents.len()], contents);
     }
 }


### PR DESCRIPTION
Expose `narOffset`, which had been missing in hydra's served NAR files (NixOS/hydra#1883) since its switch to harmonia. This makes output match that of `nix nar ls --json --recursive`.

Assisted-by: Claude:claude-opus-5

/cc @Ericson2314
