### PR TITLE
fix: avoid `std::path::Path::is_absolute` on `wasm32-unknown-unknown`

### DIFF
--- a/harmonia-store-path/src/store_dir.rs
+++ b/harmonia-store-path/src/store_dir.rs
@@ -85,7 +85,8 @@ impl StoreDir {
     /// Given a full store path like `/nix/store/hash-name`, returns `hash-name`.
     pub fn strip_prefix<'s>(&self, s: &'s str) -> Result<&'s str, StorePathError> {
         let path = Path::new(s);
-        if !path.is_absolute() {
+        // Store paths are Unix-style regardless of host (e.g. wasm32).
+        if !s.starts_with('/') {
             return Err(StorePathError::NonAbsolute(path.to_owned()));
         }
         let name = s


### PR DESCRIPTION
On `wasm32-unknown-unknown`, `std::path::Path::is_absolute` always returns `false` because there's no concept of a filesystem, so `/` doesn't "mean" anything.

But `StorePath` and `StoreDir` are an abstract representation of a nix store entries, so `is_absolute` does have a meaning in this context. Or perhaps another way of looking at it is that `StorePath` and `StoreDir` use Unix's semantics.

The fix still only applies to `wasm32` because I wanted to make sure this has no impact on anything else, but technically using `.starts_with('/')` always would probably be a better fix (or simply avoiding `std::path::Path` and use a path structure that only has the Unix semantics, like [`UnixPath`](https://docs.rs/typed-path/latest/typed_path/type.UnixPath.html) from the `typed_paths` crate or similar)